### PR TITLE
Change usages of `datetime.date` to `tlo.Date` in lifestyle module

### DIFF
--- a/src/tlo/methods/enhanced_lifestyle.py
+++ b/src/tlo/methods/enhanced_lifestyle.py
@@ -2,7 +2,6 @@
 Lifestyle module
 Documentation: 04 - Methods Repository/Method_Lifestyle.xlsx
 """
-import datetime
 from pathlib import Path
 
 import numpy as np


### PR DESCRIPTION
`datetime.date` instances are being used in various places in `src/tlo/methods/enhanced_lifestyle.py` to set start dates of campaigns rather than `tlo.Date == pandas.Timestamp` instances, which I think is hitting against issue described in #934 and causing differences in population dataframe when simulating with Pandas v1.2.2 and v2.0.0 described in https://github.com/UCL/TLOmodel/issues/763#issuecomment-1512617008. Will re-run the `scale_run.py` simulations with this change to see if it removes differences in population dataframes and then report back.