### PR TITLE
Avoid repeated dataframe accesses in `HealthSystemScheduler`

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -1259,6 +1259,17 @@ class HealthSystemScheduler(RegularEvent, PopulationScopeEventMixin):
         list_of_individual_hsi_event_tuples_due_today = list()
         list_of_population_hsi_event_tuples_due_today = list()
 
+        # To avoid repeated dataframe accesses in subsequent loop, assemble set of alive
+        # person IDs as  one-off operation, exploiting the improved efficiency of
+        # boolean-indexing of a Series compared to row-by-row access. From benchmarks
+        # converting Series to list before converting to set is ~2x more performant than
+        # direct conversion to set, while checking membership of set is ~10x quicker
+        # than checking membership of Pandas Index object and ~25x quicker than checking
+        # membership of list
+        alive_persons = set(
+            self.sim.population.props.index[self.sim.population.props.is_alive].to_list()
+        )
+
         while len(self.module.HSI_EVENT_QUEUE) > 0:
 
             next_event_tuple = hp.heappop(self.module.HSI_EVENT_QUEUE)
@@ -1270,8 +1281,10 @@ class HealthSystemScheduler(RegularEvent, PopulationScopeEventMixin):
                 # The event has expired (after tclose) having never been run. Call the 'never_ran' function
                 event.never_ran()
 
-            elif (type(event.target) is not tlo.population.Population) \
-                    and (not self.sim.population.props.at[event.target, 'is_alive']):
+            elif not (
+                type(event.target) is tlo.population.Population
+                or event.target in alive_persons
+            ):
                 # if individual level event and the person who is the target is no longer alive, do nothing more
                 pass
 


### PR DESCRIPTION
Small performance improvement to `HealthSystemScheduler.apply`. The only direct access to the population dataframe within the method currently is in the lines

https://github.com/UCL/TLOmodel/blob/ebc5d302189155f708dfebf5313551b8cd720e54/src/tlo/methods/healthsystem.py#L1303-L1306

which checks if the target of each individually scoped HSI event is currently alive.

A 5 year / 50k population profiling run of `scale_run.py` gives the following overall Snakeviz breakdown

![image](https://user-images.githubusercontent.com/6746980/133443950-170fda71-62bd-495e-befb-78c4badd86de.png)

and concentrating specifically on the time spent in `HealthSystemScheduler.apply`

![image](https://user-images.githubusercontent.com/6746980/133444038-0f316e89-2033-436a-8288-5dea54e6c221.png)

A considerable chunk of the time spent in  `HealthSystemScheduler.apply` is in Pandas `__getitem__` calls which correspond to the lines checking whether the event target is alive.

The change made in this PR is simply to replace the repeated population dataframe accesses to check if individuals are alive within a loop, to a single 'vectorised' dataframe access which constructs a set of the person IDs of all individuals who are currently alive and then use this in place of the dataframe accesses within the loop. As there are high fixed (with respect to number of rows) costs to each dataframe access, this approach amortizes these overheads. From some quick benchmarks testing membership of an individual in a set of person IDs is around 10x quicker compared to testing membership within a Pandas index object of the same set of IDs, so as there are potentially a high number of such tests within in the loop, the conversion from an index to a Python set is worthwhile. As no events actually run within this loop there should be no danger of the set of alive persons becoming out of date as the population dataframe is not updated within the loop.

After the changes in this PR a corresponding 5 year / 50k population profiling run of `scale_run.py` gives the following overall Snakeviz breakdown

![image](https://user-images.githubusercontent.com/6746980/133404873-5cdd1465-fa0e-4442-9d40-0106eb275070.png)

and concentrating specifically on the time spent in `HealthSystemScheduler.apply`

![image](https://user-images.githubusercontent.com/6746980/133404936-b788afc2-61b3-4024-b82c-54a171676af7.png)

The time spent in the dataframe access within `HealthSystemScheduler.apply` is no longer visible and the overall run time has been reduced to about 92% of previously. 

