### PR TITLE
Improvement to `tlo batch-list` subcommand

### DIFF
--- a/src/tlo/cli.py
+++ b/src/tlo/cli.py
@@ -423,6 +423,14 @@ def batch_list(ctx, status, n, find, username):
     # sort by creation time
     jobs = jobs.sort_values("creation_time", ascending=False)
 
+    # split datetime into date and time
+    jobs["creation_time"] = pd.to_datetime(jobs.creation_time)
+    jobs["creation_date"] = jobs.creation_time.dt.date
+    jobs["creation_time"] = jobs.creation_time.dt.floor("S").dt.time
+
+    # reorder columns
+    jobs = jobs[["id", "creation_date", "creation_time", "state"]]
+
     # get the first n rows
     jobs = jobs.head(n)
 


### PR DESCRIPTION
- Display table of jobs
- List jobs ordered by creation time, descending.
- By default, only shows logged in user's jobs.

```
❯ tlo batch-list
Querying Batch...
                                                id               creation_time     state
          long_run_all_diseases-2023-07-13T100358Z  2023-07-13T10:03:59.52316Z completed
                 test_short_run-2023-06-26T082211Z 2023-06-26T08:22:16.988075Z completed
                 test_short_run-2023-06-26T080708Z 2023-06-26T08:07:16.668202Z completed
scenario_impact_of_healthsystem-2023-06-06T063118Z 2023-06-06T06:31:19.905089Z completed
          long_run_all_diseases-2023-06-01T153825Z 2023-06-01T15:38:26.615801Z completed
```

- Use `--username` to view other user's jobs.

```
❯ tlo batch-list --username sejjj49@ucl.ac.uk -n 10 --active
Querying Batch...
                                             id               creation_time  state
sba_min_sensitivity_analysis-2023-07-17T153657Z 2023-07-17T15:36:57.857086Z active
 perfect_bemonc_sba_scenario-2023-07-17T153554Z 2023-07-17T15:35:55.080851Z active
anc_min_sensitivity_scenario-2023-07-17T153518Z 2023-07-17T15:35:18.937866Z active
      increased_anc_scenario-2023-07-17T153335Z 2023-07-17T15:33:37.706374Z active

```

- `-n`, `--active`, `--completed`, `--find` options still supported

Fixes #434 