### PR TITLE
Add workflow to run scaled simulation on PR comment

### DIFF
--- a/.github/workflows/pull-request-comment-ci.yml
+++ b/.github/workflows/pull-request-comment-ci.yml
@@ -1,0 +1,16 @@
+name: Run extra tests on pull-request comments
+
+on:
+  issue_comment:
+    types:
+      - created
+      
+jobs:
+
+  scaled_sim:
+    uses: ./.github/workflows/run-on-pr-comment.yml
+    with:
+      runs-on: self-hosted
+      keyword: scaled-sim
+      commands: python -m cProfile src/scripts/profiling/scale_run.py --show-progress-bar --ignore-warnings
+      description: Scale run of model

--- a/.github/workflows/run-on-pr-comment.yml
+++ b/.github/workflows/run-on-pr-comment.yml
@@ -1,0 +1,90 @@
+name: Resuable workflow for triggering tests with a pull-request comment
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: The type of machine to run job on
+        required: false
+        type: string
+        default: ubuntu-latest
+      keyword:
+        description: The keyword to appear after /run in PR comment to trigger workflow
+        required: true
+        type: string
+      description:
+        description: A description of test to use in comment generated to indicate result
+        required: true
+        type: string
+      commands:
+        description: The shell command(s) to run to execute test
+        required: true
+        type: string
+
+jobs:
+  run_test_on_keyword_and_reply_with_result:
+    runs-on: ${{ inputs.runs-on }}
+    if: github.event.issue.pull_request && github.event.comment.body == format('/run {0}', inputs.keyword)
+    steps:
+    - name: Check permissions of commenting user
+      id: has_permissions
+      uses: actions/github-script@v4
+      with:
+        script: |
+          const response = await github.repos.getCollaboratorPermissionLevel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,  
+            username: context.payload.comment.user.login,
+          });
+          const permission_level = response.data.permission;
+          return (permission_level == 'admin') || (permission_level == 'write')
+    - name: Exit if insufficient permissions
+      if: ${{ steps.has_permissions.outputs.result == 'false' }}
+      run: |
+        exit 1
+    - name: React to comment
+      uses: actions/github-script@v4
+      with:
+        script: |
+          github.reactions.createForIssueComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: context.payload.comment.id,
+            content: "rocket",
+          });
+    - name: Get pull-request SHA
+      id: sha
+      uses: actions/github-script@v4
+      with:
+        result-encoding: string
+        script: |
+          const pr = await github.pulls.get({
+            owner: context.issue.owner,
+            repo: context.issue.repo,
+            pull_number: context.issue.number,
+          });
+          return pr.data.head.sha
+    - name: Checkout pull-request SHA
+      uses: actions/checkout@v2
+      with:
+        lfs: true
+        ref: ${{ steps.sha.outputs.result }}
+    - name: Run test command(s)
+      run: ${{ inputs.commands }}
+    - name: Create comment with test result and link to workflow run information
+      if: always() && steps.has_permissions.outputs.result == 'true'
+      uses: actions/github-script@v4
+      with:
+        script: |
+          const workflow_run = await github.actions.getWorkflowRun({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId,
+          });
+          const result = "${{ job.status == 'success' && 'succeeded ✅' || 'failed ❌' }}"
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,  
+            body: `[${{ inputs.description }} ${result}](${workflow_run.html_url})`,
+          });


### PR DESCRIPTION
Adds a new GitHub Actions workflow which will be triggered when a new pull-request comment is created and the comment body is `/run scaled-sim`. If the commenting user has write or admin permissions on the repository, a profiled run of the `src/scripts/profiling/scale_run.py` script will be set off on a self-hosted runner and the triggering comment reacted to with a :rocket:. Upon exit from the `scale_run.py` script a new comment will be created on the pull request to indicate if the run completed without error or not.

The core workflow logic has been implemented as a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) to make it simple to add further tests triggered by PR comments of the form `/run <keyword>` in future. The reusable workflow accepts inputs specifying the environment to run on, the keyword to look for in comments to trigger, the bash command(s) to run the test(s), and a description of the test to use in the comment created with the test result.

One slight downside of adding this workflow will be that _every_ issue and pull-request comment will trigger a short-running workflow which will in most cases exit straight away skipping all jobs. This will create quite a lot of noise in the workflow run information displayed under the Actions tab, though this can be easily filtered out. If this becomes problematic we could potentially add a scheduled workflow which iterates over all current workflow runs and delete the logs of those runs connected to the workflow being added here when all jobs where skipped.