### PR TITLE
add malaria parameters to ideal health system and healthcare seeking list

### DIFF
--- a/resources/ResourceFile_Improved_Healthsystem_And_Healthcare_Seeking.xlsx
+++ b/resources/ResourceFile_Improved_Healthsystem_And_Healthcare_Seeking.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:952d406c22a72c72b08ed17fb732ab8df0325de048c0ff12c81a5e7420f32545
-size 48609
+oid sha256:e4d9c48c88403b1a45bd7c4f983b228c683ea2597a6a02fc2469d2ec955d8724
+size 48646


### PR DESCRIPTION
Following the update in PR #965, we now add three relevant malaria parameters to the list of ideal health system and healthcare seeking paramenter list:
(1) prob_malaria_case_tests: probability that a malaria case will have a scheduled rdt; default value=0.4
(2) rdt_testing_rates ( "Rate_rdt_testing" in the WHO_TestData2023 sheet): per capita rdt testing rate of general population; default values from 2010-2023 <0.65
(3) scaling_factor_for_rdt_availability: scaling factor applied to the reports of rdt usage to compensate for non-availability of rdts at some facilities, to adjust rdt_testing_rates; default value = 1.2.