### PR TITLE
Variable name "reduction_risk_of_death" may be confusing

### DIFF
--- a/src/tlo/methods/measles.py
+++ b/src/tlo/methods/measles.py
@@ -375,9 +375,14 @@ class MeaslesDeathEvent(Event, IndividualScopeEventMixin):
         if df.at[person_id, "me_has_measles"]:
 
             if df.at[person_id, "me_on_treatment"]:
-                reduction_in_death_risk = 0.4
-                p_death_with_treatment = 1. - reduction_in_death_risk  # Certain death (1) is reduced by specified amount
-                if self.module.rng.random_sample() < p_death_with_treatment:  # If below that probability, death goes ahead
+
+                reduction_in_death_risk = 0.6
+
+                # Certain death (100%) is reduced by specified amount
+                p_death_with_treatment = 1. - reduction_in_death_risk
+
+                # If below that probability, death goes ahead
+                if self.module.rng.random_sample() < p_death_with_treatment:
                     logger.debug(key="MeaslesDeathEvent",
                                  data=f"MeaslesDeathEvent: scheduling death for treated {person_id} on {self.sim.date}")
 


### PR DESCRIPTION
The current logic is such that if the variable "reduction_risk_of_death" is very small, there is a very small probability that the person will proceed to die despite receiving treatment. This would seem to be the opposite of the expected effect from a small reduction (since reduction = difference between the original probability (100%) and the new probability of death). If the variable "reduction_risk_of_death" is not a reduction, but the new probability of death, suggest renaming it something like "p_death_following_treatment", or calculating the latter from it, to avoid confusion. 