### PR TITLE
Replace EOL'd Ubuntu VM image with latest with LTS

### DIFF
--- a/src/tlo/cli.py
+++ b/src/tlo/cli.py
@@ -590,6 +590,10 @@ def create_job(batch_service_client, vm_size, pool_node_count, job_id,
     """
     print("Creating job.")
 
+    # From https://docs.microsoft.com/en-us/azure/batch/batch-docker-container-workloads#linux-support
+    # We require Ubuntu image with container support (publisher microsoft-azure-batch; offer microsoft-azure-batch)
+    # Get the latest SKU by inspecting output of `az batch pool supported-images list` for publisher+offer
+    # Update node_agent_sku_id (below), if necessary
     image_reference = batch_models.ImageReference(
         publisher="microsoft-azure-batch",
         offer="ubuntu-server-container",


### PR DESCRIPTION
We were using Ubuntu 16.04 for image VM to run TLO containers on Azure Batch. These have now been removed from the marketplace, and this PR replaces it with latest Ubuntu with long-term-support, 20.04.

Sadly, the Azure Batch documentation has not been updated so _don't_ check supported images in that list (or example source code). Use `az batch pool supported-images list` and get latest `ubuntu-server-container` offer from MS.