### PR TITLE
Modify symptom list assertion in `test_tb.py::test_natural_history`

### DIFF
--- a/tests/test_tb.py
+++ b/tests/test_tb.py
@@ -188,7 +188,7 @@ def test_natural_history(seed):
 
     # check for TB-related symptoms
     symptom_list = {"fever", "respiratory_symptoms", "fatigue", "night_sweats"}
-    assert (symptom in set(sim.modules['SymptomManager'].has_what(tb_case)) for symptom in symptom_list)
+    assert symptom_list.issubset(sim.modules['SymptomManager'].has_what(tb_case))
 
     # Check person_id has a ScreeningAndRefer event scheduled by TbActiveEvent
     date_event, event = [


### PR DESCRIPTION
This PR links to issue #952 . It modifies the assertion in line [191](https://github.com/UCL/TLOmodel/blob/02e17bd198773e2ee6fed55115e56b7c197ab633/tests/test_tb.py#L191) to check if TB-related symptoms are contained within `sim.modules['SymptomManager'].has_what(tb_case)` instead of asserting equality, to account for seed tests failing. 