### PR TITLE
Diarrhoea draft PR

### DIFF
--- a/resources/Method_Lifestyle_Enhanced.xlsx
+++ b/resources/Method_Lifestyle_Enhanced.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8310aed270bca5eb52755c13369cc0c739a8c423d8b6e8d697c2e4d7cfe9fa16
+size 4141906

--- a/resources/ResourceFile_Contraception.xlsx
+++ b/resources/ResourceFile_Contraception.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48c0a0cbe45e9fbb0d45c6516b236637ae3a61eec45e50cc57d2741fc5b12eec
+size 1191128

--- a/resources/ResourceFile_Deaths_And_Causes_DeathRates_GBD.csv
+++ b/resources/ResourceFile_Deaths_And_Causes_DeathRates_GBD.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdcc66493a7a3b5abed17d96cc30c5cfa5dcf9e9c8902ac5cf2c68a3ce41cb9e
+size 18620889

--- a/resources/ResourceFile_Epilepsy.xlsx
+++ b/resources/ResourceFile_Epilepsy.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ad84f14bc41b51b8fda63eb1dbda11a7dc085b0a652f5c9304df40b184eb360
+size 1251491

--- a/resources/ResourceFile_Lifestyle_Enhanced.xlsx
+++ b/resources/ResourceFile_Lifestyle_Enhanced.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67467d496a135e6b5d6dadd9df4504153debc4b308d28d4ed68bbe1dd22eda5d
+size 4149154

--- a/resources/ResourceFile_Pop_Annual_WPP.csv
+++ b/resources/ResourceFile_Pop_Annual_WPP.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5a99e344e86b16e3236159382de4a7a95dd6dfcf8aba21072b06ae9ccc2e632
+size 1538982

--- a/resources/ResourceFile_mwi_admbnda_adm2_nso_20181016.shp
+++ b/resources/ResourceFile_mwi_admbnda_adm2_nso_20181016.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2614395c290d15fe68fecae60c27767c0043b8f4462f115f5ccb8fe081c50ea2
+size 2314568

--- a/src/tlo/methods/diarrhoea.py
+++ b/src/tlo/methods/diarrhoea.py
@@ -1035,7 +1035,7 @@ class DiarrhoeaPollingEvent(RegularEvent, PopulationScopeEventMixin):
     """
 
     def __init__(self, module):
-        super().__init__(module, frequency=DateOffset(months=1))
+        super().__init__(module, frequency=DateOffset(months=3))
         # NB. The frequency of the occurrences of this event can be edited safely.
 
     def apply(self, population):
@@ -1240,6 +1240,7 @@ class DiarrhoeaNaturalRecoveryEvent(Event, IndividualScopeEventMixin):
         assert pd.isnull(df.at[person_id, 'gi_last_diarrhoea_death_date'])
 
         # Resolve all the symptoms immediately
+        df.at[person_id, 'gi_last_diarrhoea_dehydration'] = 'none'
         self.sim.modules['SymptomManager'].clear_symptoms(person_id=person_id,
                                                           disease_module=self.sim.modules['Diarrhoea'])
 
@@ -1341,6 +1342,7 @@ class DiarrhoeaCureEvent(Event, IndividualScopeEventMixin):
         df.at[person_id, 'gi_last_diarrhoea_death_date'] = pd.NaT
 
         # Resolve all the symptoms immediately
+        df.at[person_id, 'gi_last_diarrhoea_dehydration'] = 'none'
         self.sim.modules['SymptomManager'].clear_symptoms(person_id=person_id,
                                                           disease_module=self.sim.modules['Diarrhoea'])
 

--- a/src/tlo/methods/dx_algorithm_child.py
+++ b/src/tlo/methods/dx_algorithm_child.py
@@ -113,7 +113,9 @@ class DxAlgorithmChild(Module):
                          tclose=None
                          )
         else:
-            print('no treatment for this person')
+            # There is no treatment for this person
+            pass
+
 
         # ----------------------------------------------------
 

--- a/tests/test_diarrhoea.py
+++ b/tests/test_diarrhoea.py
@@ -362,9 +362,11 @@ def test_basic_run_of_diarrhoea_module_with_high_incidence_and_high_death_and_wi
 # TODO Run with intervention but no health-care-seeking: check that no cures happen etc, some deaths hapen;
 
 
+# NB. With increased frequency, there can be 'interference' between successive episodes:
+# e.g. one episode is scheduled for a recovery, but is cured (although the reocvery event is still in the queue), then a
+# subsequent episodes has a different natural history, which don't make sense when the orignal recovery event is run.
 
 
-
-
+# TODO - add 'end of episode' (the date after which nothing else is scheduled), to prevent new episodes being started.
 
 


### PR DESCRIPTION
Diarrhoea natural history done (with rudimentary HSIs). Files to look at include: diarrhoea.py, and from analyses scripts: diarrhoea_run_me (basic run), analysis_diarrhoea_with_treatment.py, and analysis_diarrhoea_no_treatment.py

@tbhallett could you check the bars on the 0 year olds from the analysis_diarrhoea_no_treatment, please? calibrated data and output data not even. Also in analysis_diarrhoea_with_treatment.py is not producing the last plot of death rates by year: across the scenarios.

Thanks everyone!