### PR TITLE
Copy `logging.shutdown()` to close simulation log handler

### DIFF
--- a/src/tlo/simulation.py
+++ b/src/tlo/simulation.py
@@ -251,14 +251,15 @@ class Simulation:
         logger.info(key='info', data=f'simulate() {time.time() - start} s')
 
         # From Python logging.shutdown
-        try:
-            self.output_file.acquire()
-            self.output_file.flush()
-            self.output_file.close()
-        except (OSError, ValueError):
-            pass
-        finally:
-            self.output_file.release()
+        if self.output_file:
+            try:
+                self.output_file.acquire()
+                self.output_file.flush()
+                self.output_file.close()
+            except (OSError, ValueError):
+                pass
+            finally:
+                self.output_file.release()
 
     def schedule_event(self, event, date):
         """Schedule an event to happen on the given future date.


### PR DESCRIPTION
Despite flushing and closing the handler, the file still contained out-of-order entries. I've now copied the code used in Python's `logging.shutdown()` method. It applies this to all handlers but we only need to close the tlo logger's file handler, to ensure simulation log file can be processed after `simulate()` ends. 🤞 