### PR TITLE
Migrate all remaining code to TLO logging

### DIFF
--- a/src/scripts/contraception/analysis_contraception.py
+++ b/src/scripts/contraception/analysis_contraception.py
@@ -1,7 +1,5 @@
 # %% Import Statements
 import datetime
-import logging
-import os
 from pathlib import Path
 
 import numpy as np
@@ -30,34 +28,20 @@ start_date = Date(2010, 1, 1)
 end_date = Date(2070, 1, 2)
 popsize = 1000
 
-# add file handler for the purpose of logging
-sim = Simulation(start_date=start_date)
-
-# this block of code is to capture the outputs to file
-logfile = outputpath / ('LogFile' + datestamp + '.log')
-
-if os.path.exists(logfile):
-    os.remove(logfile)
-fh = logging.FileHandler(logfile)
-fr = logging.Formatter("%(levelname)s|%(name)s|%(message)s")
-fh.setFormatter(fr)
-logging.getLogger().addHandler(fh)
+sim = Simulation(start_date=start_date, seed=1, log_config={'filename': 'LogFile', 'directory': outputpath})
 
 # run the simulation
-sim.register(demography.Demography(resourcefilepath=resourcefilepath))
-sim.register(contraception.Contraception(resourcefilepath=resourcefilepath))
-sim.seed_rngs(1)
+sim.register(
+    demography.Demography(resourcefilepath=resourcefilepath),
+    contraception.Contraception(resourcefilepath=resourcefilepath),
+)
 sim.make_initial_population(n=popsize)
 sim.simulate(end_date=end_date)
 
-# this will make sure that the logging file is complete
-fh.flush()
-
 # %% read the results
-output = parse_log_file(logfile)
+output = parse_log_file(sim.log_filepath)
 
 # %% Plot Contraception Use Over time:
-
 years = mdates.YearLocator()   # every year
 months = mdates.MonthLocator()  # every month
 years_fmt = mdates.DateFormatter('%Y')

--- a/src/scripts/enhanced_lifestyle_analyses/enhanced_lifestyle_analyses.py
+++ b/src/scripts/enhanced_lifestyle_analyses/enhanced_lifestyle_analyses.py
@@ -1,7 +1,5 @@
 # %% Import Statements
-import logging
-
-from tlo import Date, Simulation
+from tlo import Date, Simulation, logging
 from tlo.analysis.utils import parse_log_file
 from tlo.methods import (
     contraception,

--- a/src/scripts/epilepsy_analyses/analysis_epilepsy.py
+++ b/src/scripts/epilepsy_analyses/analysis_epilepsy.py
@@ -1,12 +1,10 @@
 import datetime
-import logging
-import os
 from pathlib import Path
 
 import pandas as pd
 from matplotlib import pyplot as plt
 
-from tlo import Date, Simulation
+from tlo import Date, Simulation, logging
 from tlo.analysis.utils import parse_log_file
 from tlo.methods import (
     contraception,
@@ -26,48 +24,40 @@ datestamp = datetime.date.today().strftime("__%Y_%m_%d")
 # The resource files
 resourcefilepath = Path("./resources")
 
-
 start_date = Date(2010, 1, 1)
 end_date = Date(2011, 4, 1)
 popsize = 5000
 
 # Establish the simulation object
-sim = Simulation(start_date=start_date)
-
-# Establish the logger
-logfile = outputpath / ('LogFile' + datestamp + '.log')
-
-if os.path.exists(logfile):
-    os.remove(logfile)
-fh = logging.FileHandler(logfile)
-fr = logging.Formatter("%(levelname)s|%(name)s|%(message)s")
-fh.setFormatter(fr)
-logging.getLogger().addHandler(fh)
-
-logging.getLogger('tlo.methods.Demography').setLevel(logging.DEBUG)
+log_config = {
+    'filename': 'LogFile',
+    'directory': outputpath,
+    'custom_levels': {
+        'tlo.methods.demography': logging.DEBUG
+    }
+}
+sim = Simulation(start_date=start_date, seed=0, log_config=log_config)
 
 # make a dataframe that contains the switches for which interventions are allowed or not allowed
 # during this run. NB. These must use the exact 'registered strings' that the disease modules allow
 
 
 # Register the appropriate modules
-sim.register(demography.Demography(resourcefilepath=resourcefilepath))
-sim.register(contraception.Contraception(resourcefilepath=resourcefilepath))
-sim.register(enhanced_lifestyle.Lifestyle(resourcefilepath=resourcefilepath))
-sim.register(healthsystem.HealthSystem(resourcefilepath=resourcefilepath))
-sim.register(healthburden.HealthBurden(resourcefilepath=resourcefilepath))
-sim.register(epilepsy.Epilepsy(resourcefilepath=resourcefilepath))
-
+sim.register(demography.Demography(resourcefilepath=resourcefilepath),
+             contraception.Contraception(resourcefilepath=resourcefilepath),
+             enhanced_lifestyle.Lifestyle(resourcefilepath=resourcefilepath),
+             healthsystem.HealthSystem(resourcefilepath=resourcefilepath),
+             healthburden.HealthBurden(resourcefilepath=resourcefilepath),
+             epilepsy.Epilepsy(resourcefilepath=resourcefilepath)
+             )
 
 # Run the simulation and flush the logger
-# sim.seed_rngs(0)
 sim.make_initial_population(n=popsize)
 sim.simulate(end_date=end_date)
-fh.flush()
 
 
 # %% read the results
-output = parse_log_file(logfile)
+output = parse_log_file(sim.log_filepath)
 
 prop_seiz_stat_0 = pd.Series(
     output['tlo.methods.epilepsy']['summary_stats_per_3m']['prop_seiz_stat_0'].values,

--- a/src/scripts/hiv/analysis_hiv.py
+++ b/src/scripts/hiv/analysis_hiv.py
@@ -1,9 +1,7 @@
 import datetime
-import logging
-import os
 from pathlib import Path
 
-from tlo import Date, Simulation
+from tlo import Date, Simulation, logging
 from tlo.analysis.utils import parse_log_file
 from tlo.methods import (
     demography,
@@ -29,59 +27,44 @@ end_date = Date(2015, 1, 1)
 popsize = 5000
 
 # Establish the simulation object
-sim = Simulation(start_date=start_date)
-
-# Establish the logger
-logfile = outputpath / ("LogFile" + datestamp + ".log")
-
-if os.path.exists(logfile):
-    os.remove(logfile)
-fh = logging.FileHandler(logfile)
-fr = logging.Formatter("%(levelname)s|%(name)s|%(message)s")
-fh.setFormatter(fr)
-logging.getLogger().addHandler(fh)
+log_config = {
+    'filename': 'Logfile',
+    'directory': outputpath,
+    'custom_levels': {
+        '*': logging.WARNING,
+        'tlo.methods.hiv': logging.INFO,
+        'tlo.methods.tb': logging.INFO,
+        'tlo.methods.male_circumcision': logging.INFO
+    }
+}
+sim = Simulation(start_date=start_date, seed=0, log_config=log_config)
 
 # ----- Control over the types of intervention that can occur -----
 # Make a list that contains the treatment_id that will be allowed. Empty list means nothing allowed.
 # '*' means everything. It will allow any treatment_id that begins with a stub (e.g. Mockitis*)
 service_availability = ["*"]
 
-logging.getLogger("tlo.methods.demography").setLevel(logging.WARNING)
-logging.getLogger("tlo.methods.lifestyle").setLevel(logging.WARNING)
-logging.getLogger("tlo.methods.healthburden").setLevel(logging.WARNING)
-logging.getLogger("tlo.methods.hiv").setLevel(logging.INFO)
-logging.getLogger("tlo.methods.tb").setLevel(logging.INFO)
-logging.getLogger("tlo.methods.male_circumcision").setLevel(logging.INFO)
-
 # Register the appropriate modules
-sim.register(demography.Demography(resourcefilepath=resourcefilepath))
-sim.register(healthsystem.HealthSystem(resourcefilepath=resourcefilepath))
-sim.register(healthburden.HealthBurden(resourcefilepath=resourcefilepath))
-sim.register(enhanced_lifestyle.Lifestyle(resourcefilepath=resourcefilepath))
-sim.register(hiv.hiv(resourcefilepath=resourcefilepath))
-sim.register(tb.tb(resourcefilepath=resourcefilepath))
-sim.register(male_circumcision.male_circumcision(resourcefilepath=resourcefilepath))
+sim.register(demography.Demography(resourcefilepath=resourcefilepath),
+             healthsystem.HealthSystem(resourcefilepath=resourcefilepath),
+             healthburden.HealthBurden(resourcefilepath=resourcefilepath),
+             enhanced_lifestyle.Lifestyle(resourcefilepath=resourcefilepath),
+             hiv.hiv(resourcefilepath=resourcefilepath),
+             tb.tb(resourcefilepath=resourcefilepath),
+             male_circumcision.male_circumcision(resourcefilepath=resourcefilepath))
 
 # Run the simulation and flush the logger
-sim.seed_rngs(0)
 sim.make_initial_population(n=popsize)
 sim.simulate(end_date=end_date)
-fh.flush()
-# fh.close()
 
 # %% read the results
 
-output = parse_log_file(logfile)
+output = parse_log_file(sim.log_filepath)
 
 
 # outputpath = './src/scripts/outputLogs/'
 # TODO: I am removing the redef of outputpath (see above)
 
-# date-stamp to label log files and any other outputs
-# datestamp = datetime.date.today().strftime("__%Y_%m_%d")
-# logfile = outputpath + 'LogFile' + datestamp + '.log'
-# outputs = parse_log_file(logfile)
-#
 # deaths_df = outputs['tlo.methods.demography']['death']
 # deaths_df['date'] = pd.to_datetime(deaths_df['date'])
 # deaths_df['year'] = deaths_df['date'].dt.year

--- a/src/tlo/methods/contraception.py
+++ b/src/tlo/methods/contraception.py
@@ -4,12 +4,11 @@ Switching contraceptive methods, and discontiuation rates by age
 please see Dropbox/Thanzi la Onse/05 - Resources/Model design/Contraception-Pregnancy.pdf
 for conceptual diagram
 """
-import logging
 from pathlib import Path
 
 import pandas as pd
 
-from tlo import Date, DateOffset, Module, Parameter, Property, Types
+from tlo import Date, DateOffset, Module, Parameter, Property, Types, logging
 from tlo.events import PopulationScopeEventMixin, RegularEvent
 from tlo.util import transition_states
 

--- a/src/tlo/methods/epilepsy.py
+++ b/src/tlo/methods/epilepsy.py
@@ -1,9 +1,8 @@
-import logging
 from pathlib import Path
 
 import pandas as pd
 
-from tlo import DateOffset, Module, Parameter, Property, Types
+from tlo import DateOffset, Module, Parameter, Property, Types, logging
 from tlo.events import IndividualScopeEventMixin, PopulationScopeEventMixin, RegularEvent
 from tlo.methods import demography
 from tlo.methods.healthsystem import HSI_Event

--- a/src/tlo/methods/hiv.py
+++ b/src/tlo/methods/hiv.py
@@ -1,13 +1,12 @@
 """
 HIV infection event
 """
-import logging
 import os
 
 import numpy as np
 import pandas as pd
 
-from tlo import DateOffset, Module, Parameter, Property, Types
+from tlo import DateOffset, Module, Parameter, Property, Types, logging
 from tlo.events import Event, IndividualScopeEventMixin, PopulationScopeEventMixin, RegularEvent
 from tlo.methods import demography, tb
 from tlo.methods.healthsystem import HSI_Event

--- a/src/tlo/methods/male_circumcision.py
+++ b/src/tlo/methods/male_circumcision.py
@@ -1,12 +1,11 @@
 """
 Male circumcision
 """
-import logging
 import os
 
 import pandas as pd
 
-from tlo import DateOffset, Module, Parameter, Property, Types
+from tlo import DateOffset, Module, Parameter, Property, Types, logging
 from tlo.events import IndividualScopeEventMixin, PopulationScopeEventMixin, RegularEvent
 from tlo.methods.healthsystem import HSI_Event
 

--- a/src/tlo/methods/tb.py
+++ b/src/tlo/methods/tb.py
@@ -1,13 +1,11 @@
 """
 TB infections
 """
-
-import logging
 import os
 
 import pandas as pd
 
-from tlo import DateOffset, Module, Parameter, Property, Types
+from tlo import DateOffset, Module, Parameter, Property, Types, logging
 from tlo.events import Event, IndividualScopeEventMixin, PopulationScopeEventMixin, RegularEvent
 from tlo.methods import demography
 from tlo.methods.healthsystem import HSI_Event


### PR DESCRIPTION
A small PR to move some remaining files to use TLO logging. All the logger lines remain as before i.e. this _does not_ migrate old style logger messages to structured logging. Other small changes were made to set up simulations properly where necessary.