### PR TITLE
Measles module scheduling additional alri episodes for <5yo

### DIFF
--- a/resources/ResourceFile_Measles.xlsx
+++ b/resources/ResourceFile_Measles.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:947273d8b5a1cdc5c187f01f5e23a6f9ac89d188c550550cd1e7bb6850f744dd
-size 19416
+oid sha256:fa4cd4f86f9c63693b866646ca59065ae6f726411115423b35292dfc6b3168d9
+size 14469

--- a/resources/ResourceFile_Measles.xlsx
+++ b/resources/ResourceFile_Measles.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa4cd4f86f9c63693b866646ca59065ae6f726411115423b35292dfc6b3168d9
-size 14469
+oid sha256:6295fef26fec1d6e2ee5301bf4eadad553c8cf00f8a62a4a73bad11b68e489f9
+size 15334

--- a/src/tlo/methods/__init__.py
+++ b/src/tlo/methods/__init__.py
@@ -6,3 +6,4 @@ class Metadata(Enum):
     USES_SYMPTOMMANAGER = auto()  # The 'Symptom Manager' recognises modules with this label.
     USES_HEALTHSYSTEM = auto()    # The 'HealthSystem' recognises modules with this label.
     USES_HEALTHBURDEN = auto()    # The 'HealthBurden' module recognises modules with this label.
+    USES_ALRI = auto()    # The 'Alri' module recognises modules with this label.

--- a/src/tlo/methods/alri.py
+++ b/src/tlo/methods/alri.py
@@ -891,7 +891,13 @@ class Alri(Module):
         * Schedules the main logging event
         * Establishes the linear models and other data structures using the parameters that have been read-in
         """
+      
         p = self.parameters
+
+        # Capture list of disease modules:
+        self.recognised_modules_names = [
+            m.name for m in self.sim.modules.values() if Metadata.USES_ALRI in m.METADATA
+        ]
 
         # Schedule the main polling event (to first occur immediately)
         sim.schedule_event(AlriPollingEvent(self), sim.date)

--- a/src/tlo/methods/alri.py
+++ b/src/tlo/methods/alri.py
@@ -2181,6 +2181,8 @@ class AlriIncidentCase(Event, IndividualScopeEventMixin):
 
         # The event should not run if person was infected with alri by the other module since this event was scheduled:
         if person.ri_current_infection_status:
+            logger.warning(key="warning",
+                           data="Clash in scheduling of alri events by measles and alri modules.")
             return
 
         # Get the characteristics of the case

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -152,7 +152,7 @@ class HSI_Event:
         return updated_appt_footprint
 
     def get_consumables(self,
-                       item_codes: Union[None, np.integer, int, list, set, dict] = None,
+                        item_codes: Union[None, np.integer, int, list, set, dict] = None,
                         optional_item_codes: Union[None, np.integer, int, list, set, dict] = None,
                         to_log: Optional[bool] = True,
                         return_individual_results: Optional[bool] = False

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -152,7 +152,7 @@ class HSI_Event:
         return updated_appt_footprint
 
     def get_consumables(self,
-                        item_codes: Union[None, np.integer, int, list, set, dict] = None,
+                       item_codes: Union[None, np.integer, int, list, set, dict] = None,
                         optional_item_codes: Union[None, np.integer, int, list, set, dict] = None,
                         to_log: Optional[bool] = True,
                         return_individual_results: Optional[bool] = False

--- a/src/tlo/methods/measles.py
+++ b/src/tlo/methods/measles.py
@@ -326,9 +326,7 @@ class MeaslesOnsetEvent(Event, IndividualScopeEventMixin):
             # of dying from alri if concurrent measles infection.
             # Opt 4. Schedule an alri infection at the end of this one, therefore won't be realistically concurrent.
 
-            if not df.at[person_id, "ri_current_infection_status"]:
-
-                if rng.random_sample() < self.module.parameters["p_alri_if_measles"]:
+                else:
 
                     # Eventually use this to chose pathogen
                     # inc_of_acquiring_alri = pd.DataFrame(index=df.loc[person_id].index)

--- a/src/tlo/methods/measles.py
+++ b/src/tlo/methods/measles.py
@@ -156,10 +156,6 @@ class Measles(Module):
 
     def initialise_simulation(self, sim):
 
-
-        self.sim.modules['Alri'].models = Models(self.sim.modules['Alri'])
-
-
         """Schedule measles event to start straight away. Each month it will assign new infections"""
         sim.schedule_event(MeaslesEvent(self), sim.date)
         sim.schedule_event(MeaslesLoggingEvent(self), sim.date)
@@ -295,10 +291,10 @@ class MeaslesOnsetEvent(Event, IndividualScopeEventMixin):
         # Capture list of disease modules:
        
 
-        mask_could_get_new_alri_event = (
-            df.is_alive & (df.age_years < 5) & ~df.ri_current_infection_status &
-            ((df.ri_end_of_current_episode < self.sim.date) | pd.isnull(df.ri_end_of_current_episode))
-        )
+        mask_could_get_new_alri_event = (df.is_alive & (df.age_years < 5) & ~df.ri_current_infection_status &
+            ((df.ri_end_of_current_episode < self.sim.date) | pd.isnull(df.ri_end_of_current_episode)))
+        print("This is type")
+        print(type(mask_could_get_new_alri_event))
  
         inc_of_acquiring_alri = pd.DataFrame(index=df.loc[mask_could_get_new_alri_event].index)
 

--- a/src/tlo/methods/measles.py
+++ b/src/tlo/methods/measles.py
@@ -6,7 +6,9 @@ import pandas as pd
 from tlo import DateOffset, Module, Parameter, Property, Types, logging
 from tlo.events import Event, IndividualScopeEventMixin, PopulationScopeEventMixin, RegularEvent
 from tlo.methods import Metadata
+from tlo.methods import alri
 from tlo.methods.causes import Cause
+from tlo.methods.alri import Models
 from tlo.methods.healthsystem import HSI_Event
 from tlo.methods.symptommanager import Symptom
 from tlo.util import random_date
@@ -18,7 +20,7 @@ logger.setLevel(logging.INFO)
 class Measles(Module):
     """This module represents measles infections and disease."""
 
-    INIT_DEPENDENCIES = {'Demography', 'HealthSystem', 'SymptomManager'}
+    INIT_DEPENDENCIES = {'Demography', 'HealthSystem', 'SymptomManager', 'Alri'}
 
     OPTIONAL_INIT_DEPENDENCIES = {'HealthBurden'}
 
@@ -27,7 +29,8 @@ class Measles(Module):
         Metadata.DISEASE_MODULE,
         Metadata.USES_HEALTHBURDEN,
         Metadata.USES_HEALTHSYSTEM,
-        Metadata.USES_SYMPTOMMANAGER
+        Metadata.USES_SYMPTOMMANAGER,
+        Metadata.USES_ALRI
     }
 
     # Declare Causes of Death
@@ -152,6 +155,11 @@ class Measles(Module):
         df.loc[df.is_alive, "me_on_treatment"] = False
 
     def initialise_simulation(self, sim):
+
+
+        self.sim.modules['Alri'].models = Models(self.sim.modules['Alri'])
+
+
         """Schedule measles event to start straight away. Each month it will assign new infections"""
         sim.schedule_event(MeaslesEvent(self), sim.date)
         sim.schedule_event(MeaslesLoggingEvent(self), sim.date)
@@ -284,6 +292,23 @@ class MeaslesOnsetEvent(Event, IndividualScopeEventMixin):
         df.at[person_id, "me_on_treatment"] = False
 
         symp_onset = self.assign_symptoms(ref_age)  # Assign symptoms for this person
+        # Capture list of disease modules:
+       
+
+        mask_could_get_new_alri_event = (
+            df.is_alive & (df.age_years < 5) & ~df.ri_current_infection_status &
+            ((df.ri_end_of_current_episode < self.sim.date) | pd.isnull(df.ri_end_of_current_episode))
+        )
+ 
+        inc_of_acquiring_alri = pd.DataFrame(index=df.loc[mask_could_get_new_alri_event].index)
+
+        if "Alri" in self.sim.modules.keys():
+            for pathogen in self.sim.modules["Alri"].all_pathogens:
+                inc_of_acquiring_alri[pathogen] = self.sim.modules["Alri"].models.compute_risk_of_acquisition(
+                    pathogen=pathogen,
+                    df=df.loc[mask_could_get_new_alri_event]
+            )    
+
         prob_death = self.get_prob_death(ref_age)  # Look-up the probability of death for this person
 
         # Schedule either the DeathEvent of the SymptomResolution event, depending on the expected outcome of this case

--- a/src/tlo/methods/measles.py
+++ b/src/tlo/methods/measles.py
@@ -312,7 +312,7 @@ class MeaslesOnsetEvent(Event, IndividualScopeEventMixin):
                     event=AlriIncidentCase(
                         module=self.sim.modules["Alri"],
                         person_id=person_id,
-                        pathogen=self.sim.modules["Alri"].all_pathogens[0],
+                        pathogen=self.sim.modules["Alri"].all_pathogens[0], #For now passing fixed pathogen, will have to randomise
                     ),
                     date=random_date(self.sim.date, symp_resolve, self.module.rng)
                 )

--- a/tests/test_measles.py
+++ b/tests/test_measles.py
@@ -12,6 +12,10 @@ from tlo.methods import (
     healthburden,
     healthseekingbehaviour,
     healthsystem,
+    tb,
+    hiv,
+    wasting,
+    alri,
     measles,
     simplified_births,
     symptommanager,
@@ -60,6 +64,10 @@ def sim(seed):
             disable=True,  # disables the health system constraints so all HSI events run
         ),
         epi.Epi(resourcefilepath=resources),
+        wasting.Wasting(resourcefilepath=resources),
+        tb.Tb(resourcefilepath=resources),
+        hiv.Hiv(resourcefilepath=resources),
+        alri.Alri(resourcefilepath=resources),
         measles.Measles(resourcefilepath=resources),
     )
 

--- a/tests/test_measles.py
+++ b/tests/test_measles.py
@@ -85,6 +85,8 @@ def test_single_person(sim):
     sim.modules['Measles'].parameters["symptom_prob"]["probability"] = 1
 
     sim.make_initial_population(n=1)  # why does this throw an error if n=1??
+
+
     # ValueError: Wrong number of items passed 5, placement implies 1
     df = sim.population.props
     person_id = 0


### PR DESCRIPTION
• Measles respiratory symptoms and deaths for <5yo exclusively handled by alri module;
• Measles infection in this age category leads to probabilistic scheduling of alri event for that individual outside of regular alri module polling event. Probability of alri episode following measles infection will be new free parameter in the module requiring calibration based on measles deaths;
• Dalys and deaths for such alri events are logged as "Measles" for all alri pathogens ;
• This approach affects the alri cases calibration, however effect would generally be negligible due to low incidence of measles. Checks based on overall incidence are included. 


<img width="1084" alt="image" src="https://user-images.githubusercontent.com/39991060/219413155-6b427365-2efb-4041-b2a4-3e4ed839e772.png">
