### PR TITLE
Fix for `Stunting` 

### DIFF
--- a/src/tlo/methods/hsi_generic_first_appts.py
+++ b/src/tlo/methods/hsi_generic_first_appts.py
@@ -169,6 +169,10 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                         topen=sim.date,
                         tclose=None)
 
+        # Routine assessments
+        if 'Stunting' in sim.modules:
+            sim.modules['Stunting'].do_routine_assessment_for_chronic_undernutrition(person_id=person_id)
+
     elif age < 15:
         # ----------------------------------- CHILD 5-14 -----------------------------------
         if 'fever' in symptoms and "Malaria" in sim.modules:


### PR DESCRIPTION
This PR allows there to be routine assesment for stunting for chilldren udner 5 years-olds as part of `do_at_generic_first_appt_non_emergency`.

This corrects an error, whereby the rountine assesment (`do_routine_assessment_for_chronic_undernutrition`) was not previously used at all!