### PR TITLE
`optional_item_codes` in HSI_EVENT.get_consumables

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -1541,7 +1541,7 @@ class HSI_Event:
 
         # Return result in expected format:
         if not return_individual_results:
-            # Determine if all results for all the `item_codes` are True (discarding results from optional_item_codes).  # todo - logic here
+            # Determine if all results for all the `item_codes` are True (discarding results from optional_item_codes).
             return all([v for k, v in rtn.items() if k in _item_codes])
         else:
             return rtn


### PR DESCRIPTION
Cherry-picked change to expeidate Joe's work that brings in the argument `opitional_item_code`. 

Usage is explained on wiki: https://github.com/UCL/TLOmodel/wiki/Using-Consumables#2-make-the-request

Test and further refactoring will come in on: https://github.com/UCL/TLOmodel/pull/405