### PR TITLE
Updated neonatal PNC scheduling date to be one day later

### DIFF
--- a/src/tlo/methods/newborn_outcomes.py
+++ b/src/tlo/methods/newborn_outcomes.py
@@ -1080,8 +1080,8 @@ class NewbornOutcomes(Module):
 
             self.sim.modules['HealthSystem'].schedule_hsi_event(
                 early_event, priority=0,
-                topen=self.sim.date,
-                tclose=self.sim.date + pd.DateOffset(days=1))
+                topen=self.sim.date + pd.DateOffset(days=1),
+                tclose=self.sim.date + pd.DateOffset(days=2))
 
         else:
             # 'Late' PNC is scheduled in the postnatal supevervisor module


### PR DESCRIPTION
draft PR to check updates to neonatal scheduling, inline with conversations with @marghe-molaro, dont cause test failure (newborn_outcomes tests passing locally)