### PR TITLE
change the quantity of consumables to float type

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -189,10 +189,11 @@ class HSI_Event:
 
             elif isinstance(item_codes, dict):
                 if not all(
-                    [(isinstance(code, (int, np.integer)) and isinstance(quantity, (float, np.floating)))
+                    [(isinstance(code, (int, np.integer)) and
+                      isinstance(quantity, (float, np.floating, int, np.integer)))
                      for code, quantity in item_codes.items()]
                 ):
-                    raise ValueError("item_codes must be integers and quantities must be floats.")
+                    raise ValueError("item_codes must be integers and quantities must be integers or floats.")
                 return {int(i): float(q) for i, q in item_codes.items()}
 
             else:


### PR DESCRIPTION
the function def _return_item_codes_in_dict requires item_codes to be integers. This PR changes the quantity from integer to a float type, as many 'Expected_Units_Per_Case' TLO list require less than 1 unit.