### PR TITLE
Make `extract_results` robust when runs have failed

### DIFF
--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -287,7 +287,7 @@ def extract_results(results_folder: Path,
                 # Some logs could not be found - probably because this run failed.
                 res[draw_run] = None
 
-    # Use pd.concat to compile results (skips dict items where the values in None)
+    # Use pd.concat to compile results (skips dict items where the values is None)
     _concat = pd.concat(res, axis=1)
     _concat.columns.names = ['draw', 'run']  # name the levels of the columns multi-index
     return _concat


### PR DESCRIPTION
In a large batch run, some runs fail. This would cause `extract_results` to fail and inhibit the analysis of the rest of the batch.

This change allows `extract_results` to cope with runs that have failed by:
  * Skipping them silently.
  * Indexing the runs and draws that did work correctly.

This change also introduced some refactoring to make this change simpler - i.e., handling in the same way the case where the user have provided an argument for `custom_generate_series` or `column`.