### PR TITLE
analysis_demog_calib: fig name changed to not overwrite another fig

### DIFF
--- a/src/scripts/calibration_analyses/analysis_scripts/analysis_demography_calibrations.py
+++ b/src/scripts/calibration_analyses/analysis_scripts/analysis_demography_calibrations.py
@@ -178,7 +178,7 @@ def apply(results_folder: Path, output_folder: Path, resourcefilepath: Path = No
     ax.set_title('Population Size 2018')
     ax.legend()
     fig.tight_layout()
-    plt.savefig(make_graph_file_name("Pop_Over_Time"))
+    plt.savefig(make_graph_file_name("Pop_Males_Females_2018"))
     plt.show()
     plt.close(fig)
 


### PR DESCRIPTION
Original name 'Pop_Over_Time' already used, hence the fig is overwritten by this. With the new name, we have both Figs.