### PR TITLE
Two loggers in the healthsystem

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -31,6 +31,7 @@ logger.setLevel(logging.INFO)
 logger_summary = logging.getLogger(f"{__name__}.summary")
 logger_summary.setLevel(logging.INFO)
 
+
 class FacilityInfo(NamedTuple):
     """Information about a specific health facility."""
     id: int

--- a/tests/test_healthsystem_and_symptommanager.py
+++ b/tests/test_healthsystem_and_symptommanager.py
@@ -767,7 +767,6 @@ def test_two_loggers_in_healthsystem(seed, tmpdir):
                                                            tclose=None,
                                                            priority=0)
 
-
     sim = Simulation(start_date=start_date, seed=seed, log_config={
         'filename': 'tmpfile',
         'directory': tmpdir,


### PR DESCRIPTION
In response to https://github.com/UCL/TLOmodel/issues/484, here we introduce a second dedicated logger in the HealthSystem that can be used to output summary metrics only. This should produce a smaller / more manageable file when only summary outputs of the HealthSystem are needed.