### PR TITLE
Run profiling on comment-trigger, and cron

### DIFF
--- a/.github/workflows/run-on-comment.yml
+++ b/.github/workflows/run-on-comment.yml
@@ -195,6 +195,6 @@ jobs:
       if: "${{ inputs.artifact-path != '' }}"
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.artifact-tag }}
+        name: ${{ inputs.artifact-name }}
         path: ${{ inputs.artifact-path }}
-        retention-days: ${{ inputs.artifact-days }}
+        retention-days: ${{ inputs.artifact-retention-days }}

--- a/.github/workflows/run-profiling.yaml
+++ b/.github/workflows/run-profiling.yaml
@@ -32,10 +32,10 @@ jobs:
     name: Create unique output file identifier and artifact name
     runs-on: ubuntu-latest
     outputs:
-      profiling-filename: ${{ steps.set-output-id.outputs.name }}
+      profiling-filename: ${{ steps.set-profiling-filename.outputs.name }}
       artifact-name: $${{ steps.set-artifact-name.outputs.name }}
     steps:
-      - id: set-output-id
+      - id: set-profiling-filename
         name: Set profiling output file name
         run: |
           echo "name=${GITHUB_EVENT_NAME}_${GITHUB_RUN_NUMBER}_${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Updates the profiling workflow to:
- Run as a `cron` job once a week (Sundays at 00:00).
- Be triggered by comments on pull-requests.

Updates the `run-on-comment` workflow:
- Can be optionally passed a directory and tag to upload as an artifact after the run completes.

## Comment Triggering

Profiling can be triggered by commenting on a PR with
```
/run profiling
```
provided the commenting user has the necessary permissions to trigger a workflow run.

Our current comment-triggered workflow was only capable of running `shell` commands, and for the profiling runs we needed to trigger a workflow (since running the profiling alone is not enough, as we need to export and upload the artifacts). 

The solution suggested below is to adapt `run-on-comment` to allow export of an artifact. This means that, on comment-triggered runs we perform the `profile-on-comment` job, which passes the shell commands needed to trigger profiling to the `run-on-comment` workflow and requests an artifact to be produced with the profiling results. Conversely on workflows not triggered by comments, we can just run an alternative job (`profile-on-dispatch`) with the profiling commands and then upload an artifact with the same naming convention. The workflow will then check that at least one of `profile-on-comment` or `profile-on-dispatch` succeeded, and then push the results to the profiling repository and trigger a rebuild of the results website.