### PR TITLE
Change CI workflows to actions/checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           lfs: true
       - id: set-matrix
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.gen-test-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           lfs: true
       - name: System info
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           lfs: true
       - name: System info
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           lfs: true
       - name: System info


### PR DESCRIPTION
Second part of fix to #718 along with changes that are part of #775. Changes the usages of the `actions/checkout` Action in the main continuous integration workflows to the `v3` tag which [uses Node16 runtime by default](https://github.com/actions/checkout#whats-new). As there doesn't appear to have been any other changes to the action API, I think it should be sufficient to just change the tag here (just changing the `actions/checkout` version tag  for the comment triggered CI workflows in #775 in the test repository worked without any problems).