### PR TITLE
fix error raising in LogsDict

### DIFF
--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -539,7 +539,7 @@ class LogsDict(Mapping):
             return self._results_cache[key]  # return the added results
 
         else:
-            return KeyError
+            raise KeyError
 
     def __contains__(self, k):
         # if key k is a valid logfile entry


### PR DESCRIPTION
I _think_ this is an error. The `KeyError` is returned rather than raised, leading to the eventually resulting error message to be misleading.