### PR TITLE
Add concurrency group to CI.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # master branch will be allowed to have pending jobs
   # https://stackoverflow.com/questions/68418857/how-to-cancel-existing-runs-when-a-new-push-happens-on-github-actions-but-only
-  cancel-in-progress: ${{ github.ref }} != 'refs/heads/master'
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
   LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # master branch will be allowed to have pending jobs
   # https://stackoverflow.com/questions/68418857/how-to-cancel-existing-runs-when-a-new-push-happens-on-github-actions-but-only
-  cancel-in-progress: $${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref }} != 'refs/heads/master'
 
 env:
   LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
   schedule:
     - cron: 0 0 * * *
 
+# Force cancellation of in-progress workflows if changes are made to
+# the HEAD of the branch the workflow is currently running on.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so
   SEGFAULT_SIGNALS: all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # master branch will be allowed to have pending jobs
-  # https://stackoverflow.com/questions/68418857/how-to-cancel-existing-runs-when-a-new-push-happens-on-github-actions-but-only
+  # https://stackoverflow.com/a/70972844
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ on:
 # the HEAD of the branch the workflow is currently running on.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # master branch will be allowed to have pending jobs
+  # https://stackoverflow.com/questions/68418857/how-to-cancel-existing-runs-when-a-new-push-happens-on-github-actions-but-only
+  cancel-in-progress: $${{ github.ref != 'refs/heads/master' }}
 
 env:
   LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so


### PR DESCRIPTION
Adds a concurrency group to the main `CI.yaml` workflow.

This will cancel an in-progress workflow run if the same workflow is requested on a more up to date version of a branch. Particularly handy for when updates to PRs come in.