### PR TITLE
Using `Counter` update method to sum footprints

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -1397,11 +1397,11 @@ class HealthSystemScheduler(RegularEvent, PopulationScopeEventMixin):
             ]
 
             # Compute total appointment footprint across all events
-            # Summing manually in loop seems to be ~3 time quicker than
-            # sum(footprints_of_all_individual_level_hsi_event, Counter())
             total_footprint = Counter()
             for footprint in footprints_of_all_individual_level_hsi_event:
-                total_footprint += footprint
+                # Counter.update method when called with dict-like argument adds counts
+                # from argument to Counter object called from
+                total_footprint.update(footprint)
 
             # 5) Estimate Squeeze-Factors for today
             if self.module.mode_appt_constraints == 0:


### PR DESCRIPTION
Profiling a 1 year run of `scale_run.py` shows that a significant amount of time is being spent in computing the total appointment footprint in the following lines

https://github.com/UCL/TLOmodel/blob/5f82456d86c851823ae894ebb71b7d5f01b66c8d/src/tlo/methods/healthsystem.py#L1399-L1404

Specifically the SnakeViz output for a 1 year `scale_run.py` run shows an overall breakdown

![image](https://user-images.githubusercontent.com/6746980/124131344-9cb4f380-da77-11eb-9927-41449337fb2b.png)

with the relevant time being the block in the light green block under the orange `healthsystem.py:1316(apply)` block, to the immediate right of the `healthsystem.py:1394(<listcomp>)` block. Concentrating specifically on this block:

![image](https://user-images.githubusercontent.com/6746980/124149971-01c51500-da89-11eb-9f77-15690506b3bc.png)

we see that 1470s (of the overall ~12000s) is being spent in the `__iadd__` method of `Counter` instances (i.e. the implementation of the `+=` operator) with the majority of this time being spent in the a `_keep_positive` method. From some searching I found [this thread on the Python bug tracker](https://bugs.python.org/issue36380) which explains that the `_keep_positive` calls are a necessary feature of `Counter` instances to maintain the property that '[Counter arithmetic] operation can accept inputs with signed counts, but the output will exclude results with counts of zero or less'. In our case as we know all the values in the footprints are non-negative this check is unnecessary. Fortunately the thread also suggests an easy work around of using the `Counter.update` method which does not perform these checks. 

This PR therefore changes the accumulation of the total footprint to instead use the [`Counter.update` method](https://docs.python.org/3/library/collections.html#collections.Counter.update). Using an update to the ['sparse summation' benchmark Gist](https://gist.github.com/matt-graham/af685c92cf8b8e0f5b00b7df287ea7f2) suggests using `update` to perform the summation give a substantial improvement over both using the in-built `sum` and the previous 'in-place' approach using `+=`:
```
        sum(Counter) times: min = 8.41s, max = 10.49s
sum_inplace(Counter) times: min = 2.52s, max = 3.81s
 sum_update(Counter) times: min = 0.03s, max = 0.05s
```
This is also reflected in the profiling results of a 12 month `scale_run.py` run after the changes made in this PR with the the SnakeViz output showing an overall breakdown

![image](https://user-images.githubusercontent.com/6746980/124160447-2c689b00-da94-11eb-960c-df65cc64e4f9.png)

with the time spend in summing the `Counters` now 428s compared to 1470s previously with the breakdown

![image](https://user-images.githubusercontent.com/6746980/124160401-207cd900-da94-11eb-9be3-8a989d966eee.png)
