### PR TITLE
Revert temporary fix

### DIFF
--- a/resources/ResourceFile_ContraceptionParams.csv
+++ b/resources/ResourceFile_ContraceptionParams.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8bbfc0627cd853dee7b038f058676a2ff37144b5562685619efd79f196d63f7a
-size 630
+oid sha256:14205ecc544760aebeff19cdcd23f9a8a3df653b293e1186f48fe17206556069
+size 620

--- a/src/tlo/methods/contraception.py
+++ b/src/tlo/methods/contraception.py
@@ -96,11 +96,9 @@ class Contraception(Module):
             Types.INT, "The maximum delay (in days) between the decision for a contraceptive to change and the `topen` "
                        "date of the HSI that is scheduled to effect the change (when using the healthsystem)."),
 
-        # TODO: needs to be fixed to be BOOL parameter (together with resolving the temporary fix below)
         'use_interventions': Parameter(
-            Types.STRING, "if 'On': FP interventions (pop & ppfp) are simulated since 'interventions_start_date',"
-                          " if 'Off': FP interventions (pop & ppfp) are not simulated."),
-
+            Types.BOOL, "if True: FP interventions (pop & ppfp) are simulated from the date 'interventions_start_date',"
+                        " if False: FP interventions (pop & ppfp) are not simulated."),
         'interventions_start_date': Parameter(
             Types.DATE, "The date since which the FP interventions (pop & ppfp) are implemented, if at all (ie, if "
                         "use_interventions==True")
@@ -192,24 +190,6 @@ class Contraception(Module):
         self.load_parameters_from_dataframe(pd.read_csv(
             Path(self.resourcefilepath) / 'ResourceFile_ContraceptionParams.csv'
         ))
-
-        # Temporary fix of loading the boolean  parameter 'use_interventions':
-        co_params = pd.read_csv(
-            Path(self.resourcefilepath) / 'ResourceFile_ContraceptionParams.csv'
-        )
-        self.parameters['use_interventions_loaded'] =\
-            co_params['value'].loc[co_params['parameter_name'] == 'use_interventions'].values[0]
-        self.parameters['use_interventions'] = self.parameters['use_interventions_loaded'] == 'On'
-        if self.parameters['use_interventions_loaded'] not in ('On', 'Off'):
-            warnings.warn(UserWarning(f"'use_intervention' parameter set to 'Off' (=False) as the given value "
-                                      f"{self.parameters['use_interventions_loaded']} was not recognised."))
-            logger.info(
-                key="use_intervention",
-                data={"input_given": self.parameters['use_interventions_loaded'],
-                      "value_used": self.parameters['use_interventions']
-                      },
-                description='Unrecognised value given for use_intervention parameter replaced.'
-            )
 
         # Import the Age-specific fertility rate data from WPP
         self.parameters['age_specific_fertility_rates'] = \


### PR DESCRIPTION
Temporary fix done to overcome issue #1070 until it's resolved.

Now resolved in the PR #1071, hence the temporary fix is reversed here.
NB. the change in RF_ContraceptionParams.csv: `use_interventions,Off,On / Off` -> `use_interventions,0,`

TODO: @tbhallett also mentioned the same issue was found in the HealthSytem updates in PR #986. I guess there might also be a temporary fix that now requires a rollback?