### PR TITLE
Squeeze factor based on officer with largest time requirement for treatment

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -1292,11 +1292,7 @@ class HealthSystem(Module):
         for footprint in footprints_per_event:
             if len(footprint) > 0:
                 # If any of the required officers are not available at the facility, set overall squeeze to inf
-                require_missing_officer = False
-                for officer in footprint:
-                    if load_factor[officer] == float('inf'):
-                        require_missing_officer = True
-                        break
+                require_missing_officer = any([load_factor[officer] == float('inf') for officer in footprint])
 
                 if require_missing_officer:
                     squeeze_factor_per_hsi_event.append(float('inf'))


### PR DESCRIPTION
Previously, the squeeze factor for a given appointment was taken to be the largest one among those of the medical officers required for that particular treatment. In this PR, the squeeze factor is now taken to be the one of the medical officer most “necessary” for that treatment, where the latter is defined as the officer with the largest time requirement to see the treatment to completion.

Unfortunately most_common() throws a key error if the counter is empty, so the logic is a bit long-winded to side-step those cases. 