### PR TITLE
Increase scaled simulation workflow `timeout-minutes` value

### DIFF
--- a/.github/workflows/pull-request-comment-ci.yml
+++ b/.github/workflows/pull-request-comment-ci.yml
@@ -14,3 +14,4 @@ jobs:
       keyword: scaled-sim
       commands: tox -v -e profile
       description: Profiled scale run of model
+      timeout-minutes: 8640

--- a/.github/workflows/run-on-pr-comment.yml
+++ b/.github/workflows/run-on-pr-comment.yml
@@ -20,10 +20,16 @@ on:
         description: The shell command(s) to run to execute test
         required: true
         type: string
+      timeout-minutes:
+        description: The timeout in minutes to halt job after
+        required: false
+        type: number
+        default: 360
 
 jobs:
   run_test_on_keyword_and_reply_with_result:
     runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     if: github.event.issue.pull_request && github.event.comment.body == format('/run {0}', inputs.keyword)
     steps:
     - name: Check permissions of commenting user


### PR DESCRIPTION
Fixes #492 

Adds a `timeout-minutes` input reusable workflow and sets it to `24 * 60 = 8640` for scaled simulation PR comment triggered workflow job, which should be enough to do a full run of the `scale_run.py` script with its current default parameters (50k initial population, 20 year simulation time)