### PR TITLE
Remove `squeeze_factor` logic from `Depression`

### DIFF
--- a/src/tlo/methods/depression.py
+++ b/src/tlo/methods/depression.py
@@ -512,8 +512,7 @@ class Depression(Module):
         """
         df = self.sim.population.props
         if hsi_event.TREATMENT_ID == "FirstAttendance_NonEmergency":
-            if (squeeze_factor == 0.0) and (self.rng.rand() <
-                                            self.parameters['pr_assessed_for_depression_in_generic_appt_level1']):
+            if self.rng.rand() < self.parameters['pr_assessed_for_depression_in_generic_appt_level1']:
                 self.do_when_suspected_depression(person_id=person_id, hsi_event=hsi_event)
 
         elif hsi_event.TREATMENT_ID == "FirstAttendance_Emergency":


### PR DESCRIPTION
Removes a clause that the assesment for Depression  within a `FirstAttendance_NonEmergency` `HSI_Event` can only occur if `squeeze_factor == 0.0`. This is removed as we wish to control the effect of the `squeeze_factor` in a coordinated manner acorss the disease modules, and to be able to maximise the care that is intended to be provided, irrespective of prevailing levels of "squeeze".