### PR TITLE
Updates to module dependencies tests

### DIFF
--- a/tests/test_module_dependencies.py
+++ b/tests/test_module_dependencies.py
@@ -195,7 +195,7 @@ def test_module_dependencies_allow_initialisation(sim, module_class):
         )
     except Exception:
         pytest.fail(
-            f"Module {module_class.__name__} appears to having missing dependency "
+            f'Module {module_class.__name__} appears to be missing dependency '
             f"declarations required to run initialise_population and "
             f"initialise_simulation. The INIT_DEPENDENCIES class attribute should "
             f"specify any modules needing to be initialised before this module "


### PR DESCRIPTION
Following conversation with @joehcollins on Slack with regards to tests in `tests/test_module_dependencies.py` failing after the updates in #443, I realised that a couple of the current module dependency tests were making incorrect checks.

Specifically `test_module_init_dependencies_complete` checks that a simulation can be initialised (`Simulation.make_initial_population` called and `Module.initialise_simulation` called for each module in `Simulation.modules`) without any errors being raised by registering a set of modules corresponding to the initialisation dependencies of each of the defined `Module` subclasses, where initialisation dependencies here means the modules in the `INIT_DEPENDENCIES` set of the seed `Module` subclass, and the dependencies in each of their `INIT_DEPENDENCIES` sets and so on. This implied that the dependencies (recursively) specified in the `INIT_DEPENDENCIES` class attribute of a `Module` subclass should be sufficient to initialise the simulation, however in reality `INIT_DEPENDENCIES` is only required to specify the modules which must have their initialisation methods (`pre_initialise_population`, `initialise_population`, `initialise_simulation`) called before the relevant module but other modules required to be registered for initialisation to complete successfully (but for which the ordering does not matter) should be included in the `ADDITIONAL_DEPENDENCIES` class attribute. This is important as it allows modules which mutually depend on each other being registered to allow successful initialisation to declare these dependencies without creating circular dependencies in the directed dependency graph represented by `INIT_DEPENDENCIES` (which would prevent being able to topologically sort the modules to find a valid initialisation order).

This PR therefore updates  `test_module_init_dependencies_complete` to instead test that the union of the dependencies (recursively) specified by `INIT_DEPENDENCIES` and `ADDITIONAL_DEPENDENCIES` are sufficient to allow successful initialisation of each `Module` subclass without any error being raised, with the test also renamed to `test_module_dependencies_allow_initialisation` to reflect this change. 

The previous `test_module_init_dependencies_all_required` test which checked (for each `Module` subclass) that removing any of the dependencies declared in `INIT_DEPENDENCIES` resulted in an error being raised (with the intention of picking up any modules unnecessarily included in the `INIT_DEPENDENCIES` class attribute) has also been removed. This test  was problematic as in some cases removing a dependency from `INIT_DEPENDENCIES` might not result in a error being raised but still result in invalid behaviour - for instance most modules use the values in the `is_alive` column of the population dataframe which is defined as a property in the `Demography` module in their `initialise_population` methods. As long as the `Demography` module is registered this property and so the corresponding column in the population dataframe will exist, however all rows will have the default value of `False` until the `Demography.initialise_population` method is called. This means that if `Demography` is not specified in the `INIT_DEPENDENCIES` of another module which uses the `is_alive` values in its `initialise_population` call, and so `Demography.initialise_population` is not guaranteed to have been called before the relevant module's `initialise_population` call, then the `initialise_population` call is likely to complete without error but having used the invalid default `False` values for the `is_alive` column.

As I noticed there was no explicit tests for the `topological_sort_modules` and `get_dependencies_and_initialise` helper functions defined in the `tlo.dependencies` module I have also added a couple of basic sanity checks to ensure these give the expected results when operating on modules with a simple chain like dependency structure. I also added tests to check that the module names declared in the `OPTIONAL_INIT_DEPENDENCIES` class attribute and module names that a module can be an alternative to in the `ALTERNATIVE_TO` class attribute all correspond to `Module` subclasses that exist.