### PR TITLE
Fix definition of duplicate symptom exception

### DIFF
--- a/src/tlo/methods/symptommanager.py
+++ b/src/tlo/methods/symptommanager.py
@@ -116,8 +116,8 @@ class Symptom:
 
 
 class DuplicateSymptomWithNonIdenticalPropertiesError(Exception):
-    print("A symptom with this name has been registered already but with different properties")
-    pass
+    def __init__(self):
+        super().__init__("A symptom with this name has been registered already but with different properties")
 
 
 class SymptomManager(Module):


### PR DESCRIPTION
Message was configured in wrong place. (Does not fix Andrew's error - still to do)