### PR TITLE
Remove use of deprecated `inplace` kwarg in `set_axis`

### DIFF
--- a/src/tlo/methods/malaria.py
+++ b/src/tlo/methods/malaria.py
@@ -305,7 +305,7 @@ class Malaria(Module):
             # get the monthly incidence probabilities for these individuals
             monthly_prob = curr_inc.loc[district_age_lookup, _col]
             # update the index so it"s the same as the original population dataframe for these individuals
-            monthly_prob = monthly_prob.set_axis(df.index[_where], copy=True)
+            monthly_prob = monthly_prob.set_axis(df.index[_where])
             # select individuals for infection
             random_draw = rng.random_sample(_where.sum()) < monthly_prob
             selected = _where & random_draw


### PR DESCRIPTION
Would fix #894 ~~by changing usage of `inplace` kwarg in `pandas.Series.set_axis` for new `copy` kwarg however this is only available from Pandas v1.5.0 and so __this should only be merged as part of updating dependencies with Pandas >= 1.5.0__.~~

EDIT: As described in comment below current behaviour can be maintained just by removing use of deprecated `inplace` kwarg as value set to corresponds to default behaviour across Pandas versions.