### PR TITLE
Dev simulation task runner expects exactly ten replicates

### DIFF
--- a/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
+++ b/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
@@ -23,7 +23,7 @@ class LongRun(BaseScenario):
         self.end_date = Date(2019, 12, 31)
         self.pop_size = 5_000  # <- recommended population size for the runs
         self.number_of_draws = 1  # <- one scenario
-        self.runs_per_draw = 2  # <- repeated this many times
+        self.runs_per_draw = 10  # <- repeated this many times
 
     def log_configuration(self):
         return {


### PR DESCRIPTION
When this scenario is run on the dev server (to produce plots), the task runner expects exactly ten replicate runs. This restores number of runs to the previous value.