### PR TITLE
Optimise performance of DiarrhoeaIncidentCase

### DIFF
--- a/src/tlo/methods/diarrhoea.py
+++ b/src/tlo/methods/diarrhoea.py
@@ -900,8 +900,8 @@ class DiarrhoeaIncidentCase(Event, IndividualScopeEventMixin):
         # ----------------------- Determine duration for this episode ----------------------
         mean_duration = m.mean_duration_in_days_of_diarrhoea_lookup[self.pathogen]
         half_range = p['range_in_days_duration_of_episode'] / 2
-        mean_duration = mean_duration + rng.randint(-half_range, half_range)
-        duration_in_days_of_episode = int(max(p['min_days_duration_of_episode'], mean_duration))
+        actual_duration = mean_duration + rng.randint(-half_range, half_range)
+        duration_in_days_of_episode = int(max(p['min_days_duration_of_episode'], actual_duration))
 
         date_of_outcome = self.sim.date + DateOffset(days=duration_in_days_of_episode)
 


### PR DESCRIPTION
Part of #63.

Using linear model on many individual events is very expensive. We're looking into optimising linear models too, but in the meantime:

* Replace mean_duration_in_days_of_diarrhoea linear model with simple lookup of probabilities
* Calculate probability directly in python rather than calling linear model
* Collect all updates to person in dict and update entry in population in single call

Other minor changes.