### PR TITLE
Ignore `output` directory in root .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,4 +112,6 @@ docs/reference/tlo*.rst
 # TLO configuration
 tlo.conf
 
-
+# ignore all files in outputs directory, except README
+outputs/*
+!outputs/README

--- a/outputs/.gitignore
+++ b/outputs/.gitignore
@@ -1,4 +1,0 @@
-# Ignore all except gitignore
-*
-!.gitignore
-!README


### PR DESCRIPTION
Having two `.gitignore` files is unnecessary and can lead to output files being committed to repo if the output directory is accidentaly deleted. With this PR, all files in `outputs` (except README) are ignored if outputs directory deleted/created by user.