### PR TITLE
Update Azure Batch Docker container to commit 9d1333e

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-REGISTRY_NAME="tlomodel"
+REGISTRY_NAME="tlob1acr"
 REGISTRY_URL="${REGISTRY_NAME}.azurecr.io"
 IMAGE_NAME="tlo"
-IMAGE_TAG="1.0"
+IMAGE_TAG="1.1"
 IMAGE_FULL_NAME="${IMAGE_NAME}:${IMAGE_TAG}"
 
 # Documentation at


### PR DESCRIPTION
I suspected one of the sources of LFS bandwidth use was updates on the container used for each Azure Batch task. Many large LFS files had been added since the last build. I built the container and deployed to the registry used by the TLO Azure Batch account.

- bumped tag version
- fixed repository name