### PR TITLE
Adding declaration of store dictionary (for tutorial)

### DIFF
--- a/src/tlo/methods/skeleton.py
+++ b/src/tlo/methods/skeleton.py
@@ -58,6 +58,7 @@ class Skeleton(Module):
 
         super().__init__(name)
         self.resourcefilepath = resourcefilepath
+        self.store = {'Proportion_infected': []}
 
     def read_parameters(self, data_folder):
         """Read parameter values from file, if required.


### PR DESCRIPTION
A minor change to `Skeleton` class's `__init__` method: declare `store` dictionary (used in tutorial) 