### PR TITLE
tests for seeds failing in test_beddays

### DIFF
--- a/tests/test_beddays.py
+++ b/tests/test_beddays.py
@@ -391,7 +391,7 @@ def test_bed_days_property_is_inpatient(tmpdir, seed):
 
 def test_bed_days_released_on_death(tmpdir, seed):
     """Check that bed-days scheduled to be occupied are released upon the death of the person"""
-    _bed_type = bed_types[2]
+    _bed_type = 'general_bed'
     days_simulation_duration = 20
 
     class DummyModule(Module):


### PR DESCRIPTION
This PR creates some fixes for the seed tests failing as described in issue #834 
1. It changes _bed_type in line [388](https://github.com/UCL/TLOmodel/blob/6b9a1d5e8bd7e6817cf479b3fec7391a969a68ae/tests/test_beddays.py#L388) to general bed the previous type was maternity and it resulted in male and children patients being assigned to maternity beds (perhaps an assertion can be considered to ensure this is not happening?). 
2. To fix the capacity issue the beds_availability is set to 'all' in the healthsystem, line [464](https://github.com/UCL/TLOmodel/blob/6b9a1d5e8bd7e6817cf479b3fec7391a969a68ae/tests/test_beddays.py#L464)