### PR TITLE
Rename the scenario generated by `long_run_all_diseases.py`

### DIFF
--- a/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
+++ b/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
@@ -28,7 +28,7 @@ class LongRun(BaseScenario):
 
     def log_configuration(self):
         return {
-            'filename': 'long_run',  # <- (specified only for local running)
+            'filename': 'long_run_all_diseases',  # <- (specified only for local running)
             'directory': './outputs',  # <- (specified only for local running)
             'custom_levels': {
                 '*': logging.WARNING,


### PR DESCRIPTION
This will mean that the name of the results_folder will be the same as it was before #1052 (thus avoiding need for changes of other analysis files).