### PR TITLE
Enhancement/optimise request consumables

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -472,8 +472,8 @@ class HealthSystem(Module):
 
             e.g.
             cons_footprint = {
-                        'Intervention_Package_Code': [{my_pkg_code:1}],
-                        'Item_Code': [{'my_item_code':10, 'another_item_code':1}]
+                        'Intervention_Package_Code': [{my_pkg_code: 1}],
+                        'Item_Code': [{my_item_code: 10}, {another_item_code: 1}]
             }
         """
 
@@ -619,8 +619,8 @@ class HealthSystem(Module):
         #     * the codes within each list must be unique and valid codes, quantities must be integer values >0
         #     e.g.
         #     cons_footprint = {
-        #                 'Intervention_Package_Code': [{my_pkg_code:1}],
-        #                 'Item_Code': [{'my_item_code':10, 'another_item_code':1}]
+        #                 'Intervention_Package_Code': [{my_pkg_code: 1}],
+        #                 'Item_Code': [{my_item_code: 10}, {another_item_code: 1}]
         #     }
 
         # check basic formatting
@@ -633,15 +633,14 @@ class HealthSystem(Module):
         consumables = self.parameters['Consumables']
 
         for pkg in cons_req_as_footprint['Intervention_Package_Code']:
-            pkg_code = list(pkg.keys())[0]
-            pkg_quant =  list(pkg.values())[0]
+            # dict only ever has one item so we only want the key and the value
+            (pkg_code, pkg_quant), = pkg.items()
             assert pkg_code in consumables['Intervention_Pkg_Code'].values
             assert type(pkg_quant) is int
             assert pkg_quant > 0
 
         for itm in cons_req_as_footprint['Item_Code']:
-            itm_code = list(itm.keys())[0]
-            itm_quant =  list(itm.values())[0]
+            (itm_code, itm_quant), = itm.items()
             assert itm_code in consumables['Item_Code'].values
             assert type(itm_quant) is int
             assert itm_quant > 0
@@ -700,14 +699,15 @@ class HealthSystem(Module):
         packages_availability = dict()
         if not cons_req_as_footprint['Intervention_Package_Code'] == []:
             for p_dict in cons_req_as_footprint['Intervention_Package_Code']:
-                package_code = int(list(p_dict.keys())[0])
+                # dict only ever has one item so we only want the key and ignore the value
+                (package_code, _val), = p_dict.items()
                 packages_availability[int(package_code)] = bool(items_req.loc[items_req['Package_Code'] == float(package_code), 'Available'].all())
 
         # Iterate through the individual items that were requested
         items_availability=dict()
         if not cons_req_as_footprint['Item_Code'] == []:
             for i_dict in cons_req_as_footprint['Item_Code']:
-                item_code = int(list(i_dict.keys())[0])
+                (item_code, _val), = i_dict.items()
                 # check if *all* items in this package are available
                 items_availability[int(item_code)]=bool(items_req.loc[items_req['Item_Code']==item_code,'Available'].values[0])
 
@@ -736,8 +736,7 @@ class HealthSystem(Module):
         individual_consumables = []
         # Get the individual items in each package:
         for p_dict in cons['Intervention_Package_Code']:
-            package_code = int(list(p_dict.keys())[0])
-            quantity_of_packages = int(list(p_dict.values())[0])
+            (package_code, quantity_of_packages), = p_dict.items()
             items = consumables.loc[
                 consumables['Intervention_Pkg_Code'] == package_code, ['Item_Code', 'Expected_Units_Per_Case']
             ].to_dict(orient='records')
@@ -748,8 +747,7 @@ class HealthSystem(Module):
 
         # Add in any additional items that have been specified seperately:
         for i_dict in cons['Item_Code']:
-            item_code = int(list(i_dict.keys())[0])
-            quantity_of_item = int(list(i_dict.values())[0])
+            (item_code, quantity_of_item), = i_dict.items()
             item = {'Item_Code': item_code, 'Package_Code': np.nan,
                     'Quantity_Of_Item': quantity_of_item, 'Expected_Units_Per_Case': np.nan}
             individual_consumables.append(item)


### PR DESCRIPTION
## A couple of optimisations across two methods

for `request_consumables`

- Merging dataframes by index on both sides is faster than column (as long as unique index), even when taking into account the time to build the index. This also drops the column. 
- Then get_consumables_as_individual_items method also improved performance

for `get_consumables_as_individual_items`

- An empty for loop won't be looped through so can remove the `if not cons['...'] == []:`
- Build dictionary and then convert into dataframe after all iterations is faster than merging the dataframe

Full line profile output for the two methods:
[ver4.txt](https://github.com/UCL/TLOmodel/files/3728309/ver4.txt) and [optimised.txt](https://github.com/UCL/TLOmodel/files/3728308/optimised.txt)


##  Before optimisation

````
Total time: 215.509 s
Function: request_consumables at line 606

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   683                                                       # Get the the cost of the each consumable item (could not do this merge until after model run)
   684      8837      25782.0      2.9      0.0              items_req_to_log = items_req_to_log.merge(self.parameters['Consumables_Cost_List'],
   685      8837       6658.0      0.8      0.0                                                                  how='left',
   686      8837       6093.0      0.7      0.0                                                                  on='Item_Code',
   687      8837   37511094.0   4244.8     17.4                                                                  left_index=True
   688                                                                                                           )
   689
   690                                                       # Compute total cost (limiting to those items which were available)
   691      8837   22715459.0   2570.5     10.5              total_cost = items_req_to_log.loc[items_req_to_log['Available'],['Quantity_Of_Item','Unit_Cost']].prod(axis=1).sum()
   692
   693                                                       # Enter to the log
   694
   695      8837    7545599.0    853.9      3.5              items_req_to_log = items_req_to_log.drop(['Item_Code','Package_Code'], axis=1)  # drop from log for neatness
...

Total time: 83.0996 s
Function: get_consumables_as_individual_items at line 730
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
...
   747                                                   # Get the individual items in each package:
   748      8406      17649.0      2.1      0.0          if cons['Intervention_Package_Code']:
   749      4846       5938.0      1.2      0.0              for p_dict in cons['Intervention_Package_Code']:
   750      2423       7518.0      3.1      0.0                  package_code = int(list(p_dict.keys())[0])
   751      2423       3485.0      1.4      0.0                  quantity_of_packages = int(list(p_dict.values())[0])
   752      2423       5140.0      2.1      0.0                  items = consumables.loc[
   753      2423    5294309.0   2185.0      6.4                      consumables['Intervention_Pkg_Code'] == package_code, ['Item_Code', 'Expected_Units_Per_Case']]
   754      2423    1770812.0    730.8      2.1                  items['Quantity_Of_Item'] = items['Expected_Units_Per_Case'] * quantity_of_packages
   755      2423    1129094.0    466.0      1.4                  items['Package_Code'] = package_code
   756      2423    5159314.0   2129.3      6.2                  consumables_as_individual_items = consumables_as_individual_items.append(items, ignore_index=True, sort=False).reset_index(drop=True)
   757                                           
   758                                                   # Add in any additional items that have been specified seperately:
   759                                                   if not cons['Item_Code'] == []:
   760      8406       8157.0      1.0      0.0              for i_dict in cons['Item_Code']:
   761     11966      12830.0      1.1      0.0                  item_code = int(list(i_dict.keys())[0])
   762      5983      18017.0      3.0      0.0                  quantity_of_item = int(list(i_dict.values())[0])
   763      5983       8766.0      1.5      0.0                  items = pd.DataFrame(data={'Item_Code': item_code, 'Package_Code': np.nan, 'Quantity_Of_Item': quantity_of_item}, index=[0])
   764      5983    5911711.0    988.1      7.1                  consumables_as_individual_items = consumables_as_individual_items.append(items, ignore_index=True, sort=False).reset_index(
   765      5983   12402139.0   2072.9     14.9                      drop=True)
   766      5983    2109426.0    352.6      2.5  
   767                                                   consumables_as_individual_items = consumables_as_individual_items.drop('Expected_Units_Per_Case', axis=1)
....

````

## After optimisation

````
Total time: 136.639 s
Function: request_consumables at line 606
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
...
   683                                                       # Get the the cost of the each consumable item (could not do this merge until after model run)
   684      8338    1414380.0    169.6      1.0              consumable_costs = self.parameters['Consumables_Cost_List'].copy()
   685      8338    3712655.0    445.3      2.7              consumable_costs.set_index('Item_Code', inplace=True)
   686                                           
   687      8338      13719.0      1.6      0.0              items_req_to_log = items_req_to_log.merge(consumable_costs,
   688      8338       6244.0      0.7      0.0                                                        how='left',
   689      8338       5769.0      0.7      0.0                                                        left_index=True,
   690      8338    9772434.0   1172.0      7.2                                                        right_index=True)
   691                                           
   692                                                       # Compute total cost (limiting to those items which were available)
   693      8338   20969509.0   2514.9     15.3              total_cost = items_req_to_log.loc[items_req_to_log['Available'],['Quantity_Of_Item','Unit_Cost']].prod(axis=1).sum()
   694                                           
   695                                                       # Enter to the log
   696                                           
   697      8338    7373813.0    884.4      5.4              items_req_to_log = items_req_to_log.drop(['Package_Code'], axis=1)  # drop from log for neatness
...

Total time: 32.6358 s
Function: get_consumables_as_individual_items at line 733
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
...
   747      8338       4719.0      0.6      0.0          individual_consumables = []
   748                                                   # Get the individual items in each package:
   749     10797       7421.0      0.7      0.0          for p_dict in cons['Intervention_Package_Code']:
   750      2459       5064.0      2.1      0.0              package_code = int(list(p_dict.keys())[0])
   751      2459       2843.0      1.2      0.0              quantity_of_packages = int(list(p_dict.values())[0])
   752      2459       2657.0      1.1      0.0              items = consumables.loc[
   753      2459    5375106.0   2185.9     16.5                  consumables['Intervention_Pkg_Code'] == package_code, ['Item_Code', 'Expected_Units_Per_Case']
   754      2459     563530.0    229.2      1.7              ].to_dict(orient='records')
   755      4974       4750.0      1.0      0.0              for item in items:
   756      2515       7506.0      3.0      0.0                  item['Quantity_Of_Item'] = item['Expected_Units_Per_Case'] * quantity_of_packages
   757      2515       1616.0      0.6      0.0                  item['Package_Code'] = package_code
   758      2515       2498.0      1.0      0.0                  individual_consumables.append(item)
   759                                           
   760                                                   # Add in any additional items that have been specified seperately:
   761     14217       9338.0      0.7      0.0          for i_dict in cons['Item_Code']:
   762      5879      12274.0      2.1      0.0              item_code = int(list(i_dict.keys())[0])
   763      5879       7440.0      1.3      0.0              quantity_of_item = int(list(i_dict.values())[0])
   764      5879       4593.0      0.8      0.0              item = {'Item_Code': item_code, 'Package_Code': np.nan,
   765      5879       5766.0      1.0      0.0                       'Quantity_Of_Item': quantity_of_item, 'Expected_Units_Per_Case': np.nan}
   766      5879       5450.0      0.9      0.0              individual_consumables.append(item)
   767                                           
   768      8338    8101971.0    971.7     24.8          consumables_as_individual_items = pd.DataFrame.from_dict(individual_consumables)
   769                                           
   770      8338      10494.0      1.3      0.0          try:
   771      8338    7828112.0    938.8     24.0              consumables_as_individual_items = consumables_as_individual_items.drop('Expected_Units_Per_Case', axis=1)
   772                                                   except KeyError:
   773                                                       # No data from cons['Intervention_Package_Code'] or cons['Item_Code']
   774                                                       # Maybe this should never happen? If so then can remove the try and except and have the error
   775                                                       consumables_as_individual_items = pd.DataFrame(columns=['Item_Code', 'Package_Code', 'Quantity_Of_Item'])
....
````