### PR TITLE
Fix rate of 'Other' deaths

### DIFF
--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -608,9 +608,7 @@ class OtherDeathPoll(RegularEvent, PopulationScopeEventMixin):
         for individual_id in max_age_or_older:
             self.module.do_death(individual_id=individual_id, cause='Other', originating_module=self.module)
 
-        # Get the mortality schedule for now...
-        # - get the subset of mortality rates for this year.
-        # confirms that we go to the five year period that we are in, not the exact year.
+        # Get the mortality schedule for the five-year calendar period we are currently in.
         fallbackyear = int(math.floor(self.sim.date.year / 5) * 5)
 
         mort_risk = self.mort_risk_per_poll.loc[


### PR DESCRIPTION
This fixes a bug detected in the `OtherDeathPoll` of `Demography` module, wherein the risks of death were applied to people wrongly. The source of the error was that merging a copy of the `population.props` dataframe with another dataframe led to (silent) re-indexing by pandas, meaning that the the indicies ceased to be related properly to the person_id. 