### PR TITLE
Handle errors in simulation run in `test_scale_run_script_deterministic`

### DIFF
--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -39,11 +39,10 @@ def test_scale_run_script_deterministic(tmp_path):
         "--save-final-population",
     ]
     final_population_dataframes = []
+    env = dict(os.environ)
     for hash_seed in (564059029, 1143360992):
-        completed_process = subprocess.run(
-            command_args,
-            env={'PYTHONHASHSEED': str(hash_seed)},
-        )
+        env["PYTHONHASHSEED"] = str(hash_seed)
+        completed_process = subprocess.run(command_args, env=env)
         assert completed_process.returncode == 0, (
             f"Running {' '.join(command_args)} fails to successfully complete "
             f"with stderr output\n\n{completed_process.stderr}"


### PR DESCRIPTION
Fixes #485 

Adds check that subprocess used to run `scale_run.py` script finished successfully before trying to load pickle file, and outputs more helpful error message with `stderr` output from subprocess if it terminated due to an error.
