### PR TITLE
Update secret name to match envrionment variable

### DIFF
--- a/.github/workflows/run-profiling.yaml
+++ b/.github/workflows/run-profiling.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Push results to profiling repository
         uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
         env:
-          API_TOKEN_GITHUB: ${{ secrets.PROFILING_ACCESS_TOKEN }}
+          API_TOKEN_GITHUB: ${{ secrets.PROFILING_REPO_ACCESS }}
         with:
           source_file: profiling_results/
           destination_repo: UCL/TLOmodel-profiling
@@ -62,6 +62,6 @@ jobs:
       - name: Trigger website rebuild
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.PROFILING_ACCESS_TOKEN }}
+          token: ${{ secrets.PROFILING_REPO_ACCESS }}
           repository: UCL/TLOmodel-profiling
           event-type: new-profiling-results


### PR DESCRIPTION
The token for pushing profiling results to the TLOmodel-profiling repository is under a different name to that which is passed in the workflow (see [this action](https://github.com/UCL/TLOmodel/actions/runs/6158351962))

This update fixes this.