### PR TITLE
Optimizing `get_squeeze_factors` implementation

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -1408,7 +1408,13 @@ class HealthSystemScheduler(RegularEvent, PopulationScopeEventMixin):
                 self.module.get_appt_footprint_as_time_request(hsi_event=(event_tuple[4]))
                 for event_tuple in list_of_individual_hsi_event_tuples_due_today
             ]
-            total_footprint = sum(footprints_of_all_individual_level_hsi_event, Counter())
+
+            # Compute total appointment footprint across all events
+            # Summing manually in loop seems to be ~3 time quicker than
+            # sum(footprints_of_all_individual_level_hsi_event, Counter())
+            total_footprint = Counter()
+            for footprint in footprints_of_all_individual_level_hsi_event:
+                total_footprint += footprint
 
             # 5) Estimate Squeeze-Factors for today
             if self.module.mode_appt_constraints == 0:


### PR DESCRIPTION
Based on profiling (see #286) `HealthSystem.get_squeeze_factors` in the `healthsystem` module had become a bottleneck. This PR optimizes `HealthSystem.get_squeeze_factors` and some related upstream code in `HealthSystemScheduler.apply` and `HealthSystem.log_current_capabilities` to improve performance.

Specifically `HealthSystemScheduler.apply` previously constructed a `pandas.Dataframe` from the appointment time footprints for each individual level HSI event due for the current simulation day, with rows corresponding to the different officer types in each health facility type, and columns corresponding to each of the different due events, with the entries corresponding to officer times required in minutes. This dataframe was constructed from a dictionary (keyed by an 'event number' index) of 'footprint time request' objects returned by `HealthSystem.get_appt_footprint_as_time_request`. 

https://github.com/UCL/TLOmodel/blob/dcb82a197c2d0122cd73eba28867a93d53f95843/src/tlo/methods/healthsystem.py#L1400-L1409

Post #303 these footprint objects are `dict`-like (in reality they are instances of the in-built `dict` subclass [`Counter`](https://docs.python.org/3/library/collections.html#collections.Counter)), with keys corresponding to the officers and values the (non-zero) officer times required. While these dictionaries are 'sparse' in the sense of only storing entries for officers with non-zero time requirements, the corresponding dataframe contains entries for every officer and event number combination, with many of these being zero, and construction of this dataframe in itself takes up a considerable portion of the run time.

The first optimization made in this PR is to remove this step of constructing the dataframe as the footprint dictionaries (counters)  include all the necessary information. As the dictionary of per event footprints is keyed by consecutive integer indices, it seemed more natural to store this as a list, hence `footprints_of_all_individual_level_hsi_event` is constructed as a list comprehension instead of the current dictionary comprehension.

The previously defined `df_footprints_of_all_individual_level_hsi_event` dataframe was used downstream in calls to `HealthSystem.get_squeeze_factors`  and `HealthSystem.log_current_capabilities`. In both, the total times required of all officer types are computed by summing all of the per-event footprints. As `Counter` objects support arithmetic operations including addition and subtraction, the total times can be computed by directly calling `sum` on the list of footprints. As this operation is relatively expensive it is moved out of `HealthSystem.get_squeeze_factors`  and `HealthSystem.log_current_capabilities` and computed once in `HealthSystemScheduler.apply` after constructing the list of per event footprints, with the total footprint then passed in as a new argument to these methods. As there is a possibility of events returning an updated footprint after being run (though per #291 this does not currently seem to be in use), the list of per-event footprints and total footprint need to both be updated after any such changes (in the latter case just be subtracting the previous footprint of the event and adding in the new footprint).

To account for the per-event footprints now being passed as a list of counters to `HealthSystem.get_squeeze_factors`, the per-officer load factors are now computed in a for loop and stored in a `dict` rather than `Series` - while there is potentially an overhead from using a loop here compared to the vectorized operations on `Series` objects used previously, from the profiling results this seems to be negligible. The subsequent computation of the per-officer squeeze factors is moved to a list comprehension using the load factors `dict`.  As all indexing is now with a `dict` object rather than `Series` this removes the overhead associated with indexing in to `Series` objects compared to native Python types. The computed squeeze factors are directly stored in an array to simplify the subsequent sanity check `assert` statement that all are non-negative, with all of the downstream usages, previously of a list of floats, being compatible with a NumPy array.

After these changes running the `scale_run.py` profiling script for one month simulation time gives a final population dataframe with the same checksum as when running the code on master.

A 20&thinsp;000 population / one-month simulation time run of `scale_run.py` before these changes (dcb82a1) gives the following SnakeViz output for the overall run

![image](https://user-images.githubusercontent.com/6746980/121435017-204a5b80-c976-11eb-9f15-c9566a79fb96.png)

and focusing specifically on  `HealthSystemScheduler.apply`
![image](https://user-images.githubusercontent.com/6746980/121435065-33f5c200-c976-11eb-84c7-ebd1a2d8ed50.png)

After the changes in this PR, the corresponding SnakeViz output for the overall run is

![image](https://user-images.githubusercontent.com/6746980/121435100-4112b100-c976-11eb-8b37-4354ed63f148.png)

and focusing specifically on  `HealthSystemScheduler.apply`

![image](https://user-images.githubusercontent.com/6746980/121435229-6e5f5f00-c976-11eb-8f13-b9222a65f73c.png)

The total time spent in `HealthSystem.get_squeeze_factors` after the changes is 2.148s (not individually labelled in the plot as too small) compared to 1068s previously. This comparison is not entirely fair as the computation of the sum of all the footprints is now performed in `HealthSystemScheduler.apply`, with this corresponding to the `<built-in method builtins.sum>` entry in the latter plot; however, even combining all of this time (which in reality is amortized with the separate usage of the totals in `HealthSystem.log_current_capabilities`) with that now spent in `HealthSystem.get_squeeze_factors` still means a roughly 9&times; speed-up for this part of the code, and the overall run time is just over a third of previously.

Alternatively using [`pyinstrument`](https://github.com/joerick/pyinstrument) which uses a different statistical profiling approach we get the following results for the same `scale_run.py` run with 20&thinsp;000 population and 1 month simulation time (`pyinstrument` outputs the profiling data as a call tree annotated with the estimated time in seconds spent in each function, and its children). The times here are consistently lower, reflective of the lower overhead of `pyinstrument` compared to the in-built profiler, but show the same general patterns.

<details>
  <summary><code>pyinstrument</code> profiling output for current master</summary>

```
1362.433 <module>  ../<string>:1
   [4 frames hidden]  .., runpy
      1362.433 _run_code  runpy.py:64
      └─ 1362.433 <module>  scale_run_updated.py:1
         └─ 1348.474 simulate  tlo/simulation.py:194
            ├─ 1301.507 fire_single_event  tlo/simulation.py:262
            │  └─ 1301.507 run  tlo/events.py:32
            │     ├─ 1012.044 apply  tlo/methods/healthsystem.py:1322
            │     │  ├─ 678.601 get_squeeze_factors  tlo/methods/healthsystem.py:791
            │     │  │  ├─ 336.522 __getitem__  pandas/core/indexing.py:882
            │     │  │  │     [738 frames hidden]  pandas, .., abc, numpy, typing, conte...
            │     │  │  ├─ 179.815 new_method  pandas/core/ops/common.py:50
            │     │  │  │     [548 frames hidden]  pandas, .., numpy, abc, warnings
            │     │  │  ├─ 78.478 astype  pandas/core/indexes/base.py:665
            │     │  │  │     [276 frames hidden]  pandas, numpy, .., typing
            │     │  │  ├─ 54.285 __getitem__  pandas/core/frame.py:2987
            │     │  │  │     [126 frames hidden]  pandas, ..
            │     │  │  └─ 17.112 [self]
            │     │  ├─ 244.772 __init__  pandas/core/frame.py:502
            │     │  │     [312 frames hidden]  pandas, .., numpy, abc, typing
            │     │  ├─ 38.952 <dictcomp>  tlo/methods/healthsystem.py:1400
            │     │  │  └─ 37.830 get_appt_footprint_as_time_request  tlo/methods/healthsystem.py:738
            │     │  └─ 16.860 log_current_capabilities  tlo/methods/healthsystem.py:1054
            │     │     └─ 16.667 sum  pandas/core/generic.py:11046
            │     │           [164 frames hidden]  pandas, numpy, .., abc
            │     ├─ 214.606 apply  tlo/methods/healthseekingbehaviour.py:193
            │     │  ├─ 155.252 schedule_hsi_event  tlo/methods/healthsystem.py:385
            │     │  │  ├─ 90.930 <listcomp>  tlo/methods/healthsystem.py:500
            │     │  │  │  ├─ 36.679 all  pandas/core/generic.py:10870
            │     │  │  │  │     [1782 frames hidden]  pandas, .., numpy, typing, abc, inspect
            │     │  │  │  └─ 36.540 __getitem__  pandas/core/indexing.py:882
            │     │  │  │        [1028 frames hidden]  pandas, .., numpy, abc, typing, conte...
            │     │  │  └─ 29.316 __getitem__  pandas/core/indexing.py:882
            │     │  │        [1596 frames hidden]  pandas, .., numpy, typing, abc, conte...
            │     │  ├─ 25.580 have_what  tlo/methods/symptommanager.py:435
            │     │  │  └─ 25.288 apply  pandas/core/frame.py:7622
            │     │  │        [405 frames hidden]  pandas, .., numpy
            │     │  │           25.216 apply_series_generator  pandas/core/apply.py:281
            │     │  │           └─ 14.543 <lambda>  tlo/methods/symptommanager.py:440
            │     │  │              └─ 14.457 <listcomp>  tlo/methods/symptommanager.py:440
            │     │  └─ 13.719 iterrows  pandas/core/frame.py:1026
            │     │        [356 frames hidden]  pandas, .., abc, numpy
            │     ├─ 16.129 apply  tlo/methods/malaria.py:557
            │     │  └─ 15.614 schedule_hsi_event  tlo/methods/healthsystem.py:385
            │     └─ 14.374 apply  tlo/methods/cardio_metabolic_disorders.py:395
            └─ 46.053 initialise_simulation  tlo/methods/hiv.py:557
               └─ 45.840 get_time_from_infection_to_aids  tlo/methods/hiv.py:862
                  └─ 39.616 predict  tlo/lm.py:339
                     └─ 39.164 eval  pandas/core/computation/eval.py:160
                           [24576 frames hidden]  pandas, .., abc, collections, ast, nu...
```
</details>

<details> 
  <summary><code>pyinstrument</code> profiling output for this PR</summary>

```
498.981 <module>  ../<string>:1
   [4 frames hidden]  .., runpy
      498.981 _run_code  runpy.py:64
      └─ 498.981 <module>  scale_run_updated.py:1
         ├─ 485.554 simulate  tlo/simulation.py:194
         │  ├─ 438.603 fire_single_event  tlo/simulation.py:262
         │  │  └─ 438.601 run  tlo/events.py:32
         │  │     ├─ 206.934 apply  tlo/methods/healthseekingbehaviour.py:193
         │  │     │  ├─ 149.194 schedule_hsi_event  tlo/methods/healthsystem.py:385
         │  │     │  │  ├─ 88.366 <listcomp>  tlo/methods/healthsystem.py:500
         │  │     │  │  │  ├─ 36.606 all  pandas/core/generic.py:10870
         │  │     │  │  │  │     [1780 frames hidden]  pandas, .., numpy, typing, abc, inspect
         │  │     │  │  │  ├─ 34.936 __getitem__  pandas/core/indexing.py:882
         │  │     │  │  │  │     [1028 frames hidden]  pandas, .., numpy, abc, typing, conte...
         │  │     │  │  │  ├─ 8.722 new_method  pandas/core/ops/common.py:50
         │  │     │  │  │  │     [446 frames hidden]  pandas, .., numpy, abc
         │  │     │  │  │  └─ 6.796 wrapper  pandas/core/strings/accessor.py:93
         │  │     │  │  │        [236 frames hidden]  pandas, .., numpy, re
         │  │     │  │  ├─ 27.694 __getitem__  pandas/core/indexing.py:882
         │  │     │  │  │     [1602 frames hidden]  pandas, .., numpy, typing, abc, conte...
         │  │     │  │  ├─ 9.864 new_method  pandas/core/ops/common.py:50
         │  │     │  │  │     [542 frames hidden]  pandas, .., numpy, abc, warnings
         │  │     │  │  └─ 5.026 [self]
         │  │     │  ├─ 25.400 have_what  tlo/methods/symptommanager.py:435
         │  │     │  │  └─ 25.112 apply  pandas/core/frame.py:7622
         │  │     │  │        [416 frames hidden]  pandas, .., numpy
         │  │     │  │           25.041 apply_series_generator  pandas/core/apply.py:281
         │  │     │  │           ├─ 14.380 <lambda>  tlo/methods/symptommanager.py:440
         │  │     │  │           │  └─ 14.305 <listcomp>  tlo/methods/symptommanager.py:440
         │  │     │  │           │     └─ 12.795 __getitem__  pandas/core/series.py:837
         │  │     │  │           │           [38 frames hidden]  pandas, ..
         │  │     │  ├─ 13.280 iterrows  pandas/core/frame.py:1026
         │  │     │  │     [361 frames hidden]  pandas, .., abc, numpy
         │  │     │  └─ 5.590 __init__  tlo/methods/hsi_generic_first_appts.py:67
         │  │     ├─ 161.140 apply  tlo/methods/healthsystem.py:1330
         │  │     │  ├─ 91.242 __add__  collections/__init__.py:706
         │  │     │  │     [12 frames hidden]  collections, ..
         │  │     │  ├─ 37.710 <listcomp>  tlo/methods/healthsystem.py:1409
         │  │     │  │  └─ 36.804 get_appt_footprint_as_time_request  tlo/methods/healthsystem.py:738
         │  │     │  │     ├─ 12.568 <listcomp>  tlo/methods/healthsystem.py:771
         │  │     │  │     ├─ 8.388 get_facility_info  tlo/methods/healthsystem.py:727
         │  │     │  │     │  └─ 6.670 __getitem__  pandas/core/indexing.py:2148
         │  │     │  │     │        [34 frames hidden]  pandas, ..
         │  │     │  │     └─ 6.856 [self]
         │  │     │  ├─ 7.183 [self]
         │  │     │  ├─ 6.982 __getitem__  pandas/core/indexing.py:2148
         │  │     │  │     [34 frames hidden]  pandas, ..
         │  │     │  ├─ 6.799 heappop  ../<built-in>:0
         │  │     │  │     [2 frames hidden]  ..
         │  │     │  └─ 5.464 log_hsi_event  tlo/methods/healthsystem.py:1014
         │  │     ├─ 15.365 apply  tlo/methods/malaria.py:557
         │  │     │  └─ 14.875 schedule_hsi_event  tlo/methods/healthsystem.py:385
         │  │     │     └─ 8.666 <listcomp>  tlo/methods/healthsystem.py:500
         │  │     ├─ 13.142 apply  tlo/methods/cardio_metabolic_disorders.py:395
         │  │     │  ├─ 7.003 lmpredict_rtn_a_series  tlo/methods/cardio_metabolic_disorders.py:412
         │  │     │  │  └─ 7.003 predict  tlo/lm.py:339
         │  │     │  │     └─ 6.967 eval  pandas/core/computation/eval.py:160
         │  │     │  │           [22085 frames hidden]  pandas, .., warnings, numpy, collecti...
         │  │     │  └─ 5.979 predict  tlo/lm.py:339
         │  │     │     └─ 5.953 eval  pandas/core/computation/eval.py:160
         │  │     │           [20347 frames hidden]  pandas, .., typing, shutil, warnings,...
         │  │     ├─ 8.976 apply  tlo/methods/hiv.py:1040
         │  │     │  └─ 8.050 schedule_hsi_event  tlo/methods/healthsystem.py:385
         │  │     └─ 5.428 apply  tlo/methods/pregnancy_supervisor.py:1605
         │  └─ 46.056 initialise_simulation  tlo/methods/hiv.py:557
         │     └─ 45.850 get_time_from_infection_to_aids  tlo/methods/hiv.py:862
         │        ├─ 39.620 predict  tlo/lm.py:339
         │        │  └─ 39.153 eval  pandas/core/computation/eval.py:160
         │        │        [24509 frames hidden]  pandas, .., abc, collections, ast, nu...
         │        └─ 6.040 __getitem__  pandas/core/indexing.py:882
         │              [697 frames hidden]  pandas, .., numpy, abc, typing
         ├─ 6.443 make_initial_population  tlo/simulation.py:172
         └─ 6.174 register  tlo/simulation.py:126
```
</details>