### PR TITLE
Caching appointment time requests

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -733,40 +733,48 @@ class HealthSystem(Module):
 
     def get_appt_footprint_as_time_request(self, hsi_event, actual_appt_footprint=None):
         """
-        This will take an HSI event and return the required appointments in terms of the time required of each
-        Officer Type in each Facility ID.
-        The index will identify the Facility ID and the Officer Type in the same format as is used in
-        Daily_Capabilities.
+        This will take an HSI event and return the required appointments in terms of the
+        time required of each Officer Type in each Facility ID.
+        The index will identify the Facility ID and the Officer Type in the same format
+        as is used in Daily_Capabilities.
 
         :param hsi_event: The HSI event
-        :param actual_appt_footprint: The actual appt footprint (optional) if different to that in the HSI_event
-        :return: A series that gives the time required for each officer-type in each facility_ID
+        :param actual_appt_footprint: The actual appt footprint (optional) if different
+            to that in the HSI event.
+        :return: A Counter that gives the times required for each officer-type in each
+            facility_ID, where this time is non-zero.
         """
+        # If specified use actual_appt_footprint otherwise use EXPECTED_APPT_FOOTPRINT
+        the_appt_footprint = (
+            hsi_event.EXPECTED_APPT_FOOTPRINT if actual_appt_footprint is None else
+            actual_appt_footprint
+        )
+        # Check in time request cache in event if a time request corresponding to the
+        # current relevant event attributes and appointment footprint has previously
+        # been stored, and if so return this
+        cache_key = (
+            hsi_event.target,
+            hsi_event.ACCEPTED_FACILITY_LEVEL,
+            tuple(the_appt_footprint)
+        )
+        cached_time_request = hsi_event._cached_time_requests.get(cache_key)
+        if cached_time_request is not None:
+            return cached_time_request
 
-        # If actual_appt_footprint not specified (such that EXPECTED_APPT_FOOTPRINT is
-        # used) and there is a cached time request previously computed from
-        # EXPECTED_APPT_FOOTPRINT then return this
-        if actual_appt_footprint is None and hsi_event._cached_time_request is not None:
-            return hsi_event._cached_time_request
+        # No entry in cache so compute time request
 
-        # Gather useful information
+        # Appointment times for each facility and officer combination
         appt_times = self.parameters['Appt_Time_Table']
 
-        # Gather information about the HSI event
+        # Facility level required by this event
         the_facility_level = hsi_event.ACCEPTED_FACILITY_LEVEL
-
-        # Get the appt_footprint
-        if actual_appt_footprint is None:
-            # use the appt_footprint in the hsi_event
-            the_appt_footprint = hsi_event.EXPECTED_APPT_FOOTPRINT
-        else:
-            # use the actual_appt_provided
-            the_appt_footprint = actual_appt_footprint
 
         # Get the (one) health_facility available to this person (based on their
         # district), which is accepted by the hsi_event.ACCEPTED_FACILITY_LEVEL:
         the_facility = self.get_facility_info(hsi_event)
 
+        # Accumulate appointment times for specified footprint using times from
+        # appointment times table
         appt_footprint_times = Counter()
         for appt_type in the_appt_footprint:
             try:
@@ -782,10 +790,8 @@ class HealthSystem(Module):
                     f"FacilityID_{the_facility.id}_Officer_{appt_info.officer_type}"
                 ] += appt_info.time_taken
 
-        # Cache a time request generated from EXPECTED_APPT_FOOTPRINT to avoid having
-        # to recompute on subsequent calls
-        if actual_appt_footprint is None:
-            hsi_event._cached_time_request = appt_footprint_times
+        # Cache the time request to avoid having to recompute on subsequent calls
+        hsi_event._cached_time_requests[cache_key] = appt_footprint_times
 
         return appt_footprint_times
 
@@ -1548,7 +1554,7 @@ class HSI_Event:
         self.ALERT_OTHER_DISEASES = []
         self.BEDDAYS_FOOTPRINT = self.make_beddays_footprint({})
         self._received_info_about_bed_days = None
-        self._cached_time_request = None
+        self._cached_time_requests = {}
 
     @property
     def bed_days_allocated_to_this_event(self):


### PR DESCRIPTION
Profiling of a 1 year run of `scale_run.py` shows that considerable time is still being spent in `HealthSystem.get_appt_footprint_as_time_request` even with the optimizations in #287, #303 and #313.

The SnakeViz output for a 1 year `scale_run.py` run shows an overall breakdown

![image](https://user-images.githubusercontent.com/6746980/124131344-9cb4f380-da77-11eb-9927-41449337fb2b.png)

with `HealthSystem.get_appt_footprint_as_time_request` corresponding to the dark orange bar beneath the light blue `healthsystem.py1394(<listcomp>)` bar on the far left, with the breakdown within `HealthSystem.get_appt_footprint_as_time_request` as follows

![image](https://user-images.githubusercontent.com/6746980/124131496-c5d58400-da77-11eb-86e9-cd20a4d51cf4.png)

Most of time seems to be spent dataframe access operations in `HealthSystem.get_facility_info`.

The high number of calls of  `get_appt_footprint_as_time_request` (149496460 in this 1 year run) I think suggests that it is being called multiple times for each `HSI_Event` due to the event being put in the hold-over list for running on subsequent days by the health system scheduler. This suggests we can cache the appointment time request generated on the first call to `get_appt_footprint_as_time_request` for a HSI event within the event and return it on any subsequent calls on the same event, with this idea being the basis of this PR.

In general the generated time request can depend on both a HSI event and a appointment footprint which may differ from the `EXPECTED_APPT_FOOTPRINT` of the event. For the sake of simplicity here I only cache time requests generated from the `EXPECTED_APPT_FOOTPRINT` footprint rather than any updated footprint passed via the `actual_appt_footprint` argument to `get_appt_footprint_as_time_request`, with a non-`None` value for this argument causing the time request to always be recomputed. 

The caching mechanism here assumes that the `HSI_Event` is essentially static after creation - in particular it assumes that neither the `EXPECTED_APPT_FOOTPRINT` `target` attributes are changed after initial creation such that a previously computed time request will remain valid. There is also an assumption that the district of residence of the target cannot change (as this would change the facility information returned by `get_facility_info`). As far as I can tell these assumptions are valid currently, with this backed up by the final population dataframe after a 1 year run being the same before and after the changes in this PR. These assumptions could however potentially be invalidated by future changes to the code. While we could potentially make the `EXPECTED_APPT_FOOTPRINT` and `target` attributes of a `HSI_Event` immutable to guard against this, this would still not protect against the possibility of the target's district being updated in the dataframe (and explicitly checking that this value is the same to check if the cached time request is valid would remove a lot of the performance gain given the proportion of time spent currently in `get_facility_info`).

The SnakeViz output for a 1 year `scale_run.py` run after the changes made in this PR<sup>[1](#note1)</sup> gives the following overall breakdown

![image](https://user-images.githubusercontent.com/6746980/124135076-624d5580-da7b-11eb-9c2f-58210312c892.png)

and specifically looking at `get_appt_footprint_as_time_request`

![image](https://user-images.githubusercontent.com/6746980/124135546-cf60eb00-da7b-11eb-8e8d-b5a86cd05361.png)

From which we can see that the time spent in computing `get_appt_footprint_as_time_request` has been drastically reduced (from 4330s to 120s).

<a name="note1">1.</a> The profiling run was in fact for a slightly different version of the code in this PR which didn't create a `_cached_time_request` attribute with value `None` in the `__init__` method of `HSI_Event` but instead simply created this attribute after the first call to `get_appt_footprint_as_time_request` and checked for the presence of this attribute with `hasattr` when deciding whether to return a cached value, hence the presence of the `hasattr` block in the SnakeViz output and slight mismatch with the line numbers.