### PR TITLE
Add Comparison to Real vs Model HealthSystem usage to the routine plots

### DIFF
--- a/src/scripts/calibration_analyses/analysis_scripts/analysis_all_calibration.py
+++ b/src/scripts/calibration_analyses/analysis_scripts/analysis_all_calibration.py
@@ -8,6 +8,9 @@ import analysis_demography_calibrations
 import analysis_hsi_descriptions
 import plot_legends
 
+from scripts.calibration_analyses.analysis_scripts import (
+    analysis_compare_appt_usage_real_and_simulation,
+)
 from tlo.analysis.utils import get_scenario_outputs
 
 
@@ -22,6 +25,9 @@ def apply(results_folder: Path, output_folder: Path, resourcefilepath: Path = No
         results_folder=results_folder, output_folder=output_folder, resourcefilepath=resourcefilepath)
 
     analysis_hsi_descriptions.apply(
+        results_folder=results_folder, output_folder=output_folder, resourcefilepath=resourcefilepath)
+
+    analysis_compare_appt_usage_real_and_simulation.apply(
         results_folder=results_folder, output_folder=output_folder, resourcefilepath=resourcefilepath)
 
     # Plot the legends


### PR DESCRIPTION
To enable progress on the calibration of the health system usage to the actual data, we are adding the relevant analysis scripts (i.e. `analysis_compare_appt_usage_real_and_simulation.py` by @BinglingICL) to the collection of scripts run that produce plots about all aspects of the model calibration (and which are run routinely on the development server).


Current version of the plots:

<img width="405" alt="image" src="https://user-images.githubusercontent.com/39991060/200811544-a102fdc9-8f88-497a-bae5-f5d8af4dd32b.png">


<img width="405" alt="image" src="https://user-images.githubusercontent.com/39991060/200811562-fe28ba81-f20d-4d4b-a580-8c8c095e65ad.png">
