### PR TITLE
Show additional statistics in progress bar

### DIFF
--- a/src/tlo/simulation.py
+++ b/src/tlo/simulation.py
@@ -224,10 +224,16 @@ class Simulation:
 
             if self.show_progress_bar:
                 simulation_day = (date - start_date).days
-                progress_bar.update(
-                    simulation_day,
-                    stats_dict={"date": str(date.date())}
-                )
+                stats_dict = {
+                    "date": str(date.date()),
+                    "dataframe size": str(len(self.population.props)),
+                    "queued events": str(len(self.event_queue)),
+                }
+                if "HealthSystem" in self.modules:
+                    stats_dict["queued HSI events"] = str(
+                        len(self.modules["HealthSystem"].HSI_EVENT_QUEUE)
+                    )
+                progress_bar.update(simulation_day, stats_dict=stats_dict)
 
             if date >= end_date:
                 self.date = end_date


### PR DESCRIPTION
To help aid with diagnosing / investigating issues such as #689 this PR adds some additional statistics (current dataframe size, number of events in main and HSI event queues) to the progress bar display when enabled. At the moment I've made these always displayed rather than configurable but this does mean the progress bar ends up requiring quite a wide terminal to display without cutting off / wrapping, for example:

```
Simulation progress: 100%|██████████|Day 31/31 [02:24<00:00, 4.66s/day, date=2010-02-01, dataframe size=51000, queued events=10667, queued HSI events=9357]
```

Not sure if this likely to be an issue or not though - on my 1920x1080 laptop display this still easily fits within the screen width. If it would be useful to retain option for a more compact progress bar I could potentially add a `progress_bar_verbosity` argument or similar.

