### PR TITLE
Reduce testing of hypertension for persons without symptoms

### DIFF
--- a/resources/cmd/ResourceFile_cmd_condition_hsi.xlsx
+++ b/resources/cmd/ResourceFile_cmd_condition_hsi.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0bb1bde6812a2cc88f9616936c9c3cc5956af1570d3cd8c3d72e240fb21c6210
-size 14752
+oid sha256:3b96cf897a1be21fb8e9d407897a5f3676365d0fdfd3c049cb14c0941364729c
+size 14750


### PR DESCRIPTION
The parameter declared at `ResourceFile_cmd_condition_hsi.xlsx` --> `hypertension` --> `pr_assessed_other_symptoms`
 determines:
* whether, during `HSI_CardioMetabolicDisorders_Investigations` a person who is not being investigated _per se_ for hypertension but does have at least one CMD symptom, will ALSO receive a test for hypertension.
* whether, during, `HSI_CardioMetabolicDisorders_SeeksEmergencyCareAndGetsTreatment`, a person will have a test for hypertension.

In both cases, if the person is diagnosed to have hypertension, an event is scheduled: `HSI_CardioMetabolicDisorders_StartWeightLossAndMedication`.

The current value is 0.50 and the current calibration (when running `src/scripts/cardio_metabolic_disorders_analyses/cardiometabolicdisorders_plots.py`)  looks like this:

<img width="452" alt="image" src="https://github.com/UCL/TLOmodel/assets/39991060/32e2a611-a078-4ac9-b520-5dda5d894c16">


We wonder whether this value is too high, when we have noted that routine testing for hypertension in clinics is not done widely. 

It may be that _different_ values for this parameter should be used in `HSI_CardioMetabolicDisorders_SeeksEmergencyCareAndGetsTreatment` (a high value, as this is an emergency event) and  `HSI_CardioMetabolicDisorders_Investigations` (a lower value, as this is routine OPD care).

But, as a first step, we are trying here reducing this value to 0.05. The updated calibration looks like:

<img width="630" alt="image" src="https://github.com/UCL/TLOmodel/assets/39991060/aa849780-ced9-495e-b77a-26335743af8c">

Interesting it makes hardly any difference. I suppose this is because most people are diagnosed with hypertension through other means (i.e., through the event `HSI_CardioMetabolicDisorders_CommunityTestingForHypertension`, whereby persons aged 50+y  are randomly selected for hypertension screening. )


- [x] The other calibrations to incidence, prevalence and deaths due to CMD have also been confirmed not to have changed 
