### PR TITLE
Account for optional dependencies when sorting modules

### DIFF
--- a/src/tlo/core.py
+++ b/src/tlo/core.py
@@ -188,6 +188,11 @@ class Module:
     # this module
     INIT_DEPENDENCIES = frozenset()
 
+    # Subclasses can override this to declare the set of optional init. dependencies
+    # Declares modules that need to be registered in simulation and initialised before
+    # this module if they are present, but are not required otherwise
+    OPTIONAL_INIT_DEPENDENCIES = frozenset()
+
     # Subclasses can override this to declare the set of additional dependencies
     # Declares any modules that need to be registered in simulation in addition to those
     # in INIT_DEPENDENCIES to allow running simulation

--- a/src/tlo/methods/alri.py
+++ b/src/tlo/methods/alri.py
@@ -89,6 +89,8 @@ class Alri(Module):
         'PropertiesOfOtherModules'
     }
 
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     # Declare Metadata
     METADATA = {
         Metadata.DISEASE_MODULE,

--- a/src/tlo/methods/bladder_cancer.py
+++ b/src/tlo/methods/bladder_cancer.py
@@ -37,6 +37,8 @@ class BladderCancer(Module):
 
     INIT_DEPENDENCIES = {'Demography', 'Lifestyle', 'HealthSystem', 'SymptomManager'}
 
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     METADATA = {
         Metadata.DISEASE_MODULE,
         Metadata.USES_SYMPTOMMANAGER,

--- a/src/tlo/methods/breast_cancer.py
+++ b/src/tlo/methods/breast_cancer.py
@@ -35,6 +35,8 @@ class BreastCancer(Module):
 
     INIT_DEPENDENCIES = {'Demography', 'HealthSystem', 'SymptomManager'}
 
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     METADATA = {
         Metadata.DISEASE_MODULE,
         Metadata.USES_SYMPTOMMANAGER,

--- a/src/tlo/methods/cardio_metabolic_disorders.py
+++ b/src/tlo/methods/cardio_metabolic_disorders.py
@@ -47,6 +47,9 @@ class CardioMetabolicDisorders(Module):
               'ever_heart_attack']
 
     INIT_DEPENDENCIES = {'Demography', 'Lifestyle', 'HealthSystem', 'SymptomManager'}
+
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     ADDITIONAL_DEPENDENCIES = {'Depression'}
 
     # Declare Metadata (this is for a typical 'Disease Module')

--- a/src/tlo/methods/chronicsyndrome.py
+++ b/src/tlo/methods/chronicsyndrome.py
@@ -35,6 +35,10 @@ class ChronicSyndrome(Module):
     # this module
     INIT_DEPENDENCIES = {'Demography', 'HealthSystem', 'SymptomManager'}
 
+    # Declare optional modules that need to be registered in simulation and initialised
+    # before this module if present
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     # Declare Metadata
     METADATA = {
         Metadata.DISEASE_MODULE,

--- a/src/tlo/methods/depression.py
+++ b/src/tlo/methods/depression.py
@@ -32,6 +32,8 @@ class Depression(Module):
         'Demography', 'Contraception', 'HealthSystem', 'Lifestyle', 'SymptomManager'
     }
 
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     # Declare Metadata
     METADATA = {
         Metadata.DISEASE_MODULE,

--- a/src/tlo/methods/diarrhoea.py
+++ b/src/tlo/methods/diarrhoea.py
@@ -58,6 +58,8 @@ class Diarrhoea(Module):
 
     INIT_DEPENDENCIES = {'Demography', 'Lifestyle', 'HealthSystem', 'SymptomManager'}
 
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     # Declare Metadata
     METADATA = {
         Metadata.DISEASE_MODULE,

--- a/src/tlo/methods/hiv.py
+++ b/src/tlo/methods/hiv.py
@@ -62,6 +62,9 @@ class Hiv(Module):
         self.footprints_for_consumables_required = dict()
 
     INIT_DEPENDENCIES = {'Demography', 'HealthSystem', 'Lifestyle', 'SymptomManager'}
+
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     ADDITIONAL_DEPENDENCIES = {'NewbornOutcomes'}
 
     METADATA = {

--- a/src/tlo/methods/malaria.py
+++ b/src/tlo/methods/malaria.py
@@ -38,6 +38,8 @@ class Malaria(Module):
         'Contraception', 'Demography', 'HealthSystem', 'SymptomManager'
     }
 
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     METADATA = {
         Metadata.DISEASE_MODULE,
         Metadata.USES_HEALTHSYSTEM,

--- a/src/tlo/methods/measles.py
+++ b/src/tlo/methods/measles.py
@@ -38,6 +38,8 @@ class Measles(Module):
 
     INIT_DEPENDENCIES = {'Demography', 'HealthSystem', 'SymptomManager'}
 
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     # declare metadata
     METADATA = {
         Metadata.DISEASE_MODULE,

--- a/src/tlo/methods/mockitis.py
+++ b/src/tlo/methods/mockitis.py
@@ -28,6 +28,8 @@ class Mockitis(Module):
 
     INIT_DEPENDENCIES = {'Demography', 'SymptomManager'}
 
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     # Declare Metadata
     METADATA = {
         Metadata.DISEASE_MODULE,

--- a/src/tlo/methods/newborn_outcomes.py
+++ b/src/tlo/methods/newborn_outcomes.py
@@ -46,6 +46,8 @@ class NewbornOutcomes(Module):
 
     INIT_DEPENDENCIES = {'Demography', 'HealthSystem', 'SymptomManager'}
 
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     ADDITIONAL_DEPENDENCIES = {
         'CareOfWomenDuringPregnancy',
         'Labour',

--- a/src/tlo/methods/oesophagealcancer.py
+++ b/src/tlo/methods/oesophagealcancer.py
@@ -37,6 +37,8 @@ class OesophagealCancer(Module):
 
     INIT_DEPENDENCIES = {'Demography', 'HealthSystem', 'Lifestyle', 'SymptomManager'}
 
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     # Declare Metadata
     METADATA = {
         Metadata.DISEASE_MODULE,

--- a/src/tlo/methods/other_adult_cancers.py
+++ b/src/tlo/methods/other_adult_cancers.py
@@ -35,6 +35,8 @@ class OtherAdultCancer(Module):
 
     INIT_DEPENDENCIES = {'Demography', 'HealthSystem', 'SymptomManager'}
 
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     METADATA = {
         Metadata.DISEASE_MODULE,
         Metadata.USES_SYMPTOMMANAGER,

--- a/src/tlo/methods/pregnancy_supervisor.py
+++ b/src/tlo/methods/pregnancy_supervisor.py
@@ -41,6 +41,9 @@ class PregnancySupervisor(Module):
         self.abortion_complication = None
 
     INIT_DEPENDENCIES = {'Demography'}
+
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     ADDITIONAL_DEPENDENCIES = {
         'CareOfWomenDuringPregnancy', 'Contraception', 'HealthSystem', 'Lifestyle'
     }

--- a/src/tlo/methods/prostate_cancer.py
+++ b/src/tlo/methods/prostate_cancer.py
@@ -36,6 +36,8 @@ class ProstateCancer(Module):
 
     INIT_DEPENDENCIES = {'Demography', 'HealthSystem', 'SymptomManager'}
 
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     METADATA = {
         Metadata.DISEASE_MODULE,
         Metadata.USES_SYMPTOMMANAGER,

--- a/src/tlo/methods/skeleton.py
+++ b/src/tlo/methods/skeleton.py
@@ -38,6 +38,10 @@ class Skeleton(Module):
     # this module
     INIT_DEPENDENCIES = {'Demography'}
 
+    # Declares optiona;l modules that need to be registered in simulation and
+    # initialised before this module if present
+    OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
+
     # Declares any modules that need to be registered in simulation in addition to those
     # in INIT_DEPENDENCIES to allow running simulation
     ADDITIONAL_DEPENDENCIES = {'HealthSystem'}

--- a/tests/test_module_dependencies.py
+++ b/tests/test_module_dependencies.py
@@ -9,6 +9,7 @@ from tlo import Date, Module, Simulation
 from tlo.dependencies import (
     ModuleDependencyError,
     get_all_dependencies,
+    get_all_required_dependencies,
     get_dependencies_and_initialise,
     get_module_class_map,
 )
@@ -203,7 +204,7 @@ def test_module_dependencies_complete(sim, module_class):
         if module.__name__ not in {
             'DxAlgorithmAdult', 'DxAlgorithmChild', 'NewbornOutcomes'
         }
-        for dependency_name in get_all_dependencies(module)
+        for dependency_name in get_all_required_dependencies(module)
     ],
     ids=lambda pair: f"{pair[0].__name__}, {pair[1].__name__}"
 )


### PR DESCRIPTION
Fixes #368.

Adds an additional `OPTIONAL_INIT_DEPENDENCIES` class attribute to `Module` subclasses (defaulting to an empty `frozenset`), which contains the set of any optional dependencies that are required to be initialised before the module if they are present in the modules being registered (but should not raise an error if not present otherwise). The `HealthBurden` module specifically falls into this category for many disease modules. The logic of the dependency sorting / getting in `src/tlo/dependencies.py` is also updated to take in to account the optional dependencies and the `OPTIONAL_INIT_DEPENDENCIES` attribute defined to include `HealthBurden` for all modules for which there does seem to be such a dependency.