### PR TITLE
update tb microscopy consumable availability

### DIFF
--- a/resources/healthsystem/consumables/ResourceFile_Consumables_availability_and_usage.csv
+++ b/resources/healthsystem/consumables/ResourceFile_Consumables_availability_and_usage.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5606f6aed370992e923ad8da06571c723fc7b16fe163aa10ca3b86fbd828f987
-size 116218626
+oid sha256:c8c9be98d6c44c80e33d8939fcb2a7c2e6a40d426f88343a368d3dc6f56ccb68
+size 116218612

--- a/resources/healthsystem/consumables/ResourceFile_Consumables_availability_small.csv
+++ b/resources/healthsystem/consumables/ResourceFile_Consumables_availability_small.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ea692cd04217ec72d63aa495a7e8f1f0e32286692a166a705a091ebebb446c70
-size 6220549
+oid sha256:1ac1cb9affa8403f56db41e8db0a57e35cee07ca455d2016da67daf8b4531b0f
+size 6247156

--- a/src/scripts/data_file_processing/healthsystem/consumables/consumable_resource_analyses_with_lmis/consumables_availability_estimation.py
+++ b/src/scripts/data_file_processing/healthsystem/consumables/consumable_resource_analyses_with_lmis/consumables_availability_estimation.py
@@ -32,7 +32,8 @@ from tlo.methods.consumables import check_format_of_consumables_file
 # Set local Dropbox source
 path_to_dropbox = Path(  # <-- point to the TLO dropbox locally
     # 'C:/Users/sm2511/Dropbox/Thanzi la Onse'
-    '/Users/sejjj49/Dropbox/Thanzi la Onse'
+    # '/Users/sejjj49/Dropbox/Thanzi la Onse'
+    # 'C:/Users/tmangal/Dropbox/Thanzi la Onse'
 )
 
 path_to_files_in_the_tlo_dropbox = path_to_dropbox / "05 - Resources/Module-healthsystem/consumables raw files/"


### PR DESCRIPTION
This PR has reset the availability of "Solid culture and DST" for TB diagnosis to the default values before the LMIS data were used. This is because there are no data on availability of microscopy. As we know availability is high, we revert to default values of 0.85, 0.9, 0.95 and 0.99 for levels 1a, 1b, 2 and 3 respectively. File consumables_availability_estimation.py has been run to generate the updated resourcefiles. Thanks to @sakshimohan for guidance.