### PR TITLE
Specify unit for `datetime64` dtype when passing to `pandas.Series.astype`

### DIFF
--- a/tests/test_logging_end_to_end.py
+++ b/tests/test_logging_end_to_end.py
@@ -35,7 +35,7 @@ def log_input():
     log_input.col4_cat = log_input.col4_cat.astype('category')
     log_input.col5_set = log_input.col5_set.apply(lambda x: eval(x))  # use python eval to create a column of sets
     log_input.col6_list = log_input.col6_list.apply(lambda x: eval(x))  # use python eval to create a column of lists
-    log_input.col7_date = log_input.col7_date.astype('datetime64')
+    log_input.col7_date = log_input.col7_date.astype('datetime64[ns]')
     log_input.col8_fixed_list = log_input.col8_fixed_list.apply(
         lambda x: eval(x))  # use python eval to create a column of lists
     return log_input
@@ -144,7 +144,7 @@ class TestWriteAndReadLog:
         # within nested dicts/entire df, need manual setting of special types
         log_output.col4_cat = log_output.col4_cat.astype('category')
         log_input.col5_set = log_input.col5_set.apply(list)
-        log_output.col7_date = log_output.col7_date.astype('datetime64')
+        log_output.col7_date = log_output.col7_date.astype('datetime64[ns]')
         # deal with index matching by resetting index
         log_output.reset_index(inplace=True, drop=True)
         expected_output = log_input.append(log_input, ignore_index=True)


### PR DESCRIPTION
Fixes #913 