### PR TITLE
update HSI Epilepsy_Treatment_Follow_Up to reduce too much use on OPD

### DIFF
--- a/src/tlo/methods/epilepsy.py
+++ b/src/tlo/methods/epilepsy.py
@@ -629,8 +629,8 @@ class HSI_Epilepsy_Follow_Up(HSI_Event, IndividualScopeEventMixin):
         # Schedule a reoccurrence of this follow-up in 3 months if ep_seiz_stat == '3',
         # else, schedule this reoccurrence of it in 1 year (i.e., if ep_seiz_stat == '2')
         hs.schedule_hsi_event(
-                hsi_event=self,
-                topen=self.sim.date + DateOffset(months=3 if df.at[person_id, 'ep_seiz_stat'] == '3' else 12),
-                tclose=None,
-                priority=0
+            hsi_event=self,
+            topen=self.sim.date + DateOffset(months=3 if df.at[person_id, 'ep_seiz_stat'] == '3' else 12),
+            tclose=None,
+            priority=0
         )


### PR DESCRIPTION
In this simple branch, we schedule the reoccurence of epilepsy treatment follow-up based on the patient's seizures status, and to reduce too much usage of OPD by this HSI.

The details of experiment and effect of this change can be found in branch #866. Plots are attached here.
Before the change:
![image](https://user-images.githubusercontent.com/86234515/225689893-35274fc3-65d3-4392-86be-478fc994305d.png)
![image](https://user-images.githubusercontent.com/86234515/225690009-999f8626-ea01-4b39-a1b0-d4933b6cfe55.png)
After the change:
![image](https://user-images.githubusercontent.com/86234515/225690145-2d770e52-94d6-49e6-9657-32450b561a4e.png)
![image](https://user-images.githubusercontent.com/86234515/225690213-4f9fbed4-cb6e-47a3-9455-494c2a157567.png)
