### PR TITLE
fix on symptom manager to make it work on windows machines

### DIFF
--- a/src/tlo/methods/symptommanager.py
+++ b/src/tlo/methods/symptommanager.py
@@ -1,4 +1,3 @@
-# This is a new push
 """
 The Symptom Manager:
 * Manages presence of symptoms for all disease modules


### PR DESCRIPTION
This required changing form parameter int64 to integer to make work on both windows and mac machines  

This pull request is in response to this issue https://github.com/UCL/TLOmodel/issues/228