### PR TITLE
Output appointment time footprint as dict rather than Pandas series

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -510,9 +510,8 @@ class HealthSystem(Module):
             # (ie. Check that this does not demand officers that are never available at a particular facility)
             caps = self.parameters['Daily_Capabilities']
             footprint = self.get_appt_footprint_as_time_request(hsi_event=hsi_event)
-
             footprint_is_possible = (len(footprint) > 0) & (
-                caps.loc[caps.index.isin(footprint.index), 'Total_Minutes_Per_Day'] > 0).all()
+                caps.loc[footprint.keys(), 'Total_Minutes_Per_Day'] > 0).all()
             if not footprint_is_possible:
                 logger.warning(key="message",
                                data=f"The expected footprint is not possible with the configuration of officers: "
@@ -787,7 +786,7 @@ class HealthSystem(Module):
                     f"FacilityID_{the_facility.id}_Officer_{appt_info.officer_type}"
                 ] += appt_info.time_taken
 
-        return pd.Series(appt_footprint_times)
+        return appt_footprint_times
 
     def get_squeeze_factors(self, all_calls_today, current_capabilities):
         """
@@ -1461,7 +1460,7 @@ class HealthSystemScheduler(RegularEvent, PopulationScopeEventMixin):
 
                         # Update load factors:
                         updated_call = self.module.get_appt_footprint_as_time_request(event, actual_appt_footprint)
-                        df_footprints_of_all_individual_level_hsi_event.loc[updated_call.index, ev_num] = updated_call
+                        df_footprints_of_all_individual_level_hsi_event.loc[updated_call.keys(), ev_num] = updated_call
                         squeeze_factor_per_hsi_event = self.module.get_squeeze_factors(
                             all_calls_today=df_footprints_of_all_individual_level_hsi_event,
                             current_capabilities=current_capabilities,


### PR DESCRIPTION
Follow on from #287. This changes the returned output of `HealthSystem.get_appt_footprint_as_time_request` from a `pandas.Series` instance to a `dict`, motivated by the observation from profiling that a large proportion of the time spent in `get_appt_footprint_as_time_request` is in the `Series.__init__` method.

There are three downstream usages of `get_appt_footprint_as_time_request`, all within the `healthsystem` module:

https://github.com/UCL/TLOmodel/blob/d9cb6e0419b52fc4cd1a49f72c34ccdea4f85b1a/src/tlo/methods/healthsystem.py#L512-L515

https://github.com/UCL/TLOmodel/blob/d9cb6e0419b52fc4cd1a49f72c34ccdea4f85b1a/src/tlo/methods/healthsystem.py#L1463-L1464

https://github.com/UCL/TLOmodel/blob/d9cb6e0419b52fc4cd1a49f72c34ccdea4f85b1a/src/tlo/methods/healthsystem.py#L1401-L1410

In the former two sections, the accesses of the `index` attribute of the previous `Series` object outputted by `get_appt_footprint_as_time_request` can be replaced by a call to the `keys` method of the dictionary, with the dictionary keys being equivalent here to the series index. In the third case, the output of a `pandas.DataFrame.__init__` call when passed a dictionary of series, each of which is constructed from a dictionary, or a dictionary of the original dictionaries, is the same and so this can be left unchanged.

After these changes running the `scale_run.py` profiling script for one month simulation time gives a final population dataframe with the same checksum as when running the code on `master`, providing in both cases the fix in #302 to ensure deterministic outputs is also applied.

A one-month simulation time run of `scale_run.py`  before these changes gives the following SnakeViz output for the overall run
 
![image](https://user-images.githubusercontent.com/6746980/121174447-d2d4ce00-c851-11eb-936d-5e4fc6cffffd.png)

and focusing specifically on `get_appt_footprint_as_time_request`

![image](https://user-images.githubusercontent.com/6746980/121174736-2515ef00-c852-11eb-84fa-dc436af48aad.png)

After the changes here, the corresponding SnakeViz output for the overall run is

![image](https://user-images.githubusercontent.com/6746980/121173658-f8150c80-c850-11eb-8bfb-55eecc8e9cba.png)

and focusing specifically on `get_appt_footprint_as_time_request`

![image](https://user-images.githubusercontent.com/6746980/121174321-b59fff80-c851-11eb-9ce4-c84e28658864.png)

The main obvious change is that removal of the `Series.__init__` call significantly reduces the time spent in `get_appt_footprint_as_time_request` to about 10% of previously (545s to 51.9s).