### PR TITLE
Ensure child does not inherit properties from self in `Lifestyle.on_birth`

### DIFF
--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -19,7 +19,7 @@ from tlo.methods.causes import (
     collect_causes_from_disease_modules,
     create_mappers_from_causes_to_label,
 )
-from tlo.util import create_age_range_lookup
+from tlo.util import create_age_range_lookup, get_person_id_to_inherit_from
 
 # Standard logger
 logger = logging.getLogger(__name__)
@@ -280,8 +280,9 @@ class Demography(Module):
 
         fraction_of_births_male = self.parameters['fraction_of_births_male'][self.sim.date.year]
 
-        # Determine characteristics that are inherited from mother (and if no mother, from a randomly selected person)
-        _id_inherit_from = mother_id if mother_id != -1 else rng.choice(df.index[df.is_alive])
+        # Determine characteristics that are inherited from mother (and if no mother,
+        # from a randomly selected person)
+        _id_inherit_from = get_person_id_to_inherit_from(child_id, mother_id, df, rng)
         _district_num_of_residence = df.at[_id_inherit_from, 'district_num_of_residence']
         _district_of_residence = df.at[_id_inherit_from, 'district_of_residence']
         _region_of_residence = df.at[_id_inherit_from, 'region_of_residence']

--- a/src/tlo/methods/enhanced_lifestyle.py
+++ b/src/tlo/methods/enhanced_lifestyle.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from tlo import DateOffset, Module, Parameter, Property, Types, logging
 from tlo.events import PopulationScopeEventMixin, RegularEvent
+from tlo.util import get_person_id_to_inherit_from
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -789,11 +790,9 @@ class Lifestyle(Module):
 
         # Determine id from which characteristics that inherited (from mother, or if no
         # mother, from a randomly selected alive person that is not child themself)
-        if mother_id == -1:
-            alive_persons_not_including_child = df.index[df.is_alive].drop(child_id)
-            _id_inherit_from = self.rng.choice(alive_persons_not_including_child)
-        else:
-            _id_inherit_from = mother_id
+        _id_inherit_from = get_person_id_to_inherit_from(
+            child_id, mother_id, df, self.rng
+        )
 
         df.at[child_id, 'li_urban'] = df.at[_id_inherit_from, 'li_urban']
         df.at[child_id, 'li_wealth'] = df.at[_id_inherit_from, 'li_wealth']

--- a/src/tlo/util.py
+++ b/src/tlo/util.py
@@ -407,3 +407,22 @@ def hash_dataframe(dataframe: pd.DataFrame):
         return df.applymap(lambda x: tuple(x) if isinstance(x, list) else x)
 
     return hashlib.sha1(pd.util.hash_pandas_object(coerce_lists_to_tuples(dataframe)).values).hexdigest()
+
+
+def get_person_id_to_inherit_from(child_id, mother_id, population_dataframe, rng):
+    """Get index of person to inherit properties from.
+
+    Should be specified mother_id unless this is equal to -1 (for example for
+    individuals generated at population initialisation with no mother set) in which
+    case an individual from currently alive persons, _excluding the person the index to
+    inherit from is being computed for_, is randomly chosen.
+    """
+    if mother_id == -1:
+        # Get indices of alive persons and try to drop child_id from these indices if
+        # present, ignoring any errors if child_id not currently in population dataframe
+        alive_persons_not_including_child = population_dataframe.index[
+            population_dataframe.is_alive
+        ].drop(child_id, errors="ignore")
+        return rng.choice(alive_persons_not_including_child)
+    else:
+        return mother_id

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -222,3 +222,30 @@ def test_logs_parsing(tmpdir):
 
         # check the created pickle file is not empty
         assert os.path.getsize(path_to_tmpdir / f"{key}.pickle") != 0
+
+
+def test_get_person_id_to_inherit_from(rng: np.random.RandomState):
+    population_size = 1000
+    num_test = 5
+    for child_id, mother_id in rng.randint(0, population_size, size=(num_test, 2)):
+        # population_dataframe and rng arguments should be unused if mother_id != -1
+        assert mother_id == tlo.util.get_person_id_to_inherit_from(
+            child_id, mother_id, population_dataframe=None, rng=None
+        )
+    population_dataframe = pd.DataFrame(
+        {
+            "is_alive": rng.choice((True, False), size=population_size),
+            "sex": rng.choice(("F", "M"), size=population_size),
+            "age_years": rng.randint(0, 100, size=population_size),
+        }
+    )
+    mother_id = -1
+    for child_id in rng.choice(
+        population_dataframe.index[population_dataframe.is_alive], size=num_test
+    ):
+        inherit_from_id = tlo.util.get_person_id_to_inherit_from(
+            child_id, mother_id, population_dataframe, rng
+        )
+        assert inherit_from_id != mother_id
+        assert inherit_from_id != child_id
+        assert population_dataframe.loc[inherit_from_id].is_alive


### PR DESCRIPTION
Fixes #561 

Ensure a newborn individual cannot have the person they inherit properties from if `mother_id` set to `-1` set to their own index. Currently the code uses the [`numpy.random.RandomState.choice` function](https://numpy.org/doc/stable/reference/random/generated/numpy.random.RandomState.choice.html) to select a random index from the currently alive individuals if `mother_id == -1` however this has a small but non-zero probability of selecting the child themselves (for whom the `is_alive` property will have already been set to `True`). This PR explicitly drops the index of the child from the set of indices the index to inherit from is selected.

It looks like this part of the code isn't being touched currently by the changes in #545 so this should hopefully not cause any problems with merging there.