### PR TITLE
Fix pull-request comment scale run workflow

### DIFF
--- a/.github/workflows/pull-request-comment-ci.yml
+++ b/.github/workflows/pull-request-comment-ci.yml
@@ -12,5 +12,5 @@ jobs:
     with:
       runs-on: self-hosted
       keyword: scaled-sim
-      commands: python -m cProfile src/scripts/profiling/scale_run.py --show-progress-bar --ignore-warnings
-      description: Scale run of model
+      commands: tox -v -e profile
+      description: Profiled scale run of model

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@ envlist =
     check,
     py38,
     report,
-    docs
+    docs,
+    profile
 
 [testenv]
 basepython =
@@ -15,7 +16,7 @@ basepython =
     py33: {env:TOXPYTHON:python3.3}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
-    {py38,docs}: {env:TOXPYTHON:python3.8}
+    {py38,docs,profile}: {env:TOXPYTHON:python3.8}
     {clean,check,report,codecov,spell}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
@@ -88,6 +89,12 @@ skip_install = true
 commands =
     coverage report
     coverage html
+
+[testenv:profile]
+deps =
+    -r{toxinidir}/requirements/base.txt
+commands =
+    python -m cProfile -s cumtime src/scripts/profiling/scale_run.py --show-progress-bar --ignore-warnings
 
 [testenv:clean]
 commands = coverage erase


### PR DESCRIPTION
Fixes #479 

Adds a new `profile` environment to `tox.ini` file which specifies dependencies in `requirements/base.txt` as requirements and runs `src/scripts/profiling/scale_run.py` with profiling, and changes pull-request comment triggered workflow to use `tox` to initiate profiling run using new environment.