### PR TITLE
Safely catch HSIs with different officers required for actual_appt_footprint in mode_appt_constraints = 2

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -2456,7 +2456,14 @@ class HealthSystemScheduler(RegularEvent, PopulationScopeEventMixin):
                             # remove them from list of available officers.
                             for officer, call in updated_call.items():
                                 if capabilities_monitor[officer] <= 0:
-                                    set_capabilities_still_available.remove(officer)
+                                    if officer in set_capabilities_still_available:
+                                        set_capabilities_still_available.remove(officer)
+                                    else:
+                                        logger.warning(
+                                            key="message",
+                                            data=(f"{event.TREATMENT_ID} actual_footprint requires different"
+                                                  f"officers than expected_footprint.")
+                                        )
 
                             # Update today's footprint based on actuall call and squeeze factor
                             self.module.running_total_footprint -= original_call


### PR DESCRIPTION
Fixes https://github.com/UCL/TLOmodel/issues/1089


The HSI likely to have caused issue #1089 has been identified in issue #1090, and this is currently being addressed. However more HSIs - whether already in the code or introduced in the future by new modules - may similarly clash with mode_appt_constraints = 2 and lead to a KeyError if their actual_appt_footprint requires different medical officers than their expected one. Because this clash will only manifest itself under specific and random circumstances (i.e. all officers required for the expected_footprint still have capabilities but those for the actual_footprint do not), some such HSIs may go undetected for a long time. It would therefore be preferable to ensure that these can be safely identified in future runs in mode_appt_constraints = 2 without leading to error, but flagging the issue as a warning, as done in this PR. As the incidence of this error at present appears to be very low, this is unlikely to significantly affect results relying on this warning. 