### PR TITLE
Use `loc` rather than `at` when setting multiple rows

### DIFF
--- a/src/tlo/methods/simplified_births.py
+++ b/src/tlo/methods/simplified_births.py
@@ -151,7 +151,7 @@ class SimplifiedBirths(Module):
                           'si_breastfeeding_status_6mo_to_23mo': breastfeeding_status_6mo_to_23mo,
                           }
                       }
-        df.at[child_id, properties.keys()] = properties.values()
+        df.loc[child_id, properties.keys()] = properties.values()
 
 
 class SimplifiedBirthsPoll(RegularEvent, PopulationScopeEventMixin):

--- a/tests/test_tb.py
+++ b/tests/test_tb.py
@@ -762,19 +762,19 @@ def test_active_tb_linear_model(seed):
     df = sim.population.props
 
     # set properties - no risk factors
-    df.at[df.is_alive, 'tb_inf'] = 'uninfected'
-    df.at[df.is_alive, 'age_years'] = 25
-    df.at[df.is_alive, 'va_bcg_all_doses'] = True
+    df.loc[df.is_alive, 'tb_inf'] = 'uninfected'
+    df.loc[df.is_alive, 'age_years'] = 25
+    df.loc[df.is_alive, 'va_bcg_all_doses'] = True
 
-    df.at[df.is_alive, 'li_bmi'] = 1  # 4=obese
-    df.at[df.is_alive, 'li_ex_alc'] = False
-    df.at[df.is_alive, 'li_tob'] = False
+    df.loc[df.is_alive, 'li_bmi'] = 1  # 4=obese
+    df.loc[df.is_alive, 'li_ex_alc'] = False
+    df.loc[df.is_alive, 'li_tob'] = False
 
-    df.at[df.is_alive, 'tb_on_ipt'] = False
+    df.loc[df.is_alive, 'tb_on_ipt'] = False
 
-    df.at[df.is_alive, 'hv_inf'] = False
-    df.at[df.is_alive, 'sy_aids_symptoms'] = 0
-    df.at[df.is_alive, 'hv_art'] = "not"
+    df.loc[df.is_alive, 'hv_inf'] = False
+    df.loc[df.is_alive, 'sy_aids_symptoms'] = 0
+    df.loc[df.is_alive, 'hv_art'] = "not"
 
     # no risk factors
     person_id0 = 0


### PR DESCRIPTION
Related to #900 and #901 - fixes some additional cases where instead of `at` accessor being used to set multiple columns it is being used to set multiple rows (which raises an error on Pandas v1.5.3 and v2.0.0rc1).