### PR TITLE
Including pregnancy status is logging of deaths 

### DIFF
--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -215,7 +215,7 @@ class Demography(Module):
         df.loc[individual_id, ['is_alive', 'date_of_death', 'cause_of_death']] = (False, self.sim.date, cause)
 
         # Log the death:
-        if 'Contraception' or 'SimplifiedBirths' in self.sim.modules.keys():
+        if ('Contraception' in self.sim.modules) or ('SimplifiedBirths' in self.sim.modules):
             logger.info(
                 key='death',
                 data={'age': person['age_years'],


### PR DESCRIPTION
Hi @tamuri - just added one line addition to demography so that pregnancy status is capture at time of death for all individuals. Discussed with @tbhallett in the programming channel who asked me to submit as PR. Thanks! 