### PR TITLE
HealthSystem handles central Priority Ranking Policy

### DIFF
--- a/resources/ResourceFile_Alri.xlsx
+++ b/resources/ResourceFile_Alri.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e297e7367bc21a9463691d2b225a4982e5a4d8d007544bb1b5fab6a3f35a7c1
-size 45131
+oid sha256:9c8fec569080f16e3b1cbb2d16e6aac3d904274a8538cb996ce45fd3e8705320
+size 29608

--- a/resources/ResourceFile_Diarrhoea.xlsx
+++ b/resources/ResourceFile_Diarrhoea.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc158a8c3e7b3d973fe98a41467e181cb344c82949940f2ca35f651b23185da6
-size 15678
+oid sha256:ec9da21c40a85d337bdb4812526b19383a3e2a78d0238069252bae0fdcef764c
+size 11095

--- a/resources/healthsystem/ResourceFile_PriorityRanking.csv
+++ b/resources/healthsystem/ResourceFile_PriorityRanking.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56ac36ea34c6cf80008ea5586dae9651d4143fc7cd00c04c58c6317fee6272c3
+size 2157

--- a/src/tlo/methods/bladder_cancer.py
+++ b/src/tlo/methods/bladder_cancer.py
@@ -161,7 +161,19 @@ class BladderCancer(Module):
         ),
         "sensitivity_of_cytoscopy_for_bladder_cancer_pelvic_pain": Parameter(
             Types.REAL, "sensitivity of cytoscopy_for diagnosis of bladder cancer given pelvic pain"
-        )
+        ),
+        'priority_BladderCancer_Investigation':
+            Parameter(Types.INT,
+                     'Priority associated with BladderCancer_Investigation'
+                     ),
+        'priority_BladderCancer_PalliativeCare':
+            Parameter(Types.INT,
+                     'Priority associated with BladderCancer_PalliativeCare'
+                     ),
+        'priority_BladderCancer_Treatment':
+            Parameter(Types.INT,
+                     'Priority associated with BladderCancer_Treatment'
+                     )
     }
 
     PROPERTIES = {
@@ -215,6 +227,11 @@ class BladderCancer(Module):
                     odds_ratio_health_seeking_in_adults=4.00,
                     no_healthcareseeking_in_children=True)
         )
+
+        #Overwrite with Health System's priority policy 
+        self.parameters['priority_BladderCancer_Investigation'] = self.sim.modules['HealthSystem'].get_priority_ranking('BladderCancer_Investigation')
+        self.parameters['priority_BladderCancer_PalliativeCare'] = self.sim.modules['HealthSystem'].get_priority_ranking('BladderCancer_PalliativeCare')
+        self.parameters['priority_BladderCancer_Treatment'] = self.sim.modules['HealthSystem'].get_priority_ranking('BladderCancer_Treatment')
 
     def initialise_population(self, population):
         """Set property values for the initial population."""
@@ -510,7 +527,7 @@ class BladderCancer(Module):
         for person_id in on_palliative_care_at_initiation:
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=HSI_BladderCancer_PalliativeCare(module=self, person_id=person_id),
-                priority=0,
+                priority=self.parameters['priority_BladderCancer_PalliativeCare'],
                 topen=self.sim.date + DateOffset(months=1),
                 tclose=self.sim.date + DateOffset(months=1) + DateOffset(weeks=1)
             )
@@ -694,7 +711,7 @@ class HSI_BladderCancer_Investigation_Following_Blood_Urine(HSI_Event, Individua
                         module=self.module,
                         person_id=person_id
                     ),
-                    priority=0,
+                    priority=self.module.parameters['priority_BladderCancer_Treatment'],
                     topen=self.sim.date,
                     tclose=None
                 )
@@ -706,7 +723,7 @@ class HSI_BladderCancer_Investigation_Following_Blood_Urine(HSI_Event, Individua
                         module=self.module,
                         person_id=person_id
                     ),
-                    priority=0,
+                    priority=self.module.parameters['priority_BladderCancer_PalliativeCare'],
                     topen=self.sim.date,
                     tclose=None
                 )
@@ -757,7 +774,7 @@ class HSI_BladderCancer_Investigation_Following_pelvic_pain(HSI_Event, Individua
                         module=self.module,
                         person_id=person_id
                     ),
-                    priority=0,
+                    priority=self.module.parameters['priority_BladderCancer_Treatment'],
                     topen=self.sim.date,
                     tclose=None
                 )
@@ -769,7 +786,7 @@ class HSI_BladderCancer_Investigation_Following_pelvic_pain(HSI_Event, Individua
                         module=self.module,
                         person_id=person_id
                     ),
-                    priority=0,
+                    priority=self.module.parameters['priority_BladderCancer_PalliativeCare'],
                     topen=self.sim.date,
                     tclose=None
                 )
@@ -808,7 +825,7 @@ class HSI_BladderCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin):
                 ),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_BladderCancer_PalliativeCare']
             )
             return self.make_appt_footprint({})
 
@@ -829,7 +846,8 @@ class HSI_BladderCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin):
             ),
             topen=self.sim.date + DateOffset(years=12),
             tclose=None,
-            priority=0
+            #This is post-treatment and not treatment, but adopting the same priority
+            priority=self.module.parameters['priority_BladderCancer_Treatment']
         )
 
 
@@ -869,7 +887,7 @@ class HSI_BladderCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMixin)
                 ),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_BladderCancer_PalliativeCare']
             )
 
         else:
@@ -881,7 +899,7 @@ class HSI_BladderCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMixin)
                 ),
                 topen=self.sim.date + DateOffset(years=1),
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_BladderCancer_Treatment']
             )
 
 
@@ -926,7 +944,7 @@ class HSI_BladderCancer_PalliativeCare(HSI_Event, IndividualScopeEventMixin):
             ),
             topen=self.sim.date + DateOffset(months=1),
             tclose=None,
-            priority=0
+            priority=self.module.parameters['priority_BladderCancer_PalliativeCare']
         )
 
 

--- a/src/tlo/methods/breast_cancer.py
+++ b/src/tlo/methods/breast_cancer.py
@@ -141,6 +141,18 @@ class BreastCancer(Module):
         "sensitivity_of_biopsy_for_stage4_breast_cancer": Parameter(
             Types.REAL, "sensitivity of biopsy_for diagnosis of stage 4 breast cancer"
         ),
+        'priority_BreastCancer_Investigation':
+            Parameter(Types.INT,
+                     'Priority associated with BreastCancer_Investigation'
+                     ),
+        'priority_BreastCancer_PalliativeCare':
+            Parameter(Types.INT,
+                     'Priority associated with BreastCancer_PalliativeCare'
+                     ),
+        'priority_BreastCancer_Treatment':
+            Parameter(Types.INT,
+                     'Priority associated with BreastCancer_Treatment'
+                     )
     }
 
     PROPERTIES = {
@@ -197,6 +209,13 @@ class BreastCancer(Module):
             Symptom(name='breast_lump_discernible',
                     odds_ratio_health_seeking_in_adults=4.00)
         )
+
+        #Overwrite with Health System's priority policy 
+        self.parameters['priority_BreastCancer_Investigation'] = self.sim.modules['HealthSystem'].get_priority_ranking('BreastCancer_Investigation')
+        self.parameters['priority_BreastCancer_PalliativeCare'] = self.sim.modules['HealthSystem'].get_priority_ranking('BreastCancer_PalliativeCare')
+        self.parameters['priority_BreastCancer_Treatment'] = self.sim.modules['HealthSystem'].get_priority_ranking('BreastCancer_Treatment')
+
+
 
     def initialise_population(self, population):
         """Set property values for the initial population."""
@@ -492,7 +511,7 @@ class BreastCancer(Module):
         for person_id in on_palliative_care_at_initiation:
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=HSI_BreastCancer_PalliativeCare(module=self, person_id=person_id),
-                priority=0,
+                priority=self.parameters['priority_BreastCancer_PalliativeCare'],
                 topen=self.sim.date + DateOffset(months=1),
                 tclose=self.sim.date + DateOffset(months=1) + DateOffset(weeks=1)
             )
@@ -687,7 +706,7 @@ class HSI_BreastCancer_Investigation_Following_breast_lump_discernible(HSI_Event
                         module=self.module,
                         person_id=person_id
                     ),
-                    priority=0,
+                    priority=self.module.parameters['priority_BreastCancer_Treatment'],
                     topen=self.sim.date,
                     tclose=None
                 )
@@ -699,7 +718,7 @@ class HSI_BreastCancer_Investigation_Following_breast_lump_discernible(HSI_Event
                         module=self.module,
                         person_id=person_id
                     ),
-                    priority=0,
+                    priority=self.module.parameters['priority_BreastCancer_PalliativeCare'],
                     topen=self.sim.date,
                     tclose=None
                 )
@@ -745,7 +764,7 @@ class HSI_BreastCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin):
                 ),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_BreastCancer_PalliativeCare'],
             )
             return self.make_appt_footprint({})
 
@@ -767,7 +786,7 @@ class HSI_BreastCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin):
             ),
             topen=self.sim.date + DateOffset(months=12),
             tclose=None,
-            priority=0
+            priority=self.module.parameters['priority_BreastCancer_Treatment'],
         )
 
 
@@ -807,7 +826,7 @@ class HSI_BreastCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMixin):
                 ),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_BreastCancer_PalliativeCare'],
             )
 
         else:
@@ -819,7 +838,7 @@ class HSI_BreastCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMixin):
                 ),
                 topen=self.sim.date + DateOffset(months=3),
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_BreastCancer_Treatment'],
             )
 
 
@@ -866,7 +885,7 @@ class HSI_BreastCancer_PalliativeCare(HSI_Event, IndividualScopeEventMixin):
             ),
             topen=self.sim.date + DateOffset(months=3),
             tclose=None,
-            priority=0
+            priority=self.module.parameters['priority_BreastCancer_PalliativeCare'],
         )
 
 

--- a/src/tlo/methods/contraception.py
+++ b/src/tlo/methods/contraception.py
@@ -88,7 +88,11 @@ class Contraception(Module):
 
         'max_days_delay_between_decision_to_change_method_and_hsi_scheduled': Parameter(
             Types.INT, "The maximum delay (in days) between the decision for a contraceptive to change and the `topen`"
-                       "date of the HSI that is scheduled to effect the change (when using the healthsystem),")
+                       "date of the HSI that is scheduled to effect the change (when using the healthsystem),"),
+        'priority_Contraception_Routine':
+            Parameter(Types.INT,
+                     'Priority associated with Contraception_Routine'
+                     ),
     }
 
     all_contraception_states = {
@@ -164,6 +168,10 @@ class Contraception(Module):
         # Import the Age-specific fertility rate data from WPP
         self.parameters['age_specific_fertility_rates'] = \
             pd.read_csv(Path(self.resourcefilepath) / 'demography' / 'ResourceFile_ASFR_WPP.csv')
+
+        #Get priority ranking from policy
+        self.parameters['priority_Contraception_Routine'] = self.sim.modules['HealthSystem'].get_priority_ranking('Contraception_Routine')
+
 
     def pre_initialise_population(self):
         """Process parameters before initialising population and simulation"""
@@ -556,7 +564,7 @@ class Contraception(Module):
                                      'max_days_delay_between_decision_to_change_method_and_hsi_scheduled'] + 1),
                         self.rng2),
                     tclose=None,
-                    priority=1
+                    priority=self.parameters['priority_Contraception_Routine']
                 )
             else:
                 # Otherwise, implement the change immediately:
@@ -978,7 +986,7 @@ class HSI_Contraception_FamilyPlanningAppt(HSI_Event, IndividualScopeEventMixin)
         self.module.sim.modules['HealthSystem'].schedule_hsi_event(hsi_event=self,
                                                                    topen=self.sim.date + pd.DateOffset(days=1),
                                                                    tclose=None,
-                                                                   priority=1)
+                                                                   priority=self.module.parameters['priority_Contraception_Routine'])
 
     def never_ran(self):
         """If this HSI never ran, the person defaults to "not_using" a contraceptive."""

--- a/src/tlo/methods/diarrhoea.py
+++ b/src/tlo/methods/diarrhoea.py
@@ -442,6 +442,14 @@ class Diarrhoea(Module):
         'rr_severe_dehydration_due_to_rotavirus_with_R1_over1yo':
             Parameter(Types.REAL,
                       'relative risk of severe dehydration with rotavirus vaccine, for those aged 1 year and older.'),
+        'priority_Diarrhoea_Treatment_Outpatient':
+            Parameter(Types.INT,
+                     'Priority associated with Diarrhoea_Treatment_Outpatient'
+                     ),
+        'priority_Diarrhoea_Treatment_Inpatient':
+            Parameter(Types.INT,
+                     'Priority associated with Diarrhoea_Treatment_Inpatient'
+                     ),
     }
 
     PROPERTIES = {
@@ -524,6 +532,11 @@ class Diarrhoea(Module):
             assert isinstance(p[param_name],
                               param_type.python_type), f'Parameter "{param_name}" is not read in correctly from the ' \
                                                        f'resourcefile.'
+
+        #Get priority ranking from policy
+        self.parameters['priority_Diarrhoea_Treatment_Inpatient'] = self.sim.modules['HealthSystem'].get_priority_ranking('Diarrhoea_Treatment_Inpatient')
+        self.parameters['priority_Diarrhoea_Treatment_Outpatient'] = self.sim.modules['HealthSystem'].get_priority_ranking('Diarrhoea_Treatment_Outpatient')
+
 
     def initialise_population(self, population):
         """
@@ -672,7 +685,7 @@ class Diarrhoea(Module):
                 HSI_Diarrhoea_Treatment_Inpatient(
                     person_id=person_id,
                     module=self),
-                priority=0,
+                priority=self.parameters['priority_Diarrhoea_Treatment_Inpatient'],
                 topen=self.sim.date,
                 tclose=None)
 
@@ -682,7 +695,7 @@ class Diarrhoea(Module):
                 HSI_Diarrhoea_Treatment_Outpatient(
                     person_id=person_id,
                     module=self),
-                priority=0,
+                priority=self.parameters['priority_Diarrhoea_Treatment_Outpatient'],
                 topen=self.sim.date,
                 tclose=None)
 

--- a/src/tlo/methods/epilepsy.py
+++ b/src/tlo/methods/epilepsy.py
@@ -93,6 +93,10 @@ class Epilepsy(Module):
         'daly_wt_epilepsy_seizure_free': Parameter(
             Types.REAL, 'disability weight for less severe epilepsy' 'controlled phase - code 862'
         ),
+        'priority_Epilepsy_Treatment':
+            Parameter(Types.INT,
+                     'Priority associated with Epilepsy_Treatment'
+                     ),
     }
 
     """
@@ -150,6 +154,9 @@ class Epilepsy(Module):
         # Register Symptom that this module will use
         self.sim.modules['SymptomManager'].register_symptom(
             Symptom("seizures", emergency_in_children=True, emergency_in_adults=True))
+
+        self.parameters['priority_Epilepsy_Treatment'] = self.sim.modules['HealthSystem'].get_priority_ranking('Epilepsy_Treatment')
+
 
     def initialise_population(self, population):
         """Set our property values for the initial population.
@@ -599,7 +606,7 @@ class HSI_Epilepsy_Start_Anti_Epileptic(HSI_Event, IndividualScopeEventMixin):
                 ),
                 topen=self.sim.date + DateOffset(months=3),
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_Epilepsy_Treatment']
             )
 
         else:
@@ -607,7 +614,7 @@ class HSI_Epilepsy_Start_Anti_Epileptic(HSI_Event, IndividualScopeEventMixin):
             self.module.sim.modules['HealthSystem'].schedule_hsi_event(hsi_event=self,
                                                                        topen=self.sim.date + pd.DateOffset(months=1),
                                                                        tclose=None,
-                                                                       priority=0)
+                                                                       priority=self.module.parameters['priority_Epilepsy_Treatment'])
 
 
 class HSI_Epilepsy_Follow_Up(HSI_Event, IndividualScopeEventMixin):
@@ -631,5 +638,5 @@ class HSI_Epilepsy_Follow_Up(HSI_Event, IndividualScopeEventMixin):
             hsi_event=self,
             topen=self.sim.date + DateOffset(months=3),
             tclose=None,
-            priority=0
+            priority=self.module.parameters['priority_Epilepsy_Treatment']
         )

--- a/src/tlo/methods/healthseekingbehaviour.py
+++ b/src/tlo/methods/healthseekingbehaviour.py
@@ -289,7 +289,7 @@ class HealthSeekingBehaviourPoll(RegularEvent, PopulationScopeEventMixin):
                 health_system.schedule_batch_of_individual_hsi_events(
                     hsi_event_class=emergency_hsi_event_class,
                     person_ids=subgroup[is_emergency_care_seeking].index,
-                    priority=0,
+                    priority=0,# Emergency care should be highest priority by definition
                     topen=self.sim.date,
                     tclose=None,
                     module=module
@@ -324,7 +324,7 @@ class HealthSeekingBehaviourPoll(RegularEvent, PopulationScopeEventMixin):
                 health_system.schedule_batch_of_individual_hsi_events(
                     hsi_event_class=routine_hsi_event_class,
                     person_ids=possibly_care_seeking_subgroup.index,
-                    priority=0,
+                    priority=0, # Care should be highest priority to satisfy "force" logic
                     topen=self.sim.date,
                     tclose=None,
                     module=module
@@ -359,7 +359,7 @@ class HealthSeekingBehaviourPoll(RegularEvent, PopulationScopeEventMixin):
                     health_system.schedule_batch_of_individual_hsi_events(
                         hsi_event_class=routine_hsi_event_class,
                         person_ids=care_seeking_ids,
-                        priority=0,
+                        priority=0, # What priority should be assigned to this?
                         topen=map(Date, care_seeking_dates),
                         tclose=None,
                         module=module

--- a/src/tlo/methods/hsi_generic_first_appts.py
+++ b/src/tlo/methods/hsi_generic_first_appts.py
@@ -115,7 +115,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                 HSI_Measles_Treatment(
                     person_id=person_id,
                     module=hsi_event.sim.modules['Measles']),
-                priority=0,
+                priority=sim.modules['Measles'].parameters['priority_Measles_Treatment'],
                 topen=hsi_event.sim.date,
                 tclose=None)
 
@@ -131,7 +131,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                 do_not_refer_if_neg=True),
             topen=hsi_event.sim.date,
             tclose=None,
-            priority=0)
+            priority=sim.modules['Hiv'].parameters['priority_Hiv_Test'])
 
     if 'injury' in symptoms:
         if 'RTI' in sim.modules:
@@ -162,7 +162,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                         HSI_Malaria_complicated_treatment_child(
                             person_id=person_id,
                             module=sim.modules["Malaria"]),
-                        priority=1,
+                        priority=sim.modules['Malaria'].parameters['priority_Malaria_Treatment_Complicated_Child'],
                         topen=sim.date,
                         tclose=None)
 
@@ -171,7 +171,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                         HSI_Malaria_non_complicated_treatment_age0_5(
                             person_id=person_id,
                             module=sim.modules["Malaria"]),
-                        priority=1,
+                        priority=sim.modules['Malaria'].parameters['priority_Malaria_Treatment_NotComplicated_Child'],
                         topen=sim.date,
                         tclose=None)
 
@@ -191,7 +191,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                     HSI_Malaria_complicated_treatment_child(
                         person_id=person_id,
                         module=sim.modules["Malaria"]),
-                    priority=1,
+                    priority=sim.modules["Malaria"].parameters['priority_Malaria_Treatment_Complicated_Child'],
                     topen=sim.date,
                     tclose=None)
 
@@ -200,7 +200,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                     HSI_Malaria_non_complicated_treatment_age5_15(
                         person_id=person_id,
                         module=sim.modules["Malaria"]),
-                    priority=1,
+                    priority=sim.modules["Malaria"].parameters['priority_Malaria_Treatment_NotComplicated_Child'],
                     topen=sim.date,
                     tclose=None)
 
@@ -213,7 +213,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                     HSI_OesophagealCancer_Investigation_Following_Dysphagia(
                         person_id=person_id,
                         module=sim.modules['OesophagealCancer']),
-                    priority=0,
+                    priority=sim.modules['OesophagealCancer'].parameters['priority_OesophagealCancer_Investigation'],
                     topen=sim.date,
                     tclose=None
                 )
@@ -225,7 +225,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                     HSI_BladderCancer_Investigation_Following_Blood_Urine(
                         person_id=person_id,
                         module=sim.modules['BladderCancer']),
-                    priority=0,
+                    priority=sim.modules['BladderCancer'].parameters['priority_BladderCancer_Investigation'],
                     topen=sim.date,
                     tclose=None
                 )
@@ -236,7 +236,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                     HSI_BladderCancer_Investigation_Following_pelvic_pain(
                         person_id=person_id,
                         module=sim.modules['BladderCancer']),
-                    priority=0,
+                    priority=sim.modules['BladderCancer'].parameters['priority_BladderCancer_Investigation'],
                     topen=sim.date,
                     tclose=None)
 
@@ -247,7 +247,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                     HSI_ProstateCancer_Investigation_Following_Urinary_Symptoms(
                         person_id=person_id,
                         module=sim.modules['ProstateCancer']),
-                    priority=0,
+                    priority=sim.modules['ProstateCancer'].parameters['priority_ProstateCancer_Investigation'],
                     topen=sim.date,
                     tclose=None)
 
@@ -256,7 +256,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                     HSI_ProstateCancer_Investigation_Following_Pelvic_Pain(
                         person_id=person_id,
                         module=sim.modules['ProstateCancer']),
-                    priority=0,
+                    priority=sim.modules['ProstateCancer'].parameters['priority_ProstateCancer_Investigation'],
                     topen=sim.date,
                     tclose=None)
 
@@ -267,7 +267,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                         person_id=person_id,
                         module=sim.modules['OtherAdultCancer']
                     ),
-                    priority=0,
+                    priority=sim.modules['OtherAdultCancer'].parameters['priority_OtherAdultCancer_Investigation'],
                     topen=sim.date,
                     tclose=None)
 
@@ -279,7 +279,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                         person_id=person_id,
                         module=sim.modules['BreastCancer'],
                     ),
-                    priority=0,
+                    priority=sim.modules['BreastCancer'].parameters['priority_BreastCancer_Investigation'],
                     topen=sim.date,
                     tclose=None)
 
@@ -300,7 +300,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                         HSI_Malaria_complicated_treatment_adult(
                             person_id=person_id,
                             module=sim.modules["Malaria"]),
-                        priority=1,
+                        priority=sim.modules["Malaria"].parameters['priority_Malaria_Treatment_Complicated_Adult'],
                         topen=sim.date,
                         tclose=None)
 
@@ -309,7 +309,7 @@ def do_at_generic_first_appt_non_emergency(hsi_event, squeeze_factor):
                         HSI_Malaria_non_complicated_treatment_adult(
                             person_id=person_id,
                             module=sim.modules["Malaria"]),
-                        priority=1,
+                        priority=sim.modules["Malaria"].parameters['priority_Malaria_Treatment_NotComplicated_Adult'],
                         topen=sim.date,
                         tclose=None)
 
@@ -337,14 +337,14 @@ def do_at_generic_first_appt_emergency(hsi_event, squeeze_factor):
         if df.at[person_id, 'ps_ectopic_pregnancy'] != 'none':
             event = HSI_CareOfWomenDuringPregnancy_TreatmentForEctopicPregnancy(
                 module=sim.modules['CareOfWomenDuringPregnancy'], person_id=person_id)
-            schedule_hsi(event, priority=0, topen=sim.date, tclose=sim.date + pd.DateOffset(days=1))
+            schedule_hsi(event, priority=sim.modules['CareOfWomenDuringPregnancy'].parameters['priority_AntenatalCare_PostEctopicPregnancy'], topen=sim.date, tclose=sim.date + pd.DateOffset(days=1))
 
         # -----  COMPLICATIONS OF ABORTION  -----
         abortion_complications = sim.modules['PregnancySupervisor'].abortion_complications
         if abortion_complications.has_any([person_id], 'sepsis', 'injury', 'haemorrhage', first=True):
             event = HSI_CareOfWomenDuringPregnancy_PostAbortionCaseManagement(
                 module=sim.modules['CareOfWomenDuringPregnancy'], person_id=person_id)
-            schedule_hsi(event, priority=0, topen=sim.date, tclose=sim.date + pd.DateOffset(days=1))
+            schedule_hsi(event, priority=sim.modules['CareOfWomenDuringPregnancy'].parameters['priority_AntenatalCare_PostAbortion'], topen=sim.date, tclose=sim.date + pd.DateOffset(days=1))
 
     if 'Labour' in sim.modules:
         mni = sim.modules['PregnancySupervisor'].mother_and_newborn_info
@@ -360,7 +360,7 @@ def do_at_generic_first_appt_emergency(hsi_event, squeeze_factor):
                 event = HSI_Labour_ReceivesSkilledBirthAttendanceDuringLabour(
                     module=sim.modules['Labour'], person_id=person_id,
                     facility_level_of_this_hsi=rng.choice(['1a', '1b']))
-                schedule_hsi(event, priority=0, topen=sim.date, tclose=sim.date + pd.DateOffset(days=1))
+                schedule_hsi(event, priority=sim.modules['Labour'].parameters['priority_DeliveryCare_Basic'], topen=sim.date, tclose=sim.date + pd.DateOffset(days=1))
 
     if "Depression" in sim.modules:
         if 'Injuries_From_Self_Harm' in symptoms:
@@ -372,7 +372,7 @@ def do_at_generic_first_appt_emergency(hsi_event, squeeze_factor):
             HSI_Hiv_TestAndRefer(person_id=person_id, module=sim.modules['Hiv']),
             topen=sim.date,
             tclose=None,
-            priority=0
+            priority=sim.modules['Hiv'].parameters['priority_Hiv_Test']
         )
 
     if "Malaria" in sim.modules:
@@ -400,15 +400,16 @@ def do_at_generic_first_appt_emergency(hsi_event, squeeze_factor):
                         hsi_event=HSI_Malaria_complicated_treatment_child(
                             sim.modules["Malaria"], person_id=person_id
                         ),
-                        priority=0,
+                        priority=sim.modules["Malaria"].parameters['priority_Malaria_Treatment_Complicated_Child'],
                         topen=sim.date,
                     )
+                #In malaria.py, priorised person 5-15 as child, but here looks like would be classified as adult?
                 else:
                     schedule_hsi(
                         hsi_event=HSI_Malaria_complicated_treatment_adult(
                             sim.modules["Malaria"], person_id=person_id
                         ),
-                        priority=0,
+                        priority=sim.modules["Malaria"].parameters['priority_Malaria_Treatment_Complicated_Adult'],
                         topen=sim.date,
                     )
 
@@ -420,7 +421,7 @@ def do_at_generic_first_appt_emergency(hsi_event, squeeze_factor):
         if 'seizures' in symptoms:
             schedule_hsi(HSI_Epilepsy_Start_Anti_Epileptic(person_id=person_id,
                                                            module=sim.modules['Epilepsy']),
-                         priority=0,
+                         priority= sim.modules['Epilepsy'].parameters['priority_Epilepsy_Treatment'],
                          topen=sim.date,
                          tclose=None)
 

--- a/src/tlo/methods/measles.py
+++ b/src/tlo/methods/measles.py
@@ -64,7 +64,12 @@ class Measles(Module):
         "symptom_prob": Parameter(
             Types.DATA_FRAME, "Probability of each symptom with measles infection"),
         "case_fatality_rate": Parameter(
-            Types.DICT, "Probability that case of measles will result in death if not treated")
+            Types.DICT, "Probability that case of measles will result in death if not treated"),
+        'priority_Measles_Treatment':
+            Parameter(Types.INT,
+                     'Priority associated with Measles_Treatment'
+                     ),
+
     }
 
     PROPERTIES = {
@@ -95,6 +100,10 @@ class Measles(Module):
     def read_parameters(self, data_folder):
         """Read parameter values from file
         """
+
+        #Get priority ranking from policy
+        self.parameters['priority_Measles_Treatment'] = self.sim.modules['HealthSystem'].get_priority_ranking('Measles_Treatment')
+
 
         workbook = pd.read_excel(
             os.path.join(self.resourcefilepath, "ResourceFile_Measles.xlsx"),

--- a/src/tlo/methods/oesophagealcancer.py
+++ b/src/tlo/methods/oesophagealcancer.py
@@ -172,6 +172,18 @@ class OesophagealCancer(Module):
         "sensitivity_of_endoscopy_for_oes_cancer_with_dysphagia": Parameter(
             Types.REAL, "sensitivity of endoscopy_for diagnosis of oesophageal cancer for those with dysphagia"
         ),
+        'priority_OesophagealCancer_Investigation':
+            Parameter(Types.INT,
+                     'Priority associated with OesophagealCancer_Investigation'
+                     ),
+        'priority_OesophagealCancer_PalliativeCare':
+            Parameter(Types.INT,
+                     'Priority associated with OesophagealCancer_PalliativeCare'
+                     ),
+        'priority_OesophagealCancer_Treatment':
+            Parameter(Types.INT,
+                     'Priority associated with OesophagealCancer_Treatment'
+                     ),
     }
 
     PROPERTIES = {
@@ -205,6 +217,7 @@ class OesophagealCancer(Module):
     }
 
     def read_parameters(self, data_folder):
+
         """Setup parameters used by the module, register it with healthsystem and register symptoms"""
         # Update parameters from the resourcefile
         self.load_parameters_from_dataframe(
@@ -217,6 +230,12 @@ class OesophagealCancer(Module):
             Symptom(name='dysphagia',
                     odds_ratio_health_seeking_in_adults=4.00)
         )
+
+        #Get priority ranking from policy
+        self.parameters['priority_OesophagealCancer_Investigation'] = self.sim.modules['HealthSystem'].get_priority_ranking('OesophagealCancer_Investigation')
+        self.parameters['priority_OesophagealCancer_PalliativeCare'] = self.sim.modules['HealthSystem'].get_priority_ranking('OesophagealCancer_PalliativeCare')
+        self.parameters['priority_OesophagealCancer_Treatment'] = self.sim.modules['HealthSystem'].get_priority_ranking('OesophagealCancer_Treatment')
+
 
     def initialise_population(self, population):
         """Set property values for the initial population."""
@@ -502,7 +521,7 @@ class OesophagealCancer(Module):
         for person_id in on_palliative_care_at_initiation:
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=HSI_OesophagealCancer_PalliativeCare(module=self, person_id=person_id),
-                priority=0,
+                priority=self.parameters['priority_OesophagealCancer_PalliativeCare'],
                 topen=self.sim.date + DateOffset(months=1),
                 tclose=self.sim.date + DateOffset(months=1) + DateOffset(weeks=1)
             )
@@ -680,7 +699,7 @@ class HSI_OesophagealCancer_Investigation_Following_Dysphagia(HSI_Event, Individ
                         module=self.module,
                         person_id=person_id
                     ),
-                    priority=0,
+                    priority=self.module.parameters['priority_OesophagealCancer_Treatment'],
                     topen=self.sim.date,
                     tclose=None
                 )
@@ -692,7 +711,7 @@ class HSI_OesophagealCancer_Investigation_Following_Dysphagia(HSI_Event, Individ
                         module=self.module,
                         person_id=person_id
                     ),
-                    priority=0,
+                    priority=self.module.parameters['priority_OesophagealCancer_PalliativeCare'],
                     topen=self.sim.date,
                     tclose=None
                 )
@@ -732,7 +751,7 @@ class HSI_OesophagealCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin)
                 ),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_OesophagealCancer_PalliativeCare'],
             )
             return self.make_appt_footprint({})
         # Check that the person has cancer, not in stage4, has been diagnosed and is not on treatment
@@ -752,7 +771,7 @@ class HSI_OesophagealCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin)
             ),
             topen=self.sim.date + DateOffset(years=12),
             tclose=None,
-            priority=0
+            priority=self.module.parameters['priority_OesophagealCancer_Treatment'],
         )
 
 
@@ -792,7 +811,7 @@ class HSI_OesophagealCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMi
                 ),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_OesophagealCancer_PalliativeCare'],
             )
 
         else:
@@ -804,7 +823,7 @@ class HSI_OesophagealCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMi
                 ),
                 topen=self.sim.date + DateOffset(years=1),
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_OesophagealCancer_Treatment']
             )
 
 
@@ -849,7 +868,7 @@ class HSI_OesophagealCancer_PalliativeCare(HSI_Event, IndividualScopeEventMixin)
             ),
             topen=self.sim.date + DateOffset(months=1),
             tclose=None,
-            priority=0
+            priority=self.module.parameters['priority_OesophagealCancer_PalliativeCare']
         )
 
 

--- a/src/tlo/methods/other_adult_cancers.py
+++ b/src/tlo/methods/other_adult_cancers.py
@@ -164,7 +164,19 @@ class OtherAdultCancer(Module):
         "sensitivity_of_diagnostic_device_for_other_adult_cancer_with_other_adult_ca_metastatic": Parameter(
             Types.REAL, "sensitivity of diagnostic_device_for diagnosis of other_adult cancer for those with "
                         "other_adult_ca metastatic"
-        )
+        ),
+        'priority_OtherAdultCancer_Investigation':
+            Parameter(Types.INT,
+                     'Priority associated with OtherAdultCancer_Investigation'
+                     ),
+        'priority_OtherAdultCancer_PalliativeCare':
+            Parameter(Types.INT,
+                     'Priority associated with OtherAdultCancer_PalliativeCare'
+                     ),
+        'priority_OtherAdultCancer_Treatment':
+            Parameter(Types.INT,
+                     'Priority associated with OtherAdultCancer_Treatment'
+                     ),
     }
 
     PROPERTIES = {
@@ -215,6 +227,11 @@ class OtherAdultCancer(Module):
                     odds_ratio_health_seeking_in_adults=4.00,
                     no_healthcareseeking_in_children=True)
         )
+
+        #Get priority ranking from policy
+        self.parameters['priority_OtherAdultCancer_Investigation'] = self.sim.modules['HealthSystem'].get_priority_ranking('OtherAdultCancer_Investigation')
+        self.parameters['priority_OtherAdultCancer_PalliativeCare'] = self.sim.modules['HealthSystem'].get_priority_ranking('OtherAdultCancer_PalliativeCare')
+        self.parameters['priority_OtherAdultCancer_Treatment'] = self.sim.modules['HealthSystem'].get_priority_ranking('OtherAdultCancer_Treatment')
 
     def initialise_population(self, population):
         """Set property values for the initial population."""
@@ -486,7 +503,7 @@ class OtherAdultCancer(Module):
         for person_id in on_palliative_care_at_initiation:
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=HSI_OtherAdultCancer_PalliativeCare(module=self, person_id=person_id),
-                priority=0,
+                priority=self.parameters['priority_OtherAdultCancer_PalliativeCare'],
                 topen=self.sim.date + DateOffset(months=1),
                 tclose=self.sim.date + DateOffset(months=1) + DateOffset(weeks=1)
             )
@@ -672,7 +689,7 @@ class HSI_OtherAdultCancer_Investigation_Following_early_other_adult_ca_symptom(
                         module=self.module,
                         person_id=person_id
                     ),
-                    priority=0,
+                    priority=self.module.parameters['priority_OtherAdultCancer_Treatment'],
                     topen=self.sim.date,
                     tclose=None
                 )
@@ -684,7 +701,7 @@ class HSI_OtherAdultCancer_Investigation_Following_early_other_adult_ca_symptom(
                         module=self.module,
                         person_id=person_id
                     ),
-                    priority=0,
+                    priority=self.module.parameters['priority_OtherAdultCancer_PalliativeCare'],
                     topen=self.sim.date,
                     tclose=None
                 )
@@ -723,7 +740,7 @@ class HSI_OtherAdultCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin):
                 ),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_OtherAdultCancer_PalliativeCare'],
             )
             return self.make_appt_footprint({})
         # Check that the person has cancer, not in metastatic, has been diagnosed and is not on treatment
@@ -743,7 +760,7 @@ class HSI_OtherAdultCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin):
             ),
             topen=self.sim.date + DateOffset(months=3),
             tclose=None,
-            priority=0
+            priority=self.module.parameters['priority_OtherAdultCancer_Treatment'],
         )
 
     def did_not_run(self):
@@ -786,7 +803,7 @@ class HSI_OtherAdultCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMix
                 ),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_OtherAdultCancer_PalliativeCare'],
             )
 
         else:
@@ -798,7 +815,7 @@ class HSI_OtherAdultCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMix
                 ),
                 topen=self.sim.date + DateOffset(months=3),
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_OtherAdultCancer_Treatment'],
             )
 
     def did_not_run(self):
@@ -847,7 +864,7 @@ class HSI_OtherAdultCancer_PalliativeCare(HSI_Event, IndividualScopeEventMixin):
             ),
             topen=self.sim.date + DateOffset(months=1),
             tclose=None,
-            priority=0
+            priority=self.module.parameters['priority_OtherAdultCancer_PalliativeCare'],
         )
 
     def did_not_run(self):

--- a/src/tlo/methods/pregnancy_supervisor.py
+++ b/src/tlo/methods/pregnancy_supervisor.py
@@ -893,7 +893,7 @@ class PregnancySupervisor(Module):
             first_anc_appt = HSI_CareOfWomenDuringPregnancy_FocusedANCVisit(
                 self.sim.modules['CareOfWomenDuringPregnancy'], person_id=individual_id, visit_number=1)
 
-        self.sim.modules['HealthSystem'].schedule_hsi_event(first_anc_appt, priority=0,
+        self.sim.modules['HealthSystem'].schedule_hsi_event(first_anc_appt, priority=self.sim.modules['CareOfWomenDuringPregnancy'].parameters['priority_AntenatalCare_Outpatient'],
                                                             topen=first_anc_date,
                                                             tclose=first_anc_date + DateOffset(days=1))
 
@@ -1495,7 +1495,7 @@ class PregnancySupervisor(Module):
             induction = HSI_CareOfWomenDuringPregnancy_PresentsForInductionOfLabour(
                 self.sim.modules['CareOfWomenDuringPregnancy'], person_id=person)
 
-            self.sim.modules['HealthSystem'].schedule_hsi_event(induction, priority=0,
+            self.sim.modules['HealthSystem'].schedule_hsi_event(induction, priority=self.sim.modules['CareOfWomenDuringPregnancy'].parameters['priority_AntenatalCare_Inpatient'],
                                                                 topen=self.sim.date,
                                                                 tclose=self.sim.date + DateOffset(days=1))
 
@@ -1540,7 +1540,7 @@ class PregnancySupervisor(Module):
                                                                   person_id=individual_id)
 
             self.sim.modules['HealthSystem'].schedule_hsi_event(event,
-                                                                priority=0,
+                                                                priority=0, # Scheduling emergency appointment, priority = 0 by definition
                                                                 topen=self.sim.date,
                                                                 tclose=self.sim.date + DateOffset(days=1))
             return True
@@ -1849,7 +1849,7 @@ class PregnancySupervisorEvent(RegularEvent, PopulationScopeEventMixin):
                 acute_pregnancy_hsi = HSI_CareOfWomenDuringPregnancy_MaternalEmergencyAssessment(
                     self.sim.modules['CareOfWomenDuringPregnancy'], person_id=person)
 
-                self.sim.modules['HealthSystem'].schedule_hsi_event(acute_pregnancy_hsi, priority=0,
+                self.sim.modules['HealthSystem'].schedule_hsi_event(acute_pregnancy_hsi, priority=self.sim.modules['CareOfWomenDuringPregnancy'].parameters['priority_AntenatalCare_Inpatient'],
                                                                     topen=self.sim.date,
                                                                     tclose=self.sim.date + DateOffset(days=1))
             else:

--- a/src/tlo/methods/prostate_cancer.py
+++ b/src/tlo/methods/prostate_cancer.py
@@ -144,6 +144,18 @@ class ProstateCancer(Module):
         "sensitivity_of_biopsy_for_prostate_ca": Parameter(
             Types.REAL, "sensitivity of biopsy for prostate cancer"
         ),
+        'priority_ProstateCancer_Investigation':
+            Parameter(Types.INT,
+                     'Priority associated with ProstateCancer_Investigation'
+                     ),
+        'priority_ProstateCancer_PalliativeCare':
+            Parameter(Types.INT,
+                     'Priority associated with ProstateCancer_PalliativeCare'
+                     ),
+        'priority_ProstateCancer_Treatment':
+            Parameter(Types.INT,
+                     'Priority associated with ProstateCancer_Treatment'
+                     ),
     }
 
     PROPERTIES = {
@@ -190,6 +202,11 @@ class ProstateCancer(Module):
     def read_parameters(self, data_folder):
         """Setup parameters used by the module, now including disability weights"""
 
+        #Get priority ranking from policy
+        self.parameters['priority_ProstateCancer_Investigation'] = self.sim.modules['HealthSystem'].get_priority_ranking('ProstateCancer_Investigation')
+        self.parameters['priority_ProstateCancer_PalliativeCare'] = self.sim.modules['HealthSystem'].get_priority_ranking('ProstateCancer_PalliativeCare')
+        self.parameters['priority_ProstateCancer_Treatment'] = self.sim.modules['HealthSystem'].get_priority_ranking('ProstateCancer_Treatment')
+        
         # Update parameters from the resourcefile
         self.load_parameters_from_dataframe(
             pd.read_excel(Path(self.resourcefilepath) / "ResourceFile_Prostate_Cancer.xlsx",
@@ -509,7 +526,7 @@ class ProstateCancer(Module):
         for person_id in on_palliative_care_at_initiation:
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=HSI_ProstateCancer_PalliativeCare(module=self, person_id=person_id),
-                priority=0,
+                priority=self.parameters['priority_ProstateCancer_PalliativeCare'],
                 topen=self.sim.date + DateOffset(months=1),
                 tclose=self.sim.date + DateOffset(months=1) + DateOffset(weeks=1)
             )
@@ -702,7 +719,7 @@ class HSI_ProstateCancer_Investigation_Following_Urinary_Symptoms(HSI_Event, Ind
                     module=self.module,
                     person_id=person_id
                 ),
-                priority=0,
+                priority=self.module.parameters['priority_ProstateCancer_Investigation'],
                 topen=self.sim.date,
                 tclose=None
             )
@@ -747,7 +764,7 @@ class HSI_ProstateCancer_Investigation_Following_Pelvic_Pain(HSI_Event, Individu
                         module=self.module,
                         person_id=person_id
                     ),
-                    priority=0,
+                    priority=self.module.parameters['priority_ProstateCancer_Investigation'],
                     topen=self.sim.date,
                     tclose=None
             )
@@ -798,7 +815,7 @@ class HSI_ProstateCancer_Investigation_Following_psa_positive(HSI_Event, Individ
                         module=self.module,
                         person_id=person_id
                     ),
-                    priority=0,
+                    priority=self.module.parameters['priority_ProstateCancer_Treatment'],
                     topen=self.sim.date,
                     tclose=None
                 )
@@ -809,7 +826,7 @@ class HSI_ProstateCancer_Investigation_Following_psa_positive(HSI_Event, Individ
                         module=self.module,
                         person_id=person_id
                     ),
-                    priority=0,
+                    priority=self.module.parameters['priority_ProstateCancer_PalliativeCare'],
                     topen=self.sim.date,
                     tclose=None
                 )
@@ -848,7 +865,7 @@ class HSI_ProstateCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin):
                 ),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_ProstateCancer_PalliativeCare'],
             )
             return self.make_appt_footprint({})
 
@@ -870,7 +887,7 @@ class HSI_ProstateCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin):
             ),
             topen=self.sim.date + DateOffset(months=12),
             tclose=None,
-            priority=0
+            priority=self.module.parameters['priority_ProstateCancer_Treatment'],
         )
 
 
@@ -910,7 +927,7 @@ class HSI_ProstateCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMixin
                 ),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_ProstateCancer_PalliativeCare']
             )
 
         else:
@@ -922,7 +939,7 @@ class HSI_ProstateCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMixin
                 ),
                 topen=self.sim.date + DateOffset(years=1),
                 tclose=None,
-                priority=0
+                priority=self.module.parameters['priority_ProstateCancer_Treatment']
             )
 
 
@@ -967,7 +984,7 @@ class HSI_ProstateCancer_PalliativeCare(HSI_Event, IndividualScopeEventMixin):
             ),
             topen=self.sim.date + DateOffset(months=1),
             tclose=None,
-            priority=0
+            priority=self.module.parameters['priority_ProstateCancer_PalliativeCare']
         )
 
 

--- a/src/tlo/methods/rti.py
+++ b/src/tlo/methods/rti.py
@@ -36,12 +36,12 @@ class RTI(Module):
         self.item_codes_for_consumables_required = dict()
 
     INIT_DEPENDENCIES = {"SymptomManager",
-                         "HealthBurden"}
+                         "HealthBurden",
+                         "HealthSystem"}
 
     ADDITIONAL_DEPENDENCIES = {
         'Demography',
         'Lifestyle',
-        'HealthSystem',
     }
 
     INJURY_INDICES = range(1, 9)
@@ -1008,7 +1008,51 @@ class RTI(Module):
             Types.INT,
             "A cut-off score above which an injuries will be considered severe enough to cause mortality in those who"
             "have not sought care."
-        )
+        ),
+        'priority_Rti_AcutePainManagement':
+            Parameter(Types.INT,
+                     'Priority associated with Rti_AcutePainManagement'
+                     ),
+        'priority_Rti_BurnManagement': 
+            Parameter(Types.INT, 
+                     'Priority associated with Rti_BurnManagement' 
+                     ), 
+        'priority_Rti_FractureCast': 
+            Parameter(Types.INT, 
+                     'Priority associated withRti_FractureCast ' 
+                     ), 
+        'priority_Rti_Imaging': 
+            Parameter(Types.INT, 
+                     'Priority associated with Rti_Imaging' 
+                     ), 
+        'priority_Rti_MajorSurgeries': 
+            Parameter(Types.INT, 
+                     'Priority associated with Rti_MajorSurgeries' 
+                     ), 
+        'priority_Rti_MedicalIntervention': 
+            Parameter(Types.INT, 
+                     'Priority associated with Rti_MedicalIntervention' 
+                     ), 
+        'priority_Rti_MinorSurgeries': 
+            Parameter(Types.INT, 
+                     'Priority associated with Rti_MinorSurgeries' 
+                     ), 
+        'priority_Rti_OpenFractureTreatment': 
+            Parameter(Types.INT, 
+                     'Priority associated with Rti_OpenFractureTreatment' 
+                     ), 
+        'priority_Rti_TetanusVaccine': 
+            Parameter(Types.INT, 
+                     'Priority associated with Rti_TetanusVaccine' 
+                     ), 
+        'priority_Rti_ShockTreatment': 
+            Parameter(Types.INT, 
+                     'Priority associated withRti_ShockTreatment ' 
+                     ), 
+        'priority_Rti_Suture': 
+            Parameter(Types.INT, 
+                     'Priority associated with Rti_Suture' 
+                     ), 
 
     }
 
@@ -1098,6 +1142,8 @@ class RTI(Module):
     def read_parameters(self, data_folder):
         """ Reads the parameters used in the RTI module"""
         p = self.parameters
+
+
 
         dfd = pd.read_excel(Path(self.resourcefilepath) / 'ResourceFile_RTI.xlsx', sheet_name='parameter_values')
         self.load_parameters_from_dataframe(dfd)
@@ -1432,6 +1478,20 @@ class RTI(Module):
         # ensure that these injuries are the permanent injuries
         assert non_zero_total_daly_change.to_list() == permanent_injuries
 
+        #Get priority ranking from policy
+        self.parameters['priority_Rti_BurnManagement'] = self.sim.modules['HealthSystem'].get_priority_ranking('Rti_BurnManagement')
+        self.parameters['priority_Rti_FractureCast'] = self.sim.modules['HealthSystem'].get_priority_ranking('Rti_FractureCast')
+        self.parameters['priority_Rti_Imaging'] = self.sim.modules['HealthSystem'].get_priority_ranking('Rti_Imaging')
+        self.parameters['priority_Rti_MajorSurgeries'] = self.sim.modules['HealthSystem'].get_priority_ranking('Rti_MajorSurgeries')
+        self.parameters['priority_Rti_MedicalIntervention'] = self.sim.modules['HealthSystem'].get_priority_ranking('Rti_MedicalIntervention')
+        self.parameters['priority_Rti_MinorSurgeries'] = self.sim.modules['HealthSystem'].get_priority_ranking('Rti_MinorSurgeries')
+        self.parameters['priority_Rti_OpenFractureTreatment'] = self.sim.modules['HealthSystem'].get_priority_ranking('Rti_OpenFractureTreatment')
+        self.parameters['priority_Rti_ShockTreatment'] = self.sim.modules['HealthSystem'].get_priority_ranking('Rti_ShockTreatment')
+        self.parameters['priority_Rti_Suture'] = self.sim.modules['HealthSystem'].get_priority_ranking('Rti_Suture')
+        self.parameters['priority_Rti_TetanusVaccine'] = self.sim.modules['HealthSystem'].get_priority_ranking('Rti_TetanusVaccine')
+        self.parameters['priority_Rti_AcutePainManagement'] = self.sim.modules['HealthSystem'].get_priority_ranking('Rti_AcutePainManagement')
+
+
     def rti_injury_diagnosis(self, person_id, the_appt_footprint):
         """
         A function used to alter the appointment footprint of the generic first appointments, based on the needs of
@@ -1551,7 +1611,7 @@ class RTI(Module):
         if counts > 0:
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=HSI_RTI_Medical_Intervention(module=self, person_id=person_id),
-                priority=0,
+                priority=self.parameters['priority_Rti_MedicalIntervention'],
                 topen=self.sim.date
             )
 
@@ -1622,7 +1682,7 @@ class RTI(Module):
                 self.sim.modules['HealthSystem'].schedule_hsi_event(
                     hsi_event=HSI_RTI_Major_Surgeries(module=self,
                                                       person_id=person_id),
-                    priority=0,
+                    priority=self.parameters['priority_Rti_MajorSurgeries'],
                     topen=self.sim.date + DateOffset(days=count),
                     tclose=self.sim.date + DateOffset(days=15))
             else:
@@ -1686,7 +1746,7 @@ class RTI(Module):
                 self.sim.modules['HealthSystem'].schedule_hsi_event(
                     hsi_event=HSI_RTI_Minor_Surgeries(module=self,
                                                       person_id=person_id),
-                    priority=0,
+                    priority=self.parameters['priority_Rti_MinorSurgeries'],
                     topen=self.sim.date + DateOffset(days=count),
                     tclose=self.sim.date + DateOffset(days=15))
             else:
@@ -1724,7 +1784,7 @@ class RTI(Module):
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=HSI_RTI_Acute_Pain_Management(module=self,
                                                         person_id=person_id),
-                priority=0,
+                priority=self.parameters['priority_Rti_AcutePainManagement'],
                 topen=self.sim.date + DateOffset(days=1),
                 tclose=self.sim.date + DateOffset(days=15))
 
@@ -1754,7 +1814,7 @@ class RTI(Module):
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=HSI_RTI_Suture(module=self,
                                          person_id=person_id),
-                priority=0,
+                priority=self.parameters['priority_Rti_Suture'],
                 topen=self.sim.date + DateOffset(days=1),
                 tclose=self.sim.date + DateOffset(days=15)
             )
@@ -1772,7 +1832,7 @@ class RTI(Module):
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=HSI_RTI_Shock_Treatment(module=self,
                                                   person_id=person_id),
-                priority=0,
+                priority=self.parameters['priority_Rti_ShockTreatment'],
                 topen=self.sim.date + DateOffset(days=1),
                 tclose=self.sim.date + DateOffset(days=15)
             )
@@ -1787,7 +1847,7 @@ class RTI(Module):
         if df.at[person_id, 'is_alive']:
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=HSI_RTI_Imaging_Event(module=self, person_id=person_id),
-                priority=0,
+                priority=self.parameters['priority_Rti_Imaging'],
                 topen=self.sim.date + DateOffset(days=1),
                 tclose=self.sim.date + DateOffset(days=15)
             )
@@ -1819,7 +1879,7 @@ class RTI(Module):
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=HSI_RTI_Burn_Management(module=self,
                                                   person_id=person_id),
-                priority=0,
+                priority=self.parameters['priority_Rti_BurnManagement'],
                 topen=self.sim.date + DateOffset(days=1),
                 tclose=self.sim.date + DateOffset(days=15)
             )
@@ -1856,7 +1916,7 @@ class RTI(Module):
                 self.sim.modules['HealthSystem'].schedule_hsi_event(
                     hsi_event=HSI_RTI_Fracture_Cast(module=self,
                                                     person_id=person_id),
-                    priority=0,
+                    priority=self.parameters['priority_Rti_FractureCast'],
                     topen=self.sim.date + DateOffset(days=1),
                     tclose=self.sim.date + DateOffset(days=15)
                 )
@@ -1894,7 +1954,7 @@ class RTI(Module):
                 # schedule the treatments, say the treatments occur a day apart for now
                 self.sim.modules['HealthSystem'].schedule_hsi_event(
                     hsi_event=HSI_RTI_Open_Fracture_Treatment(module=self, person_id=person_id),
-                    priority=0,
+                    priority=self.parameters['priority_Rti_OpenFractureTreatment'],
                     topen=self.sim.date + DateOffset(days=0 + i),
                     tclose=self.sim.date + DateOffset(days=15 + i)
                 )
@@ -1928,18 +1988,19 @@ class RTI(Module):
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=HSI_RTI_Tetanus_Vaccine(module=self,
                                                   person_id=person_id),
-                priority=0,
+                priority=self.parameters['priority_Rti_TetanusVaccine'],
                 topen=self.sim.date + DateOffset(days=1),
                 tclose=self.sim.date + DateOffset(days=15)
             )
 
-    def schedule_hsi_event_for_tomorrow(self, hsi_event: HSI_Event = None):
+    def schedule_hsi_event_for_tomorrow(self, hsi_event: HSI_Event = None,_priority=0):
         """
         A function to reschedule requested events for the following day if they have failed to run
         :return:
         """
+        print("The priority i will use is", _priority, hsi_event.TREATMENT_ID)
         self.sim.modules['HealthSystem'].schedule_hsi_event(hsi_event, topen=self.sim.date + DateOffset(days=1),
-                                                            tclose=self.sim.date + DateOffset(days=15), priority=0)
+                                                            tclose=self.sim.date + DateOffset(days=15), priority=_priority)
 
     def rti_find_injury_column(self, person_id, codes):
         """
@@ -3761,7 +3822,7 @@ class HSI_RTI_Shock_Treatment(HSI_Event, IndividualScopeEventMixin):
                          data=f"Hypovolemic shock treatment available for person {person_id}")
             df.at[person_id, 'rt_in_shock'] = False
         else:
-            self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self)
+            self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self, _priority=self.module.parameters['priority_Rti_ShockTreatment'])
             return self.make_appt_footprint({})
 
     def did_not_run(self):
@@ -3910,7 +3971,7 @@ class HSI_RTI_Fracture_Cast(HSI_Event, IndividualScopeEventMixin):
             df.loc[person_id, 'rt_injuries_to_cast'].clear()
             df.loc[person_id, 'rt_date_death_no_med'] = pd.NaT
         else:
-            self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self)
+            self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self, _priority=self.module.parameters['priority_Rti_FractureCast'])
             if pd.isnull(df.loc[person_id, 'rt_date_death_no_med']):
                 df.loc[person_id, 'rt_date_death_no_med'] = self.sim.date + DateOffset(days=7)
             logger.debug(key='rti_general_message',
@@ -4020,7 +4081,7 @@ class HSI_RTI_Open_Fracture_Treatment(HSI_Event, IndividualScopeEventMixin):
             if code[0] in df.loc[person_id, 'rt_injuries_for_open_fracture_treatment']:
                 df.loc[person_id, 'rt_injuries_for_open_fracture_treatment'].remove(code[0])
         else:
-            self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self)
+            self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self, _priority=self.module.parameters['priority_Rti_OpenFractureTreatment'])
             if pd.isnull(df.loc[person_id, 'rt_date_death_no_med']):
                 df.loc[person_id, 'rt_date_death_no_med'] = self.sim.date + DateOffset(days=7)
             logger.debug(key='rti_general_message',
@@ -4111,7 +4172,7 @@ class HSI_RTI_Suture(HSI_Event, IndividualScopeEventMixin):
                     assert df.loc[person_id, date_to_remove_daly_column] > self.sim.date
                 df.loc[person_id, 'rt_date_death_no_med'] = pd.NaT
             else:
-                self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self)
+                self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self, _priority=self.module.parameters['priority_Rti_Suture'])
                 if pd.isnull(df.loc[person_id, 'rt_date_death_no_med']):
                     df.loc[person_id, 'rt_date_death_no_med'] = self.sim.date + DateOffset(days=7)
                 logger.debug(key='rti_general_message',
@@ -4234,7 +4295,7 @@ class HSI_RTI_Burn_Management(HSI_Event, IndividualScopeEventMixin):
                 )
                 df.loc[person_id, 'rt_date_death_no_med'] = pd.NaT
             else:
-                self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self)
+                self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self, _priority=self.module.parameters['priority_Rti_BurnManagement'])
                 if pd.isnull(df.loc[person_id, 'rt_date_death_no_med']):
                     df.loc[person_id, 'rt_date_death_no_med'] = self.sim.date + DateOffset(days=7)
                 logger.debug(key='rti_general_message',
@@ -4292,7 +4353,7 @@ class HSI_RTI_Tetanus_Vaccine(HSI_Event, IndividualScopeEventMixin):
                 logger.debug(key='rti_general_message',
                              data=f"Tetanus vaccine requested for person {person_id} and given")
             else:
-                self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self)
+                self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self, _priority=self.module.parameters['priority_Rti_TetanusVaccine'])
                 logger.debug(key='rti_general_message',
                              data=f"Tetanus vaccine requested for person {person_id}, not given")
                 return self.make_appt_footprint({})
@@ -4433,7 +4494,7 @@ class HSI_RTI_Acute_Pain_Management(HSI_Event, IndividualScopeEventMixin):
                             data=dict_to_output,
                             description='Pain medicine successfully provided to the person')
             else:
-                self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self)
+                self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self, _priority=self.module.parameters['priority_Rti_AcutePainManagement'])
                 logger.debug(key='rti_general_message',
                              data=f"This facility has no pain management available for their mild pain, person "
                                   f"{person_id}.")
@@ -4464,7 +4525,8 @@ class HSI_RTI_Acute_Pain_Management(HSI_Event, IndividualScopeEventMixin):
                             data=dict_to_output,
                             description='Pain medicine successfully provided to the person')
             else:
-                self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self)
+                #Only have priority associated with Acute pain management, what should we use for moderate pain?
+                self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self, _priority=self.module.parameters['priority_Rti_AcutePainManagement'])
                 logger.debug(key='rti_general_message',
                              data=f"This facility has no pain management available for moderate pain for person "
                                   f"{person_id}.")
@@ -4496,7 +4558,7 @@ class HSI_RTI_Acute_Pain_Management(HSI_Event, IndividualScopeEventMixin):
                             data=dict_to_output,
                             description='Pain medicine successfully provided to the person')
             else:
-                self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self)
+                self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self, _priority=self.module.parameters['priority_Rti_AcutePainManagement'])
                 logger.debug(key='rti_general_message',
                              data=f"This facility has no pain management available for severe pain for person "
                                   f"{person_id}.")
@@ -4900,7 +4962,7 @@ class HSI_RTI_Major_Surgeries(HSI_Event, IndividualScopeEventMixin):
                 ['Treated injury code not removed', self.treated_code]
             df.loc[person_id, 'rt_date_death_no_med'] = pd.NaT
         else:
-            self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self)
+            self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self,_priority=self.module.parameters['priority_Rti_MajorSurgeries'])
             if pd.isnull(df.loc[person_id, 'rt_date_death_no_med']):
                 df.loc[person_id, 'rt_date_death_no_med'] = self.sim.date + DateOffset(days=7)
             return self.make_appt_footprint({})
@@ -5085,7 +5147,7 @@ class HSI_RTI_Minor_Surgeries(HSI_Event, IndividualScopeEventMixin):
                 ['Injury treated not removed', treated_code]
             df.loc[person_id, 'rt_date_death_no_med'] = pd.NaT
         else:
-            self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self)
+            self.sim.modules['RTI'].schedule_hsi_event_for_tomorrow(self, _priority=self.module.parameters['priority_Rti_MinorSurgeries'])
             if pd.isnull(df.loc[person_id, 'rt_date_death_no_med']):
                 df.loc[person_id, 'rt_date_death_no_med'] = self.sim.date + DateOffset(days=7)
             logger.debug(key='rti_general_message',

--- a/src/tlo/methods/stunting.py
+++ b/src/tlo/methods/stunting.py
@@ -125,6 +125,13 @@ class Stunting(Module):
         'prob_stunting_diagnosed_at_generic_appt': Parameter(
             Types.REAL,
             'Probability of a stunted or severely stunted person being checked and correctly diagnosed'),
+
+        'priority_Undernutrition_Feeding':
+            Parameter(Types.INT,
+                     'Priority associated with Undernutrition_Feeding'
+                     ),
+
+
     }
 
     PROPERTIES = {
@@ -147,6 +154,10 @@ class Stunting(Module):
             pd.read_excel(
                 Path(self.resourcefilepath) / 'ResourceFile_Stunting.xlsx', sheet_name='Parameter_values')
         )
+
+        #Get priority ranking from policy
+        self.parameters['priority_Undernutrition_Feeding'] = self.sim.modules['HealthSystem'].get_priority_ranking('Undernutrition_Feeding')
+
 
     def initialise_population(self, population):
         """Set initial prevalence of stunting according to distributions provided in parameters"""
@@ -288,7 +299,7 @@ class Stunting(Module):
         if p_stunting_diagnosed > self.rng.random_sample():
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=HSI_Stunting_ComplementaryFeeding(module=self, person_id=person_id),
-                priority=2,  # <-- lower priority that for wasting and most other HSI
+                priority=self.parameters['priority_Undernutrition_Feeding'],  # <-- lower priority that for wasting and most other HSI
                 topen=self.sim.date)
 
     def do_treatment(self, person_id, prob_success):
@@ -543,7 +554,7 @@ class HSI_Stunting_ComplementaryFeeding(HSI_Event, IndividualScopeEventMixin):
             # Schedule a further instance of this HSI for monitoring and resupply of consumables.
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 hsi_event=self,
-                priority=2,  # <-- lower priority that for wasting and most other HSI
+                priority=self.module.parameters['priority_Undernutrition_Feeding'],  # <-- lower priority that for wasting and most other HSI
                 topen=self.sim.date + pd.DateOffset(months=6)
             )
 

--- a/tests/test_cardiometabolicdisorders.py
+++ b/tests/test_cardiometabolicdisorders.py
@@ -281,14 +281,14 @@ def test_if_health_system_cannot_run(seed):
             'CardioMetabolicDisorders'], condition='diabetes'),
         topen=sim.date,
         tclose=sim.date + pd.DateOffset(days=1),
-        priority=0
+        priority=sim.modules['CardioMetabolicDisorders'].parameters['priority_CardioMetabolicDisorders_Prevention_WeightLoss']
     )
     sim.modules['HealthSystem'].schedule_hsi_event(
         HSI_CardioMetabolicDisorders_Refill_Medication(person_id=1, module=sim.modules['CardioMetabolicDisorders'],
                                                        condition='diabetes'),
         topen=sim.date,
         tclose=sim.date + pd.DateOffset(days=1),
-        priority=0
+        priority=sim.modules['CardioMetabolicDisorders'].parameters['priority_CardioMetabolicDisorders_Treatment']
     )
 
     # Run the HealthSystemScheduler for the days (the HSI should not be run and the never_run function should be called)

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -664,7 +664,7 @@ def test_all_appt_types_can_run(seed):
             hsi,
             topen=sim.date,
             tclose=sim.date + pd.DateOffset(days=1),
-            priority=1
+            priority=1 #Keep this hardcoded for test
         )
 
         healthsystemscheduler.apply(sim.population)
@@ -710,7 +710,7 @@ def test_two_loggers_in_healthsystem(seed, tmpdir):
             sim.modules['HealthSystem'].schedule_hsi_event(HSI_Dummy(self, person_id=0),
                                                            topen=self.sim.date,
                                                            tclose=None,
-                                                           priority=0)
+                                                           priority=0) #Keep priority 0 for dummy
 
     # Create a dummy HSI event:
     class HSI_Dummy(HSI_Event, IndividualScopeEventMixin):
@@ -729,7 +729,8 @@ def test_two_loggers_in_healthsystem(seed, tmpdir):
             sim.modules['HealthSystem'].schedule_hsi_event(self,
                                                            topen=self.sim.date + pd.DateOffset(days=3),
                                                            tclose=None,
-                                                           priority=0)
+                                                           priority=0) #Keep priority 0 for dummy
+
 
     # Set up simulation:
     sim = Simulation(start_date=start_date, seed=seed, log_config={
@@ -861,7 +862,7 @@ def test_summary_logger_generated_in_year_long_simulation(seed, tmpdir):
                 sim.modules['HealthSystem'].schedule_hsi_event(HSI_Dummy(self, person_id=0),
                                                                topen=self.sim.date,
                                                                tclose=None,
-                                                               priority=0)
+                                                               priority=0) #Keep priority 0 for dummy
 
         # Create a dummy HSI event:
         class HSI_Dummy(HSI_Event, IndividualScopeEventMixin):
@@ -880,7 +881,7 @@ def test_summary_logger_generated_in_year_long_simulation(seed, tmpdir):
                 sim.modules['HealthSystem'].schedule_hsi_event(self,
                                                                topen=self.sim.date + pd.DateOffset(days=3),
                                                                tclose=None,
-                                                               priority=0)
+                                                               priority=0) #Keep priority 0 for dummy
 
         # Set up simulation:
         sim = Simulation(start_date=start_date, seed=seed, log_config={
@@ -961,7 +962,7 @@ def test_HealthSystemChangeParameters(seed, tmpdir):
             sim.modules['HealthSystem'].schedule_hsi_event(self,
                                                            topen=self.sim.date + pd.DateOffset(days=1),
                                                            tclose=None,
-                                                           priority=0)
+                                                           priority=0) #Keep priority 0 for dummy
 
     class DummyModule(Module):
         METADATA = {Metadata.DISEASE_MODULE}
@@ -977,7 +978,7 @@ def test_HealthSystemChangeParameters(seed, tmpdir):
             sim.schedule_event(CheckHealthSystemParameters(self), sim.date)
             sim.schedule_event(HealthSystemChangeParameters(hs, parameters=new_parameters),
                                sim.date + pd.DateOffset(days=2))
-            sim.modules['HealthSystem'].schedule_hsi_event(HSI_Dummy(self, 0), topen=sim.date, tclose=None, priority=0)
+            sim.modules['HealthSystem'].schedule_hsi_event(HSI_Dummy(self, 0), topen=sim.date, tclose=None, priority=0) #Keep priority 0 for dummy
 
     sim = Simulation(start_date=start_date, seed=seed, log_config={
         'filename': 'tmpfile',
@@ -1158,7 +1159,7 @@ def test_hsi_run_on_same_day_if_scheduled_for_same_day(seed, tmpdir):
                 DummyHSI_To_Run_On_Same_Day(module=self.module, person_id=person_id, source='HSI'),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0)
+                priority=0) #Keep priority 0 for dummy
 
     class Event_To_Run_On_First_Day_Of_Simulation(Event, IndividualScopeEventMixin):
         def __init__(self, module, person_id):
@@ -1169,7 +1170,7 @@ def test_hsi_run_on_same_day_if_scheduled_for_same_day(seed, tmpdir):
                 DummyHSI_To_Run_On_Same_Day(module=self.module, person_id=person_id, source='Event'),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0)
+                priority=0) #Keep priority 0 for dummy
 
     class DummyModule(Module):
         """Schedules an HSI to occur on the first day of the simulation from initialise_simulation, and an event that
@@ -1187,14 +1188,14 @@ def test_hsi_run_on_same_day_if_scheduled_for_same_day(seed, tmpdir):
                 DummyHSI_To_Run_On_Same_Day(self, person_id=0, source='initialise_simulation'),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0)
+                priority=0) #Keep priority 0 for dummy
 
             # Schedule an HSI that will schedule a further HSI to run on the same day
             sim.modules['HealthSystem'].schedule_hsi_event(
                 DummyHSI_To_Run_On_First_Day_Of_Simulation(module=self, person_id=0),
                 topen=self.sim.date,
                 tclose=None,
-                priority=0)
+                priority=0) #Keep priority 0 for dummy
 
             # Schedule an event that will schedule an HSI to run on the same day
             sim.schedule_event(Event_To_Run_On_First_Day_Of_Simulation(self, person_id=0), sim.date)

--- a/tests/test_hiv.py
+++ b/tests/test_hiv.py
@@ -956,13 +956,13 @@ def test_hsi_art_stopped_if_healthsystem_cannot_run_hsi_and_no_restart(seed):
         HSI_Hiv_StartOrContinueTreatment(person_id=0, module=sim.modules['Hiv']),
         topen=sim.date,
         tclose=sim.date + pd.DateOffset(days=1),
-        priority=0
+        priority=sim.modules['Hiv'].parameters['priority_Hiv_Treatment']
     )
     sim.modules['HealthSystem'].schedule_hsi_event(
         HSI_Hiv_StartOrContinueTreatment(person_id=1, module=sim.modules['Hiv']),
         topen=sim.date,
         tclose=sim.date + pd.DateOffset(days=1),
-        priority=0
+        priority=sim.modules['Hiv'].parameters['priority_Hiv_Treatment']
     )
 
     # Run the HealthSystemScheduler for the days (the HSI should not be run and the never_run function should be called)
@@ -1052,13 +1052,13 @@ def test_hsi_art_stopped_if_healthsystem_cannot_run_hsi_but_will_restart(seed):
         HSI_Hiv_StartOrContinueTreatment(person_id=0, module=sim.modules['Hiv']),
         topen=sim.date,
         tclose=sim.date + pd.DateOffset(days=1),
-        priority=0
+        priority=sim.modules['Hiv'].parameters['priority_Hiv_Treatment']
     )
     sim.modules['HealthSystem'].schedule_hsi_event(
         HSI_Hiv_StartOrContinueTreatment(person_id=1, module=sim.modules['Hiv']),
         topen=sim.date,
         tclose=sim.date + pd.DateOffset(days=1),
-        priority=0
+        priority=sim.modules['Hiv'].parameters['priority_Hiv_Treatment']
     )
 
     # Run the HealthSystemScheduler for the days (the HSI should not be run and the never_run function should be called)

--- a/tests/test_rti.py
+++ b/tests/test_rti.py
@@ -115,7 +115,7 @@ def test_all_injuries_run(seed):
     for person_id in sim.population.props.index:
         sim.modules['HealthSystem'].schedule_hsi_event(
             hsi_event=HSI_GenericEmergencyFirstApptAtFacilityLevel1(module=sim.modules['RTI'], person_id=person_id),
-            priority=0,
+            priority=0, # keep priority=0 for emergency
             topen=sim.date
         )
     # run simulation
@@ -184,7 +184,7 @@ def test_all_injuries_run_no_healthsystem(seed):
     for person_id in sim.population.props.index:
         sim.modules['HealthSystem'].schedule_hsi_event(
             hsi_event=HSI_GenericEmergencyFirstApptAtFacilityLevel1(module=sim.modules['RTI'], person_id=person_id),
-            priority=0,
+            priority=0, #Keep priority=0 for emergency
             topen=sim.date
         )
     # run simulation

--- a/tests/test_tb.py
+++ b/tests/test_tb.py
@@ -192,7 +192,7 @@ def test_natural_history(seed):
         tb.HSI_Tb_ScreeningAndRefer(person_id=tb_case, module=sim.modules['Tb']),
         topen=sim.date,
         tclose=None,
-        priority=0
+        priority=sim.modules['Tb'].parameters['priority_Tb_Test_Screening']
     )
 
     # Check person_id has a ScreeningAndRefer event scheduled
@@ -446,7 +446,7 @@ def test_children_referrals(seed):
         tb.HSI_Tb_ScreeningAndRefer(person_id=person_id, module=sim.modules['Tb']),
         topen=sim.date,
         tclose=None,
-        priority=0
+        priority=sim.modules['Tb'].parameters['priority_Tb_Test_Screening']
     )
 
     hsi_event = tb.HSI_Tb_ScreeningAndRefer(person_id=person_id, module=sim.modules['Tb'])
@@ -464,7 +464,7 @@ def test_children_referrals(seed):
         tb.HSI_Tb_Xray_level1b(person_id=person_id, module=sim.modules['Tb']),
         topen=sim.date,
         tclose=None,
-        priority=0
+        priority=sim.modules['Tb'].parameters['priority_Tb_Test_Xray']
     )
 
     hsi_event = tb.HSI_Tb_Xray_level1b(person_id=person_id, module=sim.modules['Tb'])


### PR DESCRIPTION
This version allows us to consider a “Priority Ranking Policy”, which is now inputted to the simulation via the resources/healthsystem/ResourceFile_PriorityRanking.csv file, and stored in the HealthSystem’s “PriorityRank” parameter data frame. Each module then has its own priority parameters, which are initialised from the PriorityRank dataframe.

Motivation for this approach:
- Looking up these priority values only once will be a lot cheaper computationally than if e.g. the HealthSystem had to look up the priority based on the treatment_ID every time it schedules an event (although this would have been a lot simpler changes-wise).
- I similarly considered adding a “priority” parameter inside each HSI_event definition, so that the priority information could be passed implicitly to the scheduler, however I believe this would have significantly restricted our ability to address special cases (see Notes in the draft PR) and to potentially consider more complex ranking policies in the future;

Notes:
- Emergency appointments: the priority of HSI_GenericEmergencyFirstApptAtFacilityLevel1 is left as hardcoded at the highest possible priority (i.e. priority = 0) whenever it is invoked, to reflect the very definition of emergency. This is therefore currently outside of the policy.
- Special cases: (E.g. Hiv Tests for pregnant women/at-risk newborns/people with Tb) should these have a priority different from the one generally adopted for Hiv tests, to reflect the higher risk?
- Treatment_ID previously used with different priorities: Certain modules (e.g. alri) used different priorities for treatments that fall under the same TREATMENT_ID.  Do we want to allow the possibility of including relative priority within module? 
