### PR TITLE
Fix for reproducible results

### DIFF
--- a/src/tlo/methods/diarrhoea.py
+++ b/src/tlo/methods/diarrhoea.py
@@ -43,7 +43,7 @@ logger.setLevel(logging.INFO)
 
 class Diarrhoea(Module):
     # Declare the pathogens that this module will simulate:
-    pathogens = {
+    pathogens = [
         'rotavirus',
         'shigella',
         'adenovirus',
@@ -54,7 +54,7 @@ class Diarrhoea(Module):
         'norovirus',
         'astrovirus',
         'tEPEC'
-    }
+    ]
 
     # Declare Metadata
     METADATA = {
@@ -652,11 +652,11 @@ class Diarrhoea(Module):
             self.prob_symptoms[pathogen] = make_symptom_probs(pathogen)
 
         # Check that each pathogen has a risk of developing each symptom
-        assert self.pathogens == set(list(self.prob_symptoms.keys()))
+        assert set(self.pathogens) == set(self.prob_symptoms.keys())
 
         assert all(
             [
-                self.symptoms == set(list(self.prob_symptoms[pathogen].keys()))
+                set(self.symptoms) == set(self.prob_symptoms[pathogen].keys())
                 for pathogen in self.prob_symptoms.keys()
             ]
         )


### PR DESCRIPTION
Story time: had a "fun" few hours chasing this bug. 

Whilst profiling, noticed results between repeated runs of same scenario were not the same. First obvious check was  the random number generators. All seemed to be correctly seeded and used.

Using debug output, saw inconsistent use of the healthcare system: some persons were having appointments scheduled in one run but not another. Started looking over that module and health-seeking to see what was happening. Couldn't see anything obviously wrong. Added more debug logs to see where appointment was being scheduled and why. Saw persons would have different symptoms between runs and knock-on effects of failed malaria/diarrhoea or diagnoses. Started looking through those carefully and still all looked fine! 

Carefully started worked back through how diarrhoea symptoms are set. Traced back to the selection of symptoms per pathogen in diarrhoea. After more runs, confirmed diarrhoea module was selecting different pathogens and, therefore, setting different symptoms for the same persons in different runs. But the module rng was being used correctly, seeded; all looked in order. 

Finally noticed the variable listing all possible pathogens at top of module is a `set`! When iterating over a set between runs, the order is not consistent because of hash randomisation! Iterating over a set in the same Python process may be consistent (based on history of insertions/deletions) but not between different Python processes. 

Interesting how this small error in larger & longer runs led to "butterfly effect" of quite different populations.