### PR TITLE
Parse the log dict using eval if literal_eval fails

### DIFF
--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -3,6 +3,7 @@ General utility functions for TLO analysis
 """
 from ast import literal_eval
 
+import numpy as np
 import pandas as pd
 
 from tlo import logging, util
@@ -28,14 +29,22 @@ def parse_line(line):
     :return: a dictionary with parsed line
     """
     parts = line.split('|')
+
     if len(parts) != 5:
         return None
+
     logger.debug('%s', line)
+
+    try:
+        parsed = literal_eval(parts[4])
+    except ValueError:
+        parsed = eval(parts[4], {'Timestamp': pd.Timestamp, 'nan': np.nan, 'NaT': pd.NaT})
+
     info = {
         'logger': parts[1],
         'sim_date': parts[2],
         'key': parts[3],
-        'object': literal_eval(parts[4])
+        'object': parsed
     }
     logger.debug('%s', info)
     return info


### PR DESCRIPTION
Currently, we use literal_eval to parse lines in log files. These do not allow certain objects which appear in some logs e.g. nan, NaT, Timestamp.

This hotfix is a stopgap measure before the introduction of new structured logging. If literal_eval fails, we use eval to construct the dict, passing in locals dict for nan etc.