### PR TITLE
increases `prop_smear_positive_hiv` in `test_tb.py::test_natural_history`

### DIFF
--- a/tests/test_tb.py
+++ b/tests/test_tb.py
@@ -154,6 +154,7 @@ def test_natural_history(seed):
     sim.modules['Tb'].parameters['scaling_factor_WHO'] = 50
     sim.modules["Tb"].parameters["rate_testing_active_tb"]["treatment_coverage"] = 100
     sim.modules['Tb'].parameters['prop_smear_positive'] = 1.0
+    sim.modules['Tb'].parameters['prop_smear_positive_hiv'] = 1.0
 
     # Make the population
     sim.make_initial_population(n=popsize)


### PR DESCRIPTION
In response to #836 increase probability of hiv+ active tb cases that will be smear-positive to 1 to ensure seed tests pass"