### PR TITLE
Expose `BaseScenario` attributes in `__init__` and inherit from ABC

### DIFF
--- a/src/tlo/scenario.py
+++ b/src/tlo/scenario.py
@@ -21,7 +21,7 @@ A simple example of a subclass of ``BaseScenario``::
                 seed = 12,
                 start_date = Date(2010, 1, 1),
                 end_date = Date(2011, 1, 1),
-                pop_size = 200,
+                initial_population_size = 200,
                 number_of_draws = 2,
                 runs_per_draw = 2,
             )


### PR DESCRIPTION
This PR makes the attributes of a scenario the user is expected to define optional arguments of the `BaseScenario.__init__` method (with default values corresponding to maintaining the current values set in `BaseScenario.__init__` where appropriate) and also makes `BaseScenario` a subclass of the `abc.ABC` abstract base class helper class.

The former change means the required scenario attributes can be passed as keyword arguments to a `super().__init__` call within the `__init__` method of a `BaseScenario` subclass, rather than setting the attributes directly. This is more robust as using the incorrect attribute name as a keyword argument will result in an error when an instance of the class is initialised rather than when it is attempted to access the correct attribute name. By setting (appropriate) default values such that a `super().__init__` call with no arguments will run without errors should mean the current approach of directly setting the attributes should continue to work and so existing code should not be broken by this change.

The latter change also improves robustness by raising an error as soon as it is attempted to initialise a subclass of `BaseScenario` for which any of the methods marked abstract (`log_configuration` and `modules`) have not been overridden with concrete implementations. Again failing early when the class is initialised rather than when attempting to call non-implemented methods will generally be preferable.