### PR TITLE
Fix incorrect usages of inclusive kwarg to `Series.between`

### DIFF
--- a/src/tlo/methods/stunting.py
+++ b/src/tlo/methods/stunting.py
@@ -324,6 +324,8 @@ class Models:
             ).when(
                 "1 <= age_exact_years < 2", p["base_inc_rate_stunting_by_agegp"][2]
             ).when(
+                "2 <= age_exact_years < 3", p["base_inc_rate_stunting_by_agegp"][3]
+            ).when(
                 "3 <= age_exact_years < 4", p["base_inc_rate_stunting_by_agegp"][4]
             ).when(
                 "4 <= age_exact_years < 5", p["base_inc_rate_stunting_by_agegp"][5]


### PR DESCRIPTION
Fixes #942 

Changes usages of `series.between(lower, upper, inclusive="left")` to `lower <= series < upper` which is the intended behaviour of the `between` usages, but as explained in #942 wasn't performing as expected.