### PR TITLE
Update Azure batch documentation

### DIFF
--- a/docs/azure_batch.rst
+++ b/docs/azure_batch.rst
@@ -9,8 +9,8 @@ Azure Batch.
 Setup
 =====
 
-1. Install the Azure command line interface `<https://docs.microsoft.com/en-us/cli/azure/install-azure-cli>`_
-2. If you have not already done so ensure you have followed the instructions to set up a ``tlo`` `Conda <https://docs.conda.io/en/latest/>` environment in :doc:`readme`.
+1. `Install the Azure command line interface <https://docs.microsoft.com/en-us/cli/azure/install-azure-cli>`_
+2. If you have not already done so ensure you have followed the instructions to set up a ``tlo`` `Conda <https://docs.conda.io/en/latest/>`_ environment in :doc:`readme`.
 3. Open Terminal (MacOS) or Anaconda Prompt (Windows)
 4. Activate the ``tlo`` environment by running ``conda activate tlo``
 5. *Extra step for Windows only*


### PR DESCRIPTION
  * Fixes reference to `tlo.example.com` rather than `tlo.example.conf`
  * Removes replication of instructions for setting up `tlo` conda environment in favour of referencing instructions in Getting started / README file
  * Uses environment variable in Windows extra step to avoid hardcoding path