### PR TITLE
Add level argument to parse_log_file

### DIFF
--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -157,7 +157,6 @@ def to_age_group(_ages: pd.Series):
 def get_scenario_outputs(scenario_filename: str, outputs_dir: Path) -> list:
     """Returns paths of folders associated with a batch_file, in chronological order."""
     stub = scenario_filename.rstrip('.py')
-    f: os.DirEntry
     folders = [Path(f.path) for f in os.scandir(outputs_dir) if f.is_dir() and f.name.startswith(stub)]
     folders.sort()
     return folders
@@ -169,7 +168,6 @@ def get_scenario_info(scenario_output_dir: Path) -> dict:
     TODO: read the JSON file to get further information
     """
     info = dict()
-    f: os.DirEntry
     draw_folders = [f for f in os.scandir(scenario_output_dir) if f.is_dir()]
 
     info['number_of_draws'] = len(draw_folders)
@@ -206,7 +204,6 @@ def extract_params(results_folder: Path) -> Optional[pd.DataFrame]:
     """
 
     try:
-        f: os.DirEntry
         # Get the paths for the draws
         draws = [f for f in os.scandir(results_folder) if f.is_dir()]
 
@@ -394,7 +391,6 @@ def create_pickles_locally(scenario_output_dir, compressed_file_name_prefix=None
                 t.write(s.read())
         return target
 
-    f: os.DirEntry
     draw_folders = [f for f in os.scandir(scenario_output_dir) if f.is_dir()]
     for draw_folder in draw_folders:
         run_folders = [f for f in os.scandir(draw_folder) if f.is_dir()]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -5,7 +5,7 @@ from typing import List
 import numpy as np
 import pandas as pd
 
-from tlo import Date, Module, Simulation, logging, DateOffset, Property, Types
+from tlo import Date, DateOffset, Module, Property, Simulation, Types, logging
 from tlo.analysis.utils import (
     colors_in_matplotlib,
     flatten_multi_index_series_into_dict_for_logging,
@@ -20,7 +20,7 @@ from tlo.analysis.utils import (
     parse_log_file,
     unflatten_flattened_multi_index_in_logging,
 )
-from tlo.events import RegularEvent, PopulationScopeEventMixin
+from tlo.events import PopulationScopeEventMixin, RegularEvent
 from tlo.methods import demography
 from tlo.methods.fullmodel import fullmodel
 


### PR DESCRIPTION
Fixes #575 

Specify the logging level when parsing simulation output. Previously, only log entries INFO and above were parsed  although log lines at the lower levels were saved in the raw file. By specifying, for example `parse_log_file('my.log', level=logging.DEBUG)`, debug log lines are parsed and returned.

The test checks running sim at INFO and DEBUG log levels, and parsing at INFO and DEBUG levels.
