### PR TITLE
Avoid deprecated `closed` kwarg to `pandas.daterange`

### DIFF
--- a/tests/test_beddays.py
+++ b/tests/test_beddays.py
@@ -157,7 +157,13 @@ def test_bed_days_basics(tmpdir, seed):
     for bed_type in [f"bed_tracker_{bed}" for bed in hs.bed_days.bed_types]:
         # Check dates are as expected:
         dates_in_log = pd.to_datetime(log[bed_type]['date'])
-        date_range = pd.date_range(sim.start_date, sim.end_date, freq='D', inclusive='left')
+        # Default behaviour of date_range is to include both start and end date in range
+        # therefore offset end by minus one day to get all days up to but not including
+        # end date. closed / inclusive kwarg avoided here to keep compatibility across
+        # Pandas versions
+        date_range = pd.date_range(
+            sim.start_date, sim.end_date - pd.DateOffset(days=1), freq='D'
+        )
         assert set(date_range) == set(dates_in_log)
 
         # Check columns (for each facility_ID) are as expected:

--- a/tests/test_stunting.py
+++ b/tests/test_stunting.py
@@ -378,8 +378,11 @@ def test_math_of_incidence_calcs(seed):
     x = x0
 
     # Run polling event once per month for a year
+    # As default behaviour of date_range is to include both start and end dates in range
+    # we use an offset of 11 months so as not to also include date 12 months onwards
+    # closed / inclusive kwarg avoided here to keep compatibility across Pandas versions
     poll = stunting.StuntingPollingEvent(sim.modules['Stunting'])
-    for date in pd.date_range(Date(2010, 1, 1), sim.date + pd.DateOffset(years=1), freq='MS', inclusive='left'):
+    for date in pd.date_range(Date(2010, 1, 1), sim.date + pd.DateOffset(months=11), freq='MS'):
         # Do incidence of stunting through the model's polling event
         sim.date = date
         poll.apply(sim.population)


### PR DESCRIPTION
Would fix #893 ~~by swapping usages of `closed` kwarg in `pandas.date_range` for new `inclusive` kwarg however this is only available from Pandas v1.4.0 and so __this should only be merged as part of updating dependencies with Pandas >= 1.4.0__.~~

EDIT: Now updated to manually offset end dates by one step of range and use default behaviour of including both start and end dates in range (which is maintained across Pandas versions), to keep compatibility across Pandas versions.