### PR TITLE
Fix the order of pip argument

### DIFF
--- a/src/scripts/task_runner/start.sh
+++ b/src/scripts/task_runner/start.sh
@@ -42,7 +42,7 @@ eval "$(/home/${username}/miniconda3/condabin/conda shell.bash hook)"
 conda create -p "${conda_env_root}/${commit_dir}" --clone tlo
 conda activate "${conda_env_root}/${commit_dir}"
 pip uninstall -y tlo  # remove the existing tlo installation (we cloned the virtual environment)
-pip install -e --use-feature=in-tree-build "${worktree_dir}"  # install tlo from the worktree
+pip install --use-feature=in-tree-build -e "${worktree_dir}"  # install tlo from the worktree
 
 # working directory is the commit directory
 cd "${worktree_dir}"


### PR DESCRIPTION
Argh, need to specify in the right order: [-e[ditable] option requires path](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-e)