### PR TITLE
Change `||` to `&&` in `run-profiling`

### DIFF
--- a/.github/workflows/run-profiling.yaml
+++ b/.github/workflows/run-profiling.yaml
@@ -101,7 +101,7 @@ jobs:
     if: |
       always() && (
         (needs.profile-on-comment.result == 'success' && needs.profile-on-dispatch.result == 'skipped') ||
-        (needs.profile-on-comment.result == 'skipped' || needs.profile-on-dispatch.result == 'success')
+        (needs.profile-on-comment.result == 'skipped' && needs.profile-on-dispatch.result == 'success')
       )
     steps:
       - name: Download the profiling results


### PR DESCRIPTION
Another logic twist that slipped under the radar. Although the "failed workflow" does at least indicate that the hack we're using is working properly!

This error is setting off a bunch of failing workflows though :sweat_smile: 