### PR TITLE
Update `TREATMENT_ID` for "PostnatalCare_TreatmentForObstetricFistula"

### DIFF
--- a/src/tlo/methods/postnatal_supervisor.py
+++ b/src/tlo/methods/postnatal_supervisor.py
@@ -1274,7 +1274,7 @@ class HSI_PostnatalSupervisor_TreatmentForObstetricFistula(HSI_Event, Individual
         super().__init__(module, person_id=person_id)
         assert isinstance(module, PostnatalSupervisor)
 
-        self.TREATMENT_ID = 'PostnatalSupervisor_TreatmentForObstetricFistula'
+        self.TREATMENT_ID = 'PostnatalCare_TreatmentForObstetricFistula'
         self.EXPECTED_APPT_FOOTPRINT = self.make_appt_footprint({'MajorSurg': 1})
         self.ACCEPTED_FACILITY_LEVEL = '1b'
         self.ALERT_OTHER_DISEASES = []


### PR DESCRIPTION
It was:

```python
self.TREATMENT_ID = 'PostnatalSupervisor_TreatmentForObstetricFistula'
```

but to meet the conventions elsewhere, it should be:

```python
self.TREATMENT_ID = 'PostnatalCare_TreatmentForObstetricFistula'
```python