### PR TITLE
Treating an integer property column as a bitset

### DIFF
--- a/resources/Method_Lifestyle_Enhanced.xlsx
+++ b/resources/Method_Lifestyle_Enhanced.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8310aed270bca5eb52755c13369cc0c739a8c423d8b6e8d697c2e4d7cfe9fa16
+size 4141906

--- a/resources/ResourceFile_Contraception.xlsx
+++ b/resources/ResourceFile_Contraception.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48c0a0cbe45e9fbb0d45c6516b236637ae3a61eec45e50cc57d2741fc5b12eec
+size 1191128

--- a/resources/ResourceFile_Deaths_And_Causes_DeathRates_GBD.csv
+++ b/resources/ResourceFile_Deaths_And_Causes_DeathRates_GBD.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdcc66493a7a3b5abed17d96cc30c5cfa5dcf9e9c8902ac5cf2c68a3ce41cb9e
+size 18620889

--- a/resources/ResourceFile_Epilepsy.xlsx
+++ b/resources/ResourceFile_Epilepsy.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ad84f14bc41b51b8fda63eb1dbda11a7dc085b0a652f5c9304df40b184eb360
+size 1251491

--- a/resources/ResourceFile_Lifestyle_Enhanced.xlsx
+++ b/resources/ResourceFile_Lifestyle_Enhanced.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7aa1fa1d83620b65f6a6ab16998cabe1534f844deef602a09ce815ce934f38c4
+size 4149782

--- a/resources/ResourceFile_Oesophageal_Cancer.xlsx
+++ b/resources/ResourceFile_Oesophageal_Cancer.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af88846e4ac4f451afe8e9fd88def9c6c319e21a62e7312a3e921fe09de2cfc9
+size 1236492

--- a/resources/ResourceFile_Pop_Annual_WPP.csv
+++ b/resources/ResourceFile_Pop_Annual_WPP.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5a99e344e86b16e3236159382de4a7a95dd6dfcf8aba21072b06ae9ccc2e632
+size 1538982

--- a/resources/ResourceFile_mwi_admbnda_adm2_nso_20181016.shp
+++ b/resources/ResourceFile_mwi_admbnda_adm2_nso_20181016.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2614395c290d15fe68fecae60c27767c0043b8f4462f115f5ccb8fe081c50ea2
+size 2314568

--- a/src/tlo/util.py
+++ b/src/tlo/util.py
@@ -185,7 +185,7 @@ class BitsetHandler():
         value = np.invert(np.array(value, np.int64))
         self.df.loc[where, self._column] = np.bitwise_and(self.df.loc[where, self._column], value)
 
-    def has_all(self, where, *elements: str, pop=False) -> Union[pd.Series, bool]:
+    def has_all(self, where, *elements: str, first=False) -> Union[pd.Series, bool]:
         """Check whether individual(s) have all the elements given set to True
 
         The where argument is used verbatim as the first item in a `df.loc[x, y]` call. It can be index
@@ -197,24 +197,24 @@ class BitsetHandler():
 
         :param where: condition to filter rows that will checked
         :param elements: one or more elements to set to True
-        :param pop: a keyword argument to return first item in Series instead of Series"""
+        :param first: a keyword argument to return first item in Series instead of Series"""
         value = sum([self._lookup[x] for x in elements])
         matched = np.bitwise_and(self.df.loc[where, self._column], value) == value
-        if pop:
+        if first:
             return matched.iloc[0]
         return matched
 
-    def has_any(self, where, *elements: str, pop=False):
+    def has_any(self, where, *elements: str, first=False):
         """Sister method to `has_all` but instead checks whether matching rows have any of the elements
         set to True"""
         matched = pd.Series(False, index=self.df.index[where])
         for element in elements:
             matched = matched.where(matched, self.has_all(where, element))
-        if pop:
+        if first:
             return matched.iloc[0]
         return matched
 
-    def get(self, where, pop=False):
+    def get(self, where, first=False):
         """Returns a Series with set of string of elements where bit is True
 
         The where argument is used verbatim as the first item in a `df.loc[x, y]` call. It can be index
@@ -228,7 +228,7 @@ class BitsetHandler():
             bin_repr = format(integer, 'b')
             return {self._lookup[2 ** k] for k, v in enumerate(reversed(list(bin_repr))) if v == '1'}
         sets = self.df.loc[where, self._column].apply(int_to_set)
-        if pop:
+        if first:
             return sets.iloc[0]
         return sets
 

--- a/tests/test_bitset.py
+++ b/tests/test_bitset.py
@@ -54,7 +54,7 @@ def test_bitset():
     assert (symptoms.has_all(df.is_alive, 'cough') == [True, False, True, True, True]).all()
 
     # does individual 1 have vomiting or fever - use 'pop' to get single entry, not Series
-    assert (symptoms.has_any([0], 'fever', 'vomiting', pop=True))
+    assert (symptoms.has_any([0], 'fever', 'vomiting', first=True))
 
     # who has both cough and vomiting
     assert (symptoms.has_all(df.is_alive, 'cough', 'vomiting') == [True, False, True, False, True]).all()
@@ -78,7 +78,7 @@ def test_bitset():
     assert len(sets.loc[1]) == 0
     assert len(sets.loc[3]) == 1 and 'cough' in sets.loc[3]
 
-    person_symptoms = symptoms.get([4], pop=True)
+    person_symptoms = symptoms.get([4], first=True)
     assert person_symptoms.difference({'cough', 'vomiting'}) == set()
 
 


### PR DESCRIPTION
Add class `BitsetHandler` as a utility to work with integer columns as a bitset. This should replace columns currently using Python `sets` to store true/false for a _predefined_ list of items.

The test shows usage, but essentially it works on any property that has been set up with integer type. An example of a symptom column:

```
# population is the Population instance (_not props)
# 'symptoms' is the name of the column in the population dataframe
# then a list of defined elements for which we want to store true/false
symptoms = BitsetHandler(population, 'symptoms', ['fever', 'cough', 'vomiting'])

df = population.props

# set values
symptoms.set([123], 'fever')  # individual 123 now has fever
symptoms.set([123], 'vomiting')  # now has started vomiting
symptoms.set(df.index % 2 == 0, 'cough', 'vomiting')  # all even person ids are vomiting 

# unset values
symptoms.unset(df.is_alive, 'vomiting')  # no one alive is vomiting
symptoms.unset([321], 'cough') # individual 321 cough has resolved

# check status
symptoms.has_all(df.is_alive, 'vomiting', 'fever') # get series of true/false of all those with vomiting and fever
symptoms.has_any(df.is_alive, 'cough', 'fever')  # anyone with cough or fever

# pretty print
symptoms.uncompress(df.is_alive) # see an exploded representation of the bitset
```

 

