### PR TITLE
Remove repeated multiplication by capabilities coefficient

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -615,9 +615,6 @@ class HealthSystem(Module):
         # Get the capabilities data as they are imported
         capabilities = self.parameters['Daily_Capabilities']
 
-        # apply the capabilities_coefficient
-        capabilities['Total_Minutes_Per_Day'] = capabilities['Total_Minutes_Per_Day'] * self.capabilities_coefficient
-
         # Create dataframe containing background information about facility and officer types
         facility_ids = self.parameters['Master_Facilities_List']['Facility_ID'].values
         officer_type_codes = self.parameters['Officer_Types_Table']['Officer_Type_Code'].values


### PR DESCRIPTION
Fixes #311 by removing multiplication of daily capabilities by `capabilities_coefficient` in `HealthSystem.reformat_daily_capabilities`, with multiplication by `capabilities_coefficient` in `HealthSystem.get_capabilities_today` left in place.