### PR TITLE
Add improved scenario parameter grid generation function

### DIFF
--- a/src/scripts/dev/th_testing/2D_grid/mockitis_2D_grid.py
+++ b/src/scripts/dev/th_testing/2D_grid/mockitis_2D_grid.py
@@ -2,7 +2,7 @@
 This file defines a batch run through which the Mockitis module is run across a 2-dimensional grid of parameters
 
 Run on the batch system using:
-```tlo batch-submit  src/scripts/dev/th_testing/mockitis_2D_grid.py tlo.conf```
+```tlo batch-submit  src/scripts/dev/th_testing/2D_grid/mockitis_2D_grid.py```
 
 """
 
@@ -10,17 +10,15 @@ import numpy as np
 
 from tlo import Date, logging
 from tlo.methods import (
-    contraception,
     demography,
     enhanced_lifestyle,
     healthseekingbehaviour,
     healthsystem,
-    labour,
     mockitis,
-    pregnancy_supervisor,
+    simplified_births,
     symptommanager,
 )
-from tlo.scenario import BaseScenario
+from tlo.scenario import BaseScenario, make_cartesian_parameter_grid
 
 
 class MockitisBatch(BaseScenario):
@@ -28,9 +26,12 @@ class MockitisBatch(BaseScenario):
         super().__init__()
         self.seed = 12
         self.start_date = Date(2010, 1, 1)
-        self.end_date = Date(2020, 1, 1)
+        self.end_date = Date(2011, 1, 1)
         self.pop_size = 500
-        self.number_of_draws = 6
+        self._parameter_grid = make_cartesian_parameter_grid(
+            {'Mockitis': {'p_infection': np.linspace(0, 1.0, 3), 'p_cure': [0.25, 0.5]}}
+        )
+        self.number_of_draws = len(self._parameter_grid)
         self.runs_per_draw = 2
 
     def log_configuration(self):
@@ -49,23 +50,12 @@ class MockitisBatch(BaseScenario):
             healthsystem.HealthSystem(resourcefilepath=self.resources, disable=True, service_availability=['*']),
             symptommanager.SymptomManager(resourcefilepath=self.resources),
             healthseekingbehaviour.HealthSeekingBehaviour(resourcefilepath=self.resources),
-            contraception.Contraception(resourcefilepath=self.resources),
-            labour.Labour(resourcefilepath=self.resources),
-            pregnancy_supervisor.PregnancySupervisor(resourcefilepath=self.resources),
+            simplified_births.SimplifiedBirths(resourcefilepath=self.resources),
             mockitis.Mockitis(resourcefilepath=self.resources)
         ]
 
     def draw_parameters(self, draw_number, rng):
-        grid = self.make_grid(
-            {'p_infection': np.linspace(0, 1.0, 3), 'p_cure': [0.25, 0.5]}
-        )
-
-        return {
-            'Mockitis': {
-                'p_infection': grid['p_infection'][draw_number],
-                'p_cure': grid['p_cure'][draw_number]
-            },
-        }
+        return self._parameter_grid[draw_number]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #824 (indirectly).

Removes the previous `BaseScenario.make_grid` method in favour of a new module level function `make_cartesian_parameter_grid` in `tlo.scenario`. This function performs a similar role to the `BaseScenario.make_grid` method but generalises in two important aspects:

  * The function accepts a nested dictionary structure, with the outer dictionary mapping from module names to dictionaries mapping from (module-specific) parameter names to iterables of parameter values over which the grid of parameters should be constructed, and returns a list of nested dictionaries mapping from module names to dictionaries mapping from parameter names to their corresponding values, with each dictionary in the list a single point in the parameter grid. This allows the output of the function to directly be indexed by the `draw_number` argument in `BaseScenario.draw_parameters` to get a dictionary of parameter values of the expected format without any further boilerplate (as necessary with the current method).
  * The function works for any iterable of parameter values, not just NumPy arrays of numeric values, so can be used to produce grids across parameters which are a mix of types, for example numeric, categorical, string.