### PR TITLE
fix to demography logging

### DIFF
--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -21,8 +21,13 @@ from tlo.methods.causes import (
 )
 from tlo.util import create_age_range_lookup
 
+# Standard logger
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+# Detailed logger
+logger_detail = logging.getLogger(f"{__name__}.detail")
+logger_detail.setLevel(logging.INFO)
 
 # Limits for setting up age range categories
 MIN_AGE_FOR_RANGE = 0
@@ -377,9 +382,9 @@ class Demography(Module):
         logger.info(key='death', data=data_to_log_for_each_death)
 
         # - log all the properties for the deceased person
-        logger.info(key='properties_of_deceased_persons',
-                    data=person.to_dict(),
-                    description='values of all properties at the time of death for deceased persons')
+        logger_detail.info(key='properties_of_deceased_persons',
+                           data=person.to_dict(),
+                           description='values of all properties at the time of death for deceased persons')
 
         # Report the deaths to the healthburden module (if present) so that it tracks the live years lost
         if 'HealthBurden' in self.sim.modules.keys():


### PR DESCRIPTION
@tbhallett - noted that with `properties_of_deceased_persons `logging in demography the cause_of_death property is not being logged due when using` .to_dict()`  on an outdate slice of the df (property gets updated after `person` is defined).

I've put a fix here for your review- this will help with my neonatal calibrations which im making headway with.

Please ignore the first commit- I missed that `cause_of_death` was being stored at all