### PR TITLE
Rti assert statements are causing runs to fail

### DIFF
--- a/src/tlo/methods/rti.py
+++ b/src/tlo/methods/rti.py
@@ -2109,6 +2109,9 @@ class RTI(Module):
         df.at[person_id, 'rt_debugging_DALY_wt'] += \
             sum([self.ASSIGN_INJURIES_AND_DALY_CHANGES[code][2] for code in relevant_codes])
         df.at[person_id, 'rt_debugging_DALY_wt'] = np.round(df.at[person_id, 'rt_debugging_DALY_wt'], 4)
+        # TODO: the injury '5113' seems to being treated multiple times for certain people, causing a repeated DALY
+        #  weight swap which ultimately results in a negative daly weight. I need to work out why this is happening, the
+        #  if statement below is a temporary fix
         # Check that the person's true disability burden is positive
         if df.at[person_id, 'rt_debugging_DALY_wt'] < 0:
             logger.debug(key='rti_general_message',


### PR DESCRIPTION
Small change to RTI module to stop assert statements from failing, with the view of coming back to this later on