### PR TITLE
Fix to prevent crashing when never_ran() function called for HSI_NewbornOutcomes_CareOfTheNewbornBySkilledAttendantAtBirth

### DIFF
--- a/src/tlo/methods/newborn_outcomes.py
+++ b/src/tlo/methods/newborn_outcomes.py
@@ -1380,8 +1380,9 @@ class NewbornOutcomes(Module):
         logger.debug(key='message', data=f'NewbornOutcomes_CareOfTheNewbornBySkilledAttendant did not run for '
                                          f'{person_id}')
 
-        if not nci[person_id]['will_receive_pnc'] == 'early':
-            self.set_death_status(person_id)
+        if person_id in nci:
+            if not nci[person_id]['will_receive_pnc'] == 'early':
+                self.set_death_status(person_id)
 
     def run_if_care_of_the_receives_postnatal_check_cant_run(self, hsi_event):
         """


### PR DESCRIPTION
I've just added a condition to prevent the look-up against the person_id for the nci dict. I'm not 100% sure why the person_id isnt in the dictionary as i dont think risk of death should have been applied to neonates before the HSI runs...

I can do some more digging but this will stop the runs crashing for now 