### PR TITLE
consumables: get_item_codes_from_package_name need to return exact float 

### DIFF
--- a/src/tlo/methods/consumables.py
+++ b/src/tlo/methods/consumables.py
@@ -207,7 +207,7 @@ def get_item_codes_from_package_name(lookup_df: pd.DataFrame, package: str) -> d
      a given package name."""
     ser = lookup_df.loc[
         lookup_df['Intervention_Pkg'] == package, ['Item_Code', 'Expected_Units_Per_Case']].set_index(
-        'Item_Code')['Expected_Units_Per_Case'].apply(np.ceil).astype(int)
+        'Item_Code')['Expected_Units_Per_Case'].astype(float)
     return ser.groupby(ser.index).sum().to_dict()  # de-duplicate index before converting to dict
 
 

--- a/tests/test_consumables.py
+++ b/tests/test_consumables.py
@@ -535,6 +535,7 @@ def test_get_item_codes_from_package_name():
     )
 
     example_package_names = [
+        "Implant",
         "Measles rubella vaccine",
         "HPV vaccine",
         "Tetanus toxoid (pregnant women)"
@@ -546,7 +547,7 @@ def test_get_item_codes_from_package_name():
 
         res_from_lookup = \
             lookup_df.loc[lookup_df.Intervention_Pkg == _pkg_name].set_index('Item_Code').sort_index()[
-                'Expected_Units_Per_Case'].astype(int)
+                'Expected_Units_Per_Case'].astype(float)
 
         pd.testing.assert_series_equal(
             res_from_lookup.groupby(res_from_lookup.index).sum(),


### PR DESCRIPTION
The `Expected_Units_Per_Case` have been rounded down to the smallest integer but not less than the value from the ResourceFile.

However, we need the exact value because we don't always have integers as the `Expected_Units_Per_Case`.  For instance, for the 'Implants' pkg, we may only use a small amount of some items (0.1, 0.2, or 0.5).

I fixed this in consumables, and fixed the test accordingly.

I also tried to check whether the `get_item_codes_from_package_name`  fnc is used somewhere else and from what I found it is used in hiv.py, and tb.py. In both cases, the `Expected_Units_Per_Case` are integers, so they are not rounded. Hence, I think it shouldn't break anything.


