### PR TITLE
Allow disease modules to have Pandas Series/DataFrame parameters

### DIFF
--- a/src/tlo/core.py
+++ b/src/tlo/core.py
@@ -104,6 +104,9 @@ class Property(Specifiable):
         :param name: the name for the series
         :param size: the length of the series
         """
+        if self.type_ in [Types.SERIES, Types.DATA_FRAME]:
+            raise TypeError("Property cannot be of type SERIES or DATA_FRAME.")
+
         s = pd.Series(
             name=name,
             index=range(size),


### PR DESCRIPTION
Some disease modules require parameters that are best represented by Pandas types Series & DataFrames (e.g. Excel tables or parameters that are arrays interacting with the population DataFrame).