### PR TITLE
Add method to schedule batch of HSI events

### DIFF
--- a/src/tlo/methods/healthseekingbehaviour.py
+++ b/src/tlo/methods/healthseekingbehaviour.py
@@ -270,11 +270,14 @@ class HealthSeekingBehaviourPoll(RegularEvent, PopulationScopeEventMixin):
                 emergency_care_seeking_subgroup = self._select_persons_with_any_symptoms(
                     subgroup, emergency_symptoms
                 )
-                for person_id in emergency_care_seeking_subgroup.index:
-                    hsi_event = emergency_hsi_event_class(module, person_id=person_id)
-                    health_system.schedule_hsi_event(
-                        hsi_event, priority=0, topen=self.sim.date, tclose=None
-                    )
+                health_system.schedule_batch_of_individual_hsi_events(
+                    hsi_event_class=emergency_hsi_event_class,
+                    person_ids=emergency_care_seeking_subgroup.index,
+                    priority=0,
+                    topen=self.sim.date,
+                    tclose=None,
+                    module=module
+                )
             # Check if no symptoms initiating (non-emergency) care seeking specified
             if len(care_seeking_symptoms) == 0:
                 continue
@@ -289,11 +292,14 @@ class HealthSeekingBehaviourPoll(RegularEvent, PopulationScopeEventMixin):
             if module.force_any_symptom_to_lead_to_healthcareseeking:
                 # This HSB module flag causes a generic non-emergency appointment to be
                 # scheduled for any symptom immediately
-                for person_id in possibly_care_seeking_subgroup.index:
-                    hsi_event = routine_hsi_event_class(module, person_id=person_id)
-                    health_system.schedule_hsi_event(
-                        hsi_event, priority=0, topen=self.sim.date, tclose=None
-                    )
+                health_system.schedule_batch_of_individual_hsi_events(
+                    hsi_event_class=routine_hsi_event_class,
+                    person_ids=possibly_care_seeking_subgroup.index,
+                    priority=0,
+                    topen=self.sim.date,
+                    tclose=None,
+                    module=module
+                )
             else:
                 # All in-patients with symptoms always generate a HSI event
                 care_seeking_inpatients = possibly_care_seeking_subgroup[
@@ -321,8 +327,11 @@ class HealthSeekingBehaviourPoll(RegularEvent, PopulationScopeEventMixin):
                         np.array(self.sim.date, dtype='datetime64[D]')
                         + module.rng.randint(0, max_delay, size=len(care_seeking_ids))
                     )
-                    for person_id, date in zip(care_seeking_ids, care_seeking_dates):
-                        hsi_event = routine_hsi_event_class(module, person_id=person_id)
-                        health_system.schedule_hsi_event(
-                            hsi_event, priority=0, topen=Date(date), tclose=None
-                        )
+                    health_system.schedule_batch_of_individual_hsi_events(
+                        hsi_event_class=routine_hsi_event_class,
+                        person_ids=care_seeking_ids,
+                        priority=0,
+                        topen=map(Date, care_seeking_dates),
+                        tclose=None,
+                        module=module
+                    )

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -10,8 +10,9 @@ Todo:   - speed up
 
 import heapq as hp
 from collections import Counter, defaultdict
+from itertools import repeat
 from pathlib import Path
-from typing import NamedTuple, Optional, Sequence, Tuple
+from typing import Iterable, NamedTuple, Optional, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
@@ -450,25 +451,34 @@ class HealthSystem(Module):
         """
         raise NotImplementedError
 
-    def schedule_hsi_event(self, hsi_event, priority, topen, tclose=None):
+    def schedule_hsi_event(
+        self, hsi_event, priority, topen, tclose=None, do_hsi_event_checks=True
+    ):
         """
-        Schedule the health system interaction event
+        Schedule a health system interaction (HSI) event.
 
-        :param hsi_event: the hsi_event to be scheduled
-        :param priority: the priority for the hsi event (0 (highest), 1 or 2 (lowest)
-        :param topen: the earliest date at which the hsi event should run
-        :param tclose: the latest date at which the hsi event should run
+        :param hsi_event: The HSI event to be scheduled.
+        :param priority: The priority for the HSI event (0 (highest), 1 or 2 (lowest)
+        :param topen: The earliest date at which the HSI event should run
+        :param tclose: The latest date at which the HSI event should run. Set to one
+           week after ``topen`` if ``None``.
+        :param do_hsi_event_checks: Whether to perform sanity checks on the passed
+            ``hsi_event`` argument to check that it constitutes a valid HSI event. This
+            is intended for allowing disabling of these checks when scheduling multiple
+            HSI events of the same ``HSI_Event`` subclass together, in which case
+            typically performing these checks for each individual HSI event of the
+            shared type will be redundant.
         """
 
         logger.debug(
             key='message',
-            data=f"HealthSystem.schedule_event >> "
-                 f"Logging a request for an HSI: {hsi_event.TREATMENT_ID} for person: {hsi_event.target}"
+            data=(
+                "HealthSystem.schedule_event >> Logging a request for an HSI: "
+                f"{hsi_event.TREATMENT_ID} for person: {hsi_event.target}"
+            )
         )
 
-        assert isinstance(hsi_event, HSI_Event)
-
-        # 0) Check if healthsystem is disabled
+        # Check if healthsystem is disabled
         if self.disable and (not self.disable_and_reject_all):
             # If healthsystem is disabled (but HSI can still run), ...
             #   ... put this event straight into the normal simulation scheduler.
@@ -479,44 +489,6 @@ class HealthSystem(Module):
             # If healthsystem is disabled and HSI should not run, do nothing.
             return
 
-        # 1) Check that this is a legitimate health system interaction (HSI) event
-
-        if isinstance(hsi_event.target, tlo.population.Population):  # check if hsi_event is population-scoped
-            # This is a population-scoped HSI event...
-            # ... So it only needs TREATMENT_ID (the other items are ignored)
-            assert hsi_event.TREATMENT_ID != ''
-
-        else:
-            # This is an individual-scoped HSI event.
-            # It must have EXPECTED_APPT_FOOTPRINT, BEDDAYS_FOOTPRINT, ACCEPTED_FACILITY_LEVELS and
-            # ALERT_OTHER_DISEASES defined
-
-            # Correctly formatted footprint
-            assert hsi_event.TREATMENT_ID != ''
-
-            # Correct formated EXPECTED_APPT_FOOTPRINT
-            assert self.appt_footprint_is_valid(hsi_event.EXPECTED_APPT_FOOTPRINT)
-
-            # That it has an 'ACCEPTED_FACILITY_LEVEL' attribute
-            # (Integer specificying the facility level at which HSI_Event must occur)
-            assert isinstance(hsi_event.ACCEPTED_FACILITY_LEVEL, int)
-            assert hsi_event.ACCEPTED_FACILITY_LEVEL in self._facility_levels
-
-            self.check_beddays_footrpint_format(hsi_event.BEDDAYS_FOOTPRINT)
-
-            # That it has a list for the other disease that will be alerted when it is run and that this make sense
-            assert isinstance(hsi_event.ALERT_OTHER_DISEASES, Sequence)
-
-            if len(hsi_event.ALERT_OTHER_DISEASES) > 0:
-                if not (hsi_event.ALERT_OTHER_DISEASES[0] == '*'):
-                    for d in hsi_event.ALERT_OTHER_DISEASES:
-                        assert d in self.recognised_modules_names
-
-            # Check that this can accept the squeeze argument
-            assert _accepts_argument(hsi_event.run, 'squeeze_factor')
-
-        # 2) Check that topen, tclose and priority are valid
-
         # If there is no specified tclose time then set this to a week after topen
         if tclose is None:
             tclose = topen + DateOffset(days=7)
@@ -524,13 +496,86 @@ class HealthSystem(Module):
         # Check topen is not in the past
         assert topen >= self.sim.date
 
-        # Check that topen is before tclose are not the same date
-        assert topen < tclose
-
-        # Check that priority is either 0, 1 or 2
+        # Check that priority is in valid range
         assert priority in {0, 1, 2}
 
-        # 3) Check that this request is allowable under current policy (i.e. included in service_availability)
+        # Check that topen is strictly before tclose
+        assert topen < tclose
+
+        # Check that this is a legitimate health system interaction (HSI) event
+        # These checks are only performed when the flag `do_hsi_event_checks` is set
+        # to ``True`` to allow disabling when the checks are redundant for example when
+        # scheduling multiple HSI events of same `HSI_Event` subclass
+        if do_hsi_event_checks:
+
+            assert isinstance(hsi_event, HSI_Event)
+
+            # Check that non-empty treatment ID specified (required for both population
+            # and individual scoped events)
+            assert hsi_event.TREATMENT_ID != ''
+
+            if not isinstance(hsi_event.target, tlo.population.Population):
+                # This is an individual-scoped HSI event.
+                # It must have EXPECTED_APPT_FOOTPRINT, BEDDAYS_FOOTPRINT,
+                # ACCEPTED_FACILITY_LEVELS and ALERT_OTHER_DISEASES defined
+
+                # Correct formated EXPECTED_APPT_FOOTPRINT
+                assert self.appt_footprint_is_valid(hsi_event.EXPECTED_APPT_FOOTPRINT)
+
+                # That it has an 'ACCEPTED_FACILITY_LEVEL' attribute
+                # (Integer specificying the facility level at which HSI_Event must occur)
+                assert isinstance(hsi_event.ACCEPTED_FACILITY_LEVEL, int)
+                assert hsi_event.ACCEPTED_FACILITY_LEVEL in self._facility_levels
+
+                self.check_beddays_footrpint_format(hsi_event.BEDDAYS_FOOTPRINT)
+
+                # That it has a list for the other disease that will be alerted when it
+                # is run and that this make sense
+                assert isinstance(hsi_event.ALERT_OTHER_DISEASES, Sequence)
+
+                if len(hsi_event.ALERT_OTHER_DISEASES) > 0:
+                    if not (hsi_event.ALERT_OTHER_DISEASES[0] == '*'):
+                        for d in hsi_event.ALERT_OTHER_DISEASES:
+                            assert d in self.recognised_modules_names
+
+                # Check that this can accept the squeeze argument
+                assert _accepts_argument(hsi_event.run, 'squeeze_factor')
+
+                # Check that at least one type of appointment is required
+                assert len(hsi_event.EXPECTED_APPT_FOOTPRINT) > 0, (
+                    'No appointment types required in the EXPECTED_APPT_FOOTPRINT'
+                )
+                # Check that the event does not request an appointment at a facility
+                # level which is not possible
+                appt_type_to_check_list = hsi_event.EXPECTED_APPT_FOOTPRINT.keys()
+                facility_appt_types = self.parameters['ApptType_By_FacLevel'][
+                    hsi_event.ACCEPTED_FACILITY_LEVEL
+                ]
+                assert facility_appt_types.issuperset(appt_type_to_check_list), (
+                    f"An appointment type has been requested at a facility level for "
+                    f"which it is not possible: {hsi_event.TREATMENT_ID}"
+                )
+
+        # Check that event (if individual level) is able to run with this configuration
+        # of officers (i.e. check that this does not demand officers that are never
+        # available at a particular facility). This is run irrespective of the value of
+        # _do_hsi_event_checks as the appointment footprint time request depends on the
+        # district of residence of the HSI event's target and so the time requests can
+        # differ for each instance of an HSI_Event subclass even when their other
+        # attributes are shared
+        if not isinstance(hsi_event.target, tlo.population.Population):
+            footprint = self.get_appt_footprint_as_time_request(hsi_event=hsi_event)
+            if not self._officers_with_availability.issuperset(footprint.keys()):
+                logger.warning(
+                    key="message",
+                    data=(
+                        "The expected footprint is not possible with the configuration "
+                        f"of officers: {hsi_event.TREATMENT_ID}."
+                    )
+                )
+
+        # Check that this request is allowable under current policy (i.e. included in
+        # service_availability)
         allowed = False
         if not self.service_availability:  # it's an empty list
             allowed = False
@@ -550,33 +595,6 @@ class HealthSystem(Module):
                     if hsi_event.TREATMENT_ID.startswith(stub):
                         allowed = True
                         break
-
-        # Further checks for HSI which are not population level events:
-        if not isinstance(hsi_event.target, tlo.population.Population):
-
-            # 4) Check that at least one type of appointment is required
-            assert len(hsi_event.EXPECTED_APPT_FOOTPRINT) > 0, (
-                'No appointment types required in the EXPECTED_APPT_FOOTPRINT'
-            )
-            # 5) Check that the event does not request an appointment at a facility level which is not possible
-            appt_type_to_check_list = hsi_event.EXPECTED_APPT_FOOTPRINT.keys()
-            facility_appt_types = self.parameters['ApptType_By_FacLevel'][hsi_event.ACCEPTED_FACILITY_LEVEL]
-            assert facility_appt_types.issuperset(appt_type_to_check_list), (
-                f"An appointment type has been requested at a facility level for which "
-                f"it is not possible: {hsi_event.TREATMENT_ID}"
-            )
-            # 6) Check that event (if individual level) is able to run with this
-            # configuration of officers (i.e. check that this does not demand officers
-            # that are never available at a particular facility)
-            footprint = self.get_appt_footprint_as_time_request(hsi_event=hsi_event)
-            if not self._officers_with_availability.issuperset(footprint.keys()):
-                logger.warning(
-                    key="message",
-                    data=(
-                        "The expected footprint is not possible with the configuration "
-                        f"of officers: {hsi_event.TREATMENT_ID}."
-                    )
-                )
 
         #  Manipulate the priority level if needed
         # If ignoring the priority in scheduling, then over-write the provided priority information
@@ -623,6 +641,45 @@ class HealthSystem(Module):
                 key="message",
                 data=f"A request was made for a service but it was not included in the service_availability list:"
                      f" {hsi_event.TREATMENT_ID}"
+            )
+
+    def schedule_batch_of_individual_hsi_events(
+        self, hsi_event_class, person_ids, priority, topen, tclose=None, **event_kwargs
+    ):
+        """Schedule a batch of individual-scoped HSI events of the same type.
+
+        Only performs sanity checks on the HSI event for the first scheduled event
+        thus removing the overhead of multiple redundant checks.
+
+        :param hsi_event_class: The ``HSI_Event`` subclass of the events to schedule.
+        :param person_ids: A sequence of person ID index values to use as the targets
+            of the HSI events being scheduled.
+        :param priority: The priority for the HSI events: 0 (highest), 1 or 2 (lowest).
+            Either a single value for all events or an iterable of per-target values.
+        :param topen: The earliest date at which the HSI events should run. Either a
+            single value for all events or an iterable of per-target values.
+        :param tclose: The latest date at which the HSI events should run. Set to one
+           week after ``topen`` if ``None``. Either a single value for all events or an
+           iterable of per-target values.
+        :param event_kwargs: Any additional keyword arguments to pass to the
+            ``hsi_event_class`` initialiser in addition to ``person_id``.
+        """
+        # If any of {priority, topen, tclose} are iterable assume correspond to per-
+        # target values for corresponding arguments of schedule_hsi_event otherwise
+        # use same value for all calls
+        priorities = priority if isinstance(priority, Iterable) else repeat(priority)
+        topens = topen if isinstance(topen, Iterable) else repeat(topen)
+        tcloses = tclose if isinstance(tclose, Iterable) else repeat(tclose)
+        for i, (person_id, priority, topen, tclose) in enumerate(
+            zip(person_ids, priorities, topens, tcloses)
+        ):
+            self.schedule_hsi_event(
+                hsi_event=hsi_event_class(person_id=person_id, **event_kwargs),
+                priority=priority,
+                topen=topen,
+                tclose=tclose,
+                # Only perform checks for first event
+                do_hsi_event_checks=(i == 0)
             )
 
     def appt_footprint_is_valid(self, appt_footprint):


### PR DESCRIPTION
Follow on from #346.

Adds a method `schedule_batch_of_individual_hsi_events` to `HealthSystem` which schedules a batch of individually-scoped HSI events of a common `HSI_Event` subclass. As the sanity checks on the attributes of the HSI event in `schedule_hsi_event` are largely redundant between different instances of the same event class, the `schedule_batch_of_individual_hsi_events` method only performs the checks for the first event schedule in the batch. This is enabled by adding a `do_hsi_event_checks` boolean flag to `schedule_hsi_event` which defaults to `True` but if set to `False` skips the redundant checks on the passed HSI event.

As well as adding the `do_hsi_event_checks` flag, this PR also makes some small optimizations to the `schedule_hsi_event` implementation. The checks that named attributes of the HSI event are in the list returned by `dir(hsi_event)` are removed as profiling suggested the repeated calls to `dir` where relatively costly. Although the checks could have been replaced by either instead calling `dir` once and reusing the output or using `hasattr`, as default values of the named attributes are set in the `HSI_Event` base class the checks that the attributes are present are not necessary as there is a separate check that the event is an instance of `HSI_Event` and the attributes should therefore always be present unless they have been specifically deleted in a subclass or the implementatino of `HSI_Event` is changed. Further the use of the attributes in other assert statements means that an `AttributeError` exception will be raised if the attributes are missing.

The check that the event appointment time request footprint is possible with configuration of available officers is still run irrespective of the value of `do_hsi_event_checks` as the outcome of this check depends on the specific target of the event so will differ between different events of the same type.

As an additional readability improvement, the tuples added to the HSI event queue have been changed to typed named tuple instances (a new `HSIEventQueueItem` class derived from `NamedTuple` has been added). This still allows the attribute order based prioritisation in the `heapq` queue used to prioritise the events, but means that the relevant properties in the tuple can be accessed by name rather than integer index in `HealthSystemScheduler.apply`.

A SnakeViz visualisation of the overall breakdown of the time spent in a 5 year / 20k population profiling run of `scale_run.py` before the changes in this PR (a691b72) is as follows

![image](https://user-images.githubusercontent.com/6746980/130928586-2827b77d-cb56-4393-a921-66020f7b3052.png)

and concentrating specifically on time spent in `schedule_hsi_event`:

![image](https://user-images.githubusercontent.com/6746980/130928746-c91893df-0424-4d07-b77f-f954a0ee93c3.png)

Similarly the overall breakdown for an equivalent profiling run after changes in this PR (4c51802) is

![image](https://user-images.githubusercontent.com/6746980/130928448-0f1c850c-bb0b-4fb3-8c6d-71b210201671.png)

and concentrating specifically on time spent in `schedule_hsi_event`:

![image](https://user-images.githubusercontent.com/6746980/130928697-4511a89e-aaab-4c84-b4c3-9a2421853559.png)

After the changes in this PR the overall run time is 89% of previously, and the time spent in `schedule_hsi_event` specifically is 49% of previously.
 

