### PR TITLE
Fix non-deterministic behaviour of the `OtherDeathPoll` in the `Demography` module

### DIFF
--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -595,7 +595,7 @@ class OtherDeathPoll(RegularEvent, PopulationScopeEventMixin):
         gbd_deaths = self.module.parameters['gbd_causes_of_death_data']
 
         # Find the proportion of deaths to be represented by the OtherDeathPoll
-        return gbd_deaths[self.causes_to_represent].sum(axis=1)
+        return gbd_deaths[sorted(self.causes_to_represent)].sum(axis=1)
 
     def apply(self, population):
         """Randomly select some persons to die of the 'Other' tlo cause (the causes of death that are not represented


### PR DESCRIPTION
It seems that this line leads to some non-determinisitc behaviour because the ordering of the causes leads to tiny differences in the resulting sum (eh?!?!). Joe and Matt discovered this and confirm this fixes it.

@matt-graham writes, "It looks like the differences here are mainly in the least significant digits of the floating point values in the values of the second dictionary. Conceivably these could be due to the summation of the gbd_deaths dataframe in [this line](https://github.com/UCL/TLOmodel/blob/2620e8536719ae8cd92d212d4b6c62536d6d8463/src/tlo/methods/demography.py#L598) being over a sequence of columns specified by a set self.causes_to_represent as the order in which the columns will be summed up will depend on the iteration order of the set, which will change between Python sessions, and in floating point arithmetic differing orders of summations can lead to small differences in the summed values. If this is what is causing the differences in the logs then changing the line to return gbd_deaths[sorted(self.causes_to_represent)].sum(axis=1) should make sure we get consistent values over successive runs."