### PR TITLE
Convert `Demography.AGE_RANGE_LOOKUP` to read-only mapping

### DIFF
--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -86,7 +86,7 @@ class Demography(Module):
         range_size=AGE_RANGE_SIZE)
 
     # Convert AGE_RANGE_LOOKUP to read-only mapping to avoid accidental updates
-    AGE_RANGE_LOOKUP = MappingProxyType(AGE_RANGE_LOOKUP)
+    AGE_RANGE_LOOKUP = MappingProxyType(dict(AGE_RANGE_LOOKUP))
 
     # We should have 21 age range categories
     assert len(AGE_RANGE_CATEGORIES) == 21


### PR DESCRIPTION
Fixes issue described in https://github.com/UCL/TLOmodel/issues/763#issuecomment-1515089200 which was causing intermittent failure of `tests/test_demography.py::test_py_calc` test under Pandas v2.0.0. 

Wraps the class attribute `AGE_RANGE_LOOKUP` of the `Demography` module, previously set to a `defaultdict` returned by the `create_age_range_lookup` function in `src/tlo/util.py`, in a read-only [`MappingProxyType`](https://docs.python.org/3/library/types.html#types.MappingProxyType). The `defaultdict` is first converted to a `dict` as otherwise the `MappingProxyType` will still use the underlying `defaultdict` for item access, which means the problem of accessing keys which are not present in the `defaultdict` adding new entries would remain.