### PR TITLE
[skip ci] Add a scheduled CI job at midnight UTC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: "master"
     tags: ["*"]
   pull_request:
+  schedule:
+    - cron: 0 0 * * *
 
 env:
   LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so
@@ -14,6 +16,7 @@ jobs:
 
   gen-test-matrix:
     name: Find test files
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: [self-hosted]
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -37,6 +40,7 @@ jobs:
 
   test:
     needs: gen-test-matrix
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: Test ${{ matrix.file }}
     runs-on: [self-hosted]
     strategy:
@@ -61,6 +65,7 @@ jobs:
 
   check:
     name: Checks
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: [self-hosted]
     strategy:
       fail-fast: false
@@ -82,6 +87,7 @@ jobs:
 
   docs:
     name: Documentation
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: [self-hosted]
     strategy:
       fail-fast: false


### PR DESCRIPTION
This runs a job every day on the `master` branch, to catch any possible issue
with upstream packages updates.