### PR TITLE
Remove tox plugin which was causing tests to fail

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ graft requirements
 include README.rst
 include .bumpversion.cfg
 include .coveragerc
-include tox.ini .travis.yml
+include tox.ini
 include tlo.example.conf
 
 exclude .editorconfig

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@ usedevelop = false
 deps =
     -r{toxinidir}/requirements/base.txt
     pytest
-    pytest-travis-fold
     pytest-cov
 commands =
     {posargs:pytest --cov --cov-report=term-missing -vv tests}


### PR DESCRIPTION
This PR removes the tox pytest-travis plugin, which required deprecated pytest `py` library. We're not using Travis, so this can be safely removed. Successfully tested locally.

- [from pytest 7.2.0 changelog](https://docs.pytest.org/en/7.2.x/changelog.html): pytest no longer depends on the py library...If you need other py.* modules, continue to install the deprecated py library separately, otherwise it can usually be removed as a dependency.
- additional notes here https://github.com/pytest-dev/py/issues/288

