### PR TITLE
Consumable cost analysis script

### DIFF
--- a/src/scripts/maternal_perinatal_analyses/get_consumable_costs.py
+++ b/src/scripts/maternal_perinatal_analyses/get_consumable_costs.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import pandas as pd
 import time
-from tlo.analysis.utils import load_pickled_dataframes, get_scenario_outputs, extract_results
+from tlo.analysis.utils import load_pickled_dataframes, get_scenario_outputs
 
 start_time = time.time()
 


### PR DESCRIPTION
Hi @tbhallett and @tamuri. 

This draft PR is just for review/discussion around code to output yearly cost of consumables associated with certain HSIs or groups of HSIs. 

The code in the script `get_consumable_cost.py` runs without issue but currently takes about 35 mins to complete when working extracting costs from two scenarios over a ten year time period.  This is of course fine if the code if written is the best way to extract this information but I highly doubt that!!!

One issue that this has raised is how to proceed when we dont have a cost available in `ResourceFile_Consumables_Items_and_Packages` for a consumable thats being requested in the code?