### PR TITLE
modifying probabilities for seed tests failing in test_diarrhoea

### DIFF
--- a/tests/test_diarrhoea.py
+++ b/tests/test_diarrhoea.py
@@ -915,8 +915,8 @@ def test_effect_of_vaccine(seed):
     get_dehydration = sim.modules['Diarrhoea'].models.get_dehydration
 
     # increase probability to ensure at least one case of severe dehydration when vaccine is imperfect
-    sim.modules['Diarrhoea'].parameters['prob_dehydration_by_rotavirus'] = 1
-    sim.modules['Diarrhoea'].parameters['prob_dehydration_by_shigella'] = 1
+    sim.modules['Diarrhoea'].parameters['prob_dehydration_by_rotavirus'] = 1.0
+    sim.modules['Diarrhoea'].parameters['prob_dehydration_by_shigella'] = 1.0
 
     # 1) Make effect of vaccine perfect
     sim.modules['Diarrhoea'].parameters['rr_severe_dehydration_due_to_rotavirus_with_R1_under1yo'] = 0.0


### PR DESCRIPTION
Having a brief discussion with @matt-graham a better way of dealing with issue #555 is to increase the probability of dehydration inside the test for ensuring at least one draw of severe  dehydration. The majority of the seeds tested seem to succeed for:
```
    sim.modules['Diarrhoea'].parameters['prob_dehydration_by_rotavirus'] = 0.3
    sim.modules['Diarrhoea'].parameters['prob_dehydration_by_shigella'] = 0.4
```
Tagging @tbhallett to confirm if this is a robust solution here.
 