### PR TITLE
Make HSI events close after one week by default

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -463,10 +463,9 @@ class HealthSystem(Module):
 
         # 2) Check that topen, tclose and priority are valid
 
-        # If there is no specified tclose time then set this to the later of (i) the day after the end of the
-        # simulation, (ii) the day after topen
+        # If there is no specified tclose time then set this to a week after topen
         if tclose is None:
-            tclose = max(self.sim.end_date + DateOffset(days=1), topen + DateOffset(days=1))
+            tclose = topen + DateOffset(days=7)
 
         # Check topen is not in the past
         assert topen >= self.sim.date


### PR DESCRIPTION
Based on a discussion with @tbhallett this PR changes the default `tclose` attribute for a `HSI_event` set in `HealthSystem.schedule_hsi_event` (i.e. if the `tclose` argument is left as `None`) from the current maximum of {one day after the simulation end-date, one day after `topen`} to one week after `topen`. The aim with this is to prevent the current behaviour of the daily HSI event queue growing unboundedly over time if the resource availability is such that events cannot be cleared at a rate greater than they are being scheduled. Currently many events do not specify `tclose` and so remain indefinitely in the queue until run.

An alternative to this global change would be to just specify `tclose` for the events causing most of the queue growth. This primarily seems to be the `HSI_GenericFirstApptAtFacilityLevel1` events scheduled in `healthseekingbehaviour` currently. The number of `HSI_Malaria_rdt`, `HSI_Hiv_TestAndRefer`, and `HSI_MalariaIPTp` events also appears to be growing but at a lower rate.  The number of most the other event types seem to stabilise after an initial transient. For example in a six month run of `scale_run.py` the number of events in the HSI event queue per day for the 10 event types with the most events at the end of the simulation is as follows

![image](https://user-images.githubusercontent.com/6746980/125322806-0f568680-e336-11eb-9d18-7b1d0ac0fec6.png)

and the same plot with a log-scale on the vertical axis

![image](https://user-images.githubusercontent.com/6746980/125322769-0665b500-e336-11eb-883c-8520473a7aab.png)
