### PR TITLE
Extend `create_pickes_locally` to uncompress log file

### DIFF
--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -395,11 +395,9 @@ def create_pickles_locally(scenario_output_dir, compressed_file_name_prefix=None
     def uncompress_and_save_logfile(compressed_file) -> Path:
         """Uncompress and save a log file and return its path."""
         target = compressed_file.parent / str(compressed_file.name[0:-3])
-
         with open(target, "wb") as t:
             with gzip.open(compressed_file, 'rb') as s:
                 t.write(s.read())
-
         return target
 
     f: os.DirEntry


### PR DESCRIPTION
Temporary Fix to Issue #613 

`create_pickes_locally` can now unzip an identified`.gz` files to recover the simulation's log.