### PR TITLE
Default behaviour of `full_model` wll not over-ride `capabilities_coefficient`

### DIFF
--- a/src/tlo/methods/fullmodel.py
+++ b/src/tlo/methods/fullmodel.py
@@ -43,7 +43,7 @@ def fullmodel(
     symptommanager_spurious_symptoms: Optional[bool] = True,
     healthsystem_disable: Optional[bool] = False,
     healthsystem_mode_appt_constraints: Optional[int] = 1,
-    healthsystem_capabilities_coefficient: Optional[float] = 1.0,
+    healthsystem_capabilities_coefficient: Optional[float] = None,
     healthsystem_record_hsi_event_details: Optional[bool] = False
 ) -> List[Module]:
     """Return the modules that should be registered in a run of the `Full Model`."""


### PR DESCRIPTION
The default value of `capabilities_coefficient` from running `full_model` was 1.0. This means that the capabilities are scaled to be the same as in the real population. 

This is too high.

The default value should be `None`, as this means that the capabilities will be scaled in proprotion to the population size.