### PR TITLE
Logging entropy and spawn key of per-module RNGs

### DIFF
--- a/src/tlo/simulation.py
+++ b/src/tlo/simulation.py
@@ -74,7 +74,10 @@ class Simulation:
         seed_from = 'auto' if seed is None else 'user'
         self._seed = seed
         self._seed_seq = np.random.SeedSequence(seed)
-        logger.info(key='info', data=f'Simulation RNG {seed_from} seed: {self._seed}')
+        logger.info(
+            key='info',
+            data=f'Simulation RNG {seed_from} entropy = {self._seed_seq.entropy}'
+        )
         self.rng = np.random.RandomState(np.random.MT19937(self._seed_seq))
 
     def configure_logging(self, filename: str = None, directory: Union[Path, str] = "./outputs",
@@ -152,7 +155,11 @@ class Simulation:
 
             # Seed the RNG for the registered module using spawned seed sequence
             logger.info(
-                key='info', data=f'{module.name} RNG auto seed: {seed_seq.entropy}'
+                key='info',
+                data=(
+                    f'{module.name} RNG auto (entropy, spawn key) = '
+                    f'({seed_seq.entropy}, {seed_seq.spawn_key[0]})'
+                )
             )
             module.rng = np.random.RandomState(np.random.MT19937(seed_seq))
 


### PR DESCRIPTION
Fixes #360.

Changes log output when constructing per-module random number generators (RNGs) to tuple of entropy from base [`SeedSequence`](https://numpy.org/doc/stable/reference/random/bit_generators/generated/numpy.random.SeedSequence.html) object used to spawn child `SeedSequence` instance for each module, and `spawn_key` attribute of child `SeedSequence` instance, with these two properties together uniquely identifying the initial RNG state.