### PR TITLE
fix the low ratio of MentalAll usage

### DIFF
--- a/src/scripts/calibration_analyses/analysis_scripts/analysis_compare_appt_usage_real_and_simulation.py
+++ b/src/scripts/calibration_analyses/analysis_scripts/analysis_compare_appt_usage_real_and_simulation.py
@@ -276,8 +276,9 @@ def get_real_usage(resourcefilepath, adjusted=True) -> pd.DataFrame:
     # get facility_level for each record
     real_usage = real_usage.merge(mfl[['Facility_ID', 'Facility_Level']], left_on='Facility_ID', right_on='Facility_ID')
 
-    # adjust annual MentalAll usage using annual reporting rates if needed
-    # for now not adjust it considering very low reporting rates and better match with Model usage
+    # adjust annual MentalAll usage using annual reporting rates if needed,
+    # for now do not adjust it considering very low reporting rates of Mental Health report
+    # and better match with Model usage
     # if adjusted:
     #     real_usage = adjust_real_usage_on_mentalall(real_usage)
 


### PR DESCRIPTION
The latest MentalAll appt usage Mode/Data ratio is 0.4. This can be simply fixed if we do not adjust the Data, considering that the adjustment might be unreliable because of very low reporting rates of DHIS2 mental health reports. The improved ratio is 0.9, as detailed in commit https://github.com/UCL/TLOmodel/pull/436#issuecomment-1691347960.
