### PR TITLE
Use set instead of dataframe in check that HSI event footprint is possible

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -256,6 +256,13 @@ class HealthSystem(Module):
         caps = pd.read_csv(Path(self.resourcefilepath) / 'ResourceFile_Daily_Capabilities.csv')
         self.parameters['Daily_Capabilities'] = caps.iloc[:, 1:]
         self.reformat_daily_capabilities()  # Reformats this table to include zero where capacity is not available
+        # Store set of officers with non-zero daily availability for checking scheduled
+        # HSI events do not make appointment time requests of unavailable officers
+        self._officers_with_availability = set(
+            self.parameters['Daily_Capabilities'].index[
+                (self.parameters['Daily_Capabilities']['Total_Minutes_Per_Day'] > 0)
+            ]
+        )
 
         # Read in ResourceFile_Consumables and then process it to create the data structures needed
         # NB. Modules can use this to look-up what consumables they need.
@@ -511,15 +518,18 @@ class HealthSystem(Module):
                 f"An appointment type has been requested at a facility level for which "
                 f"it is not possible: {hsi_event.TREATMENT_ID}"
             )
-            # 6) Check that event (if individual level) is able to run with this configuration of officers
-            # (ie. Check that this does not demand officers that are never available at a particular facility)
-            caps = self.parameters['Daily_Capabilities']
+            # 6) Check that event (if individual level) is able to run with this
+            # configuration of officers (i.e. check that this does not demand officers
+            # that are never available at a particular facility)
             footprint = self.get_appt_footprint_as_time_request(hsi_event=hsi_event)
-            footprint_is_possible = (caps.loc[footprint, 'Total_Minutes_Per_Day'] > 0).all()
-            if not footprint_is_possible:
-                logger.warning(key="message",
-                               data=f"The expected footprint is not possible with the configuration of officers: "
-                                    f"{hsi_event.TREATMENT_ID}.")
+            if not self._officers_with_availability.issuperset(footprint.keys()):
+                logger.warning(
+                    key="message",
+                    data=(
+                        "The expected footprint is not possible with the configuration "
+                        f"of officers: {hsi_event.TREATMENT_ID}."
+                    )
+                )
 
         #  Manipulate the priority level if needed
         # If ignoring the priority in scheduling, then over-write the provided priority information


### PR DESCRIPTION
Resolves #335.

As explained in #335 the check in the following lines in `schedule_hsi_event`

https://github.com/UCL/TLOmodel/blob/754290e4ba869cb881106179dc54b911c460e3c7/src/tlo/methods/healthsystem.py#L514-L522

is a bottleneck in longer runs. This PR replaces the repeated `loc` accesses to the `Daily_Capabilities` dataframe in the current code, with a single to the `issuperset` method of a new set `self._officers_with_availability` (constructed when initialising the `HealthSystem` module instance), which contains the standardized officer code strings (`Facility_ID_{facility_id}_Officer_{officer_type_code}`) for all officers which the `Daily_Capabilities` dataframe indicates have non-zero daily availability.

The new `self._officers_with_availability` set is kept alongside the `Daily_Capabilities` dataframe in the `HealthSystem` parameters dictionary rather than for example refactoring the dataframe into a dictionary and using for both the check if a footprint is possible check and the other uses of `Daily_Capabilities`. While I had initially planned on refactoring in this manner I eventually decided against as 

  1. the grouping by `Facility_ID` of the `Daily_Capabilities` dataframe in the `log_current_capabilities` method would be less clean to implement (and potentially less performant) with a dictionary based format,
  2. using a dictionary to store the `Daily_Capabilities` data would complicate adding logic to dynamically update the officer availability in `get_capabilities_today` as it would no longer for example be possible to perform arithmetic operations on all the availabilities at once.

While there are therefore some remaining accesses to the `Daily_Capabilities` dataframe in `get_squeeze_factors` (and `log_current_capabilities`), profiling suggests these have negligible performance impact.

There are also a couple of changes made to clean up `log_current_capabilities` that are tangential to the main PR - specifically replacing a manual check if two floating point values are sufficient close with a call to the `numpy.isclose` method (on the basis that this is a bit easier to read) and caching the value of the summation of a series to avoid its repeated calculation.

I am currently profiling a 5 year run of `scale_run.py` with the changes in this PR to check it does actually remove the bottleneck - I will post the results once the run finishes.