### PR TITLE
Make tox check commands more robust

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,5 +19,7 @@ recursive-exclude resources *
 recursive-exclude docs/reference tlo.*.rst
 exclude docs/reference/tlo.rst
 exclude docs/reference/modules.rst
+exclude docs/_*.rst
+exclude docs/hsi_events.csv
 
 global-exclude *.py[cod] __pycache__ *.so *.dylib .ipynb_checkpoints/** *~

--- a/tox.ini
+++ b/tox.ini
@@ -69,8 +69,8 @@ deps =
     twine
 skip_install = true
 commands =
-    python setup.py sdist
-    twine check dist/*
+    python setup.py sdist --formats=gztar
+    twine check dist/*.tar.gz
     check-manifest {toxinidir}
     flake8 src tests setup.py
     isort --check-only --diff src tests setup.py


### PR DESCRIPTION
Fixes #494 

Makes `twine check` command in `check` environment specifically check for files matching `dist/*.tar.gz` pattern and also forces source distribution built with previous command to be in `gztar` format (as otherwise the default format produced is platform dependent). Also adds a couple of additional auto-generated file / file patterns to `MANIFSET.in`.