### PR TITLE
Make the duration of `long_run_all_diseases` be 20y

### DIFF
--- a/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
+++ b/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
@@ -21,7 +21,7 @@ class LongRun(BaseScenario):
         super().__init__()
         self.seed = 0
         self.start_date = Date(2010, 1, 1)
-        self.end_date = self.start_date + pd.DateOffset(years=10)
+        self.end_date = self.start_date + pd.DateOffset(years=20)
         self.pop_size = 20_000
         self.number_of_draws = 1
         self.runs_per_draw = 10


### PR DESCRIPTION
Checks on calibrations and model performance can now be extended to the 20y duration.

(Duration had been reduced to 10y at some point to make this faster)