### PR TITLE
Upgrade markupsafe package

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file base.txt base.in
 #
 jinja2==2.10
-markupsafe==1.0           # via jinja2
+markupsafe==1.1.1         # via jinja2
 numpy==1.14.4
 pandas==0.23.1
 python-dateutil==2.7.3    # via pandas

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -27,7 +27,7 @@ jupyter-console==5.2.0    # via jupyter
 jupyter-core==4.4.0       # via jupyter-client, nbconvert, nbformat, notebook, qtconsole
 jupyter==1.0.0
 kiwisolver==1.0.1         # via matplotlib
-markupsafe==1.0
+markupsafe==1.1.1
 matplotlib==3.0.0
 mistune==0.8.3            # via nbconvert
 more-itertools==4.2.0     # via pytest


### PR DESCRIPTION
A previous fix was removed in 1.0 - upgrade to 1.1.1
- see https://github.com/pallets/markupsafe/issues/57#issuecomment-597105876