### PR TITLE
Handle empty footprints in `get_squeeze_factors`

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -819,7 +819,8 @@ class HealthSystem(Module):
             (position in array matches that in the all_call_today list).
         """
 
-        # 1) Compute the load factors for each officer type at each facility that is called-upon in this list of HSIs
+        # 1) Compute the load factors for each officer type at each facility that is
+        # called-upon in this list of HSIs
         total_available = current_capabilities['Total_Minutes_Per_Day']
         load_factor = {}
         for officer, call in total_footprint.items():
@@ -831,10 +832,11 @@ class HealthSystem(Module):
             else:
                 load_factor[officer] = max(call / availability - 1, 0)
 
-        # 5) Convert these load-factors into an overall 'squeeze' signal for eachHSI, based on the highest load-factor
-        # of any officer required
+        # 5) Convert these load-factors into an overall 'squeeze' signal for each HSI,
+        # based on the highest load-factor of any officer required (or zero if event
+        # has an empty footprint)
         squeeze_factor_per_hsi_event = np.array([
-            max(load_factor[officer] for officer in footprint)
+            max((load_factor[officer] for officer in footprint), default=0)
             for footprint in footprints_per_event
         ])
 


### PR DESCRIPTION
Fixes #338.

Adds [`default=0`  kwarg to `max`](https://docs.python.org/3/library/functions.html#max) in list comprehension in `get_squeeze_factors` to prevent error when any of footprints in `footprints_per_event` is empty which results in the `max` being called on a zero-length iterable and so raising a `ValueError`. The `default=0` argument causes 0 to instead be returned by the `max` call in this case which is the correct squeeze factor value for an event with an empty footprint.