### PR TITLE
Update expected error type for test with setting invalid category

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -18,6 +18,8 @@ def test_categorical():
     # assignment of valid category
     s[0] = 'M'
     # assignment of invalid category
+    # depending on Pandas version this may raise either a ValueError or TypeError so we
+    # allow both but also check exception message to minimize chance of false positives
     with pytest.raises(
         (ValueError, TypeError),
         match="Cannot setitem on a Categorical with a new category"


### PR DESCRIPTION
Fixes #915

Changes `test_categorical` in `tests/test_core.py` to check setting an invalid category in a categorical series raises either a `ValueError` (Pandas v1.2.2) or `TypeError` (Pandas v2.0.0), with the optional `match` kwarg to `pytest.raises` used to also check the error message to lessen the chance of picking up other errors of these types. Should be cross compatible with Pandas v1.2.2 and v2.0.0.