### PR TITLE
Use cause of death label color map object in place of removed function

### DIFF
--- a/src/scripts/calibration_analyses/analysis_scripts/plot_legends.py
+++ b/src/scripts/calibration_analyses/analysis_scripts/plot_legends.py
@@ -6,7 +6,7 @@ import pandas as pd
 from matplotlib import pyplot as plt
 
 from tlo.analysis.utils import (
-    _define_cause_of_death_labels,
+    CAUSE_OF_DEATH_LABEL_TO_COLOR_MAP,
     get_coarse_appt_type,
     get_color_coarse_appt,
     get_color_short_treatment_id,
@@ -62,11 +62,9 @@ def apply(results_folder: Path, output_folder: Path, resourcefilepath: Path = No
     plt.close(fig)
 
     # %% Cause of Death Labels
-    all_labels = _define_cause_of_death_labels()
-
     fig, ax = plot_legend(
-        labels=all_labels.index,
-        colors=all_labels.values,
+        labels=list(CAUSE_OF_DEATH_LABEL_TO_COLOR_MAP.keys()),
+        colors=list(CAUSE_OF_DEATH_LABEL_TO_COLOR_MAP.values()),
         title="Cause-of-Death Labels",
     )
     fig.show()


### PR DESCRIPTION
Fixes `ImportError` in `src/scripts/calibration_analyses/analysis_scripts/plot_legends.py` due to trying to import function `_define_cause_of_death_labels` from `tlo.analysis.utils` removed as part of changes in #707. Instead the new `CAUSE_OF_DEATH_LABEL_TO_COLOR_MAP` mapping object defined in the same `tlo.analysis.utils` module is imported and used in-place of the previous function.