### PR TITLE
update real usage data by fixing target period and improving fill-up strategies

### DIFF
--- a/resources/healthsystem/real_appt_usage_data/real_monthly_usage_of_appt_type.csv
+++ b/resources/healthsystem/real_appt_usage_data/real_monthly_usage_of_appt_type.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:629044cf16ab33bd40eee3b85a83e8e2d92db9d5a8afe2a40080722cc694405a
-size 3976628
+oid sha256:a627bfea1cac29dcae58ab103594db6aa4fca97aee4e08468242b9b584beb7ea
+size 2575716


### PR DESCRIPTION
The updates are as follows:

(1) by looking into reporting rates, select the common time period for all appts as 2015-2019

(2) improve fill-up strategies S1, S2 and S3 by assuming that if an appt is not allowed at a certain level, then missing entries of that appt for facilities at that level are not filled (Previously, this assumption is only used for S4)

(3) improve S1, S2, S3 and S4 further considering whether or not a facility is expected to report to DHIS2, i.e., if a facility is expected to report and its reporting rate and raw usage entry are zeros, we do the fill-up; if a facility is not expected to report/its reporting rate is blank instead of zero, its raw usage entry is also blank for which we do not do the fill-up. (This improvement considers the consistency between reporting rates and fill-up strategies and filled up usage data)

(4) remove any fill-up for EPI data, this is because with fill-up strategies updated as above, EPI data without any fill-up is closer to EPI JRF report than results from any fill-up, in terms of total annual EPI usage. (Similar check is also done for MaleCirc cases and S1 + S2 remains as the best choice.)


