### PR TITLE
Set default logging setting to WARNING

### DIFF
--- a/src/tlo/logging/helpers.py
+++ b/src/tlo/logging/helpers.py
@@ -44,4 +44,4 @@ def init_logging():
     logger.handlers.clear()
     logger.filters.clear()
     logger.addHandler(handler)
-    _logging.basicConfig(level=DEBUG)
+    _logging.basicConfig(level=_logging.WARNING)


### PR DESCRIPTION
Fix to restore default behaviour of Python logging