### PR TITLE
pip install the worktree for a given commit in editable mode

### DIFF
--- a/src/scripts/task_runner/start.sh
+++ b/src/scripts/task_runner/start.sh
@@ -42,7 +42,7 @@ eval "$(/home/${username}/miniconda3/condabin/conda shell.bash hook)"
 conda create -p "${conda_env_root}/${commit_dir}" --clone tlo
 conda activate "${conda_env_root}/${commit_dir}"
 pip uninstall -y tlo  # remove the existing tlo installation (we cloned the virtual environment)
-pip install --use-feature=in-tree-build "${worktree_dir}"  # install tlo from the worktree
+pip install -e --use-feature=in-tree-build "${worktree_dir}"  # install tlo from the worktree
 
 # working directory is the commit directory
 cd "${worktree_dir}"


### PR DESCRIPTION
- Some analysis functions expect TLO code to be installed in  environment in editable mode (e.g. by looking for the root of the source via git root)

This hopefully fixes the recurring error on the dev server runs:

```
  File "/mnt/task-runner/envs/2022-10-31_214156_9d1333e5/lib/python3.8/site-packages/tlo/analysis/hsi_events.py", line 124, in get_details_of_defined_hsi_events
    resource_file_path = get_root_path() / 'resources'
  File "/mnt/task-runner/envs/2022-10-31_214156_9d1333e5/lib/python3.8/site-packages/tlo/analysis/utils.py", line 865, in get_root_path
    return get_git_root(__file__)
  File "/mnt/task-runner/envs/2022-10-31_214156_9d1333e5/lib/python3.8/site-packages/tlo/analysis/utils.py", line 860, in get_git_root
    git_repo = git.Repo(path, search_parent_directories=True)
  File "/mnt/task-runner/envs/2022-10-31_214156_9d1333e5/lib/python3.8/site-packages/git/repo/base.py", line 181, in __init__
    raise InvalidGitRepositoryError(epath)
git.exc.InvalidGitRepositoryError: /mnt/task-runner/envs/2022-10-31_214156_9d1333e5/lib/python3.8/site-packages/tlo/analysis/utils.py
```