### PR TITLE
`long_run_all_diseases` to use `actual` HR scenario

### DIFF
--- a/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
+++ b/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
@@ -49,8 +49,10 @@ class LongRun(BaseScenario):
                      "spurious_symptoms": True
                  },
                  "HealthSystem": {
-                     "use_funded_or_actual_staffing": "actual",
+                     "use_funded_or_actual_staffing": "actual",  # actual, funded, funded_plus
+                     "mode_appt_constraints": 1  # 0, 1, 2
                  }
+            }
         )
 
     def draw_parameters(self, draw_number, rng):


### PR DESCRIPTION
Currently, the calibration target script (`long_run_all_diseases`) uses a version of the `HealthSystem` that has the `funded_plus` assumption for HR. This means we assume that  all funded healthcare worker positions in the systems are filled (and their district/facility_level allocation tweaked slightly to ensure that all appointments can run.)
But, for our calibration work, we wish to find a reasonable representation of the system as it is. Therefore, using the `actual` setting (wherein the allocation of healthcare workers is exactly as it appears to be per the available data) seems more appropriate.

N.B. This should not affect the calibration work being done by @BinglingICL, because we also use a mode of HR constraints (Mode 1) that means that appointments can run even when there is strictly "insufficient" healthcare worker time (which manifests as a squeeze-factor). But, it may have a small effect is some appointments are "impossible" under the actual scenario, and therefore do not run under any HR scenario. 

(Per this test: https://github.com/UCL/TLOmodel/blob/b8cf9f5b1cfa437f7e92925624386c37a880e21c/tests/test_healthsystem.py#L592
... only funded_plus guarantees that all appointment types will work at every facility level and in every district which they are defined.)

A run of `long_run_all_diseases` has been commission: job_id `long_run_all_diseases-2023-04-03T085441Z`

