### PR TITLE
Use environment file instead of deprecated set-output in Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
               VAR_FILES="${VAR_FILES}{\"file\":\"${file}\"},"
           done
           VAR_FILES="${VAR_FILES}]}"
-          echo "matrix={VAR_FILES}" >> $GITHUB_OUTPUT
+          echo $VAR_FILES
+          echo "matrix=${VAR_FILES}" >> $GITHUB_OUTPUT
 
   test:
     needs: gen-test-matrix


### PR DESCRIPTION
The [`set-output` syntax in GitHub Actions has been deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
) in favour of using an environment file pointed to by the environment variable `$GITHUB_OUTPUT`. This PR changes the usage of `set-output` in the `set-matrix` step of the CI workflow to instead use the new `$GITHUB_OUTPUT` environment file.

Thanks to @giordano for pointing out this deprecation and that we were using this syntax in TLOmodel.