### PR TITLE
Move CI jobs to separate workflows + add paths filters

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,4 +38,4 @@ jobs:
       - name: Install tox
         run: python -m pip install tox
       - name: Run checks with tox
-        run: tox -v -e checks
+        run: tox -v -e check

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,41 @@
+name: Checks
+
+on:
+  push:
+    branches: "master"
+    tags: ["*"]
+  pull_request:
+  schedule:
+    - cron: 0 0 * * *
+
+# Force cancellation of in-progress workflows if changes are made to
+# the HEAD of the branch the workflow is currently running on.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # master branch will be allowed to have pending jobs
+  # https://stackoverflow.com/a/70972844
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+        
+  check:
+    name: Run checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+      - name: Cache tox
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{hashFiles('requirements/*.txt', 'tox.ini')}}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Run checks with tox
+        run: tox -v -e checks

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,49 @@
+name: Documentation
+
+on:
+  push:
+    branches: "master"
+    tags: ["*"]
+  pull_request:
+    paths:
+      - .github/workflows/docs.yaml
+      - docs/**
+      - requirements/**
+      - src/tlo/**
+      - README.rst
+      - setup.*
+      - tox.ini
+  schedule:
+    - cron: 0 0 * * *
+
+# Force cancellation of in-progress workflows if changes are made to
+# the HEAD of the branch the workflow is currently running on.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # master branch will be allowed to have pending jobs
+  # https://stackoverflow.com/a/70972844
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  
+jobs:
+
+  build-docs:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+      - name: Cache tox
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{hashFiles('requirements/*.txt', 'tox.ini')}}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Build HTML documentation with tox
+        run: tox -v -e docs

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          lfs: false
+          lfs: true
       - name: Cache tox
         uses: actions/cache@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
     tags: ["*"]
   pull_request:
     paths:
-      - .github/workflows/docs.yaml
+      - .github/workflows/docs.yml
       - docs/**
       - requirements/**
       - src/tlo/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
     tags: ["*"]
   pull_request:
     paths:
-      - .github/workflows/tests.yaml
+      - .github/workflows/tests.yml
       - requirements/**
       - resources/**
       - src/tlo/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,18 @@
-name: CI
+name: Tests
 
 on:
   push:
     branches: "master"
     tags: ["*"]
   pull_request:
+    paths:
+      - .github/workflows/tests.yaml
+      - requirements/**
+      - resources/**
+      - src/tlo/**
+      - tests/**
+      - setup.*
+      - tox.ini
   schedule:
     - cron: 0 0 * * *
 
@@ -24,16 +32,14 @@ jobs:
 
   gen-test-matrix:
     name: Find test files
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-    strategy:
-      fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          lfs: true
+          # No tests should be under LFS so no need to fetch LFS files
+          lfs: false
       - id: set-matrix
         name: Set matrix
         run: |
@@ -49,14 +55,13 @@ jobs:
 
   test:
     needs: gen-test-matrix
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: Test ${{ matrix.file }}
     runs-on: [self-hosted]
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.gen-test-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
       - name: System info
@@ -71,47 +76,3 @@ jobs:
       - name: Test with tox
         run: |
           tox -v -e py38,report -- pytest --cov --cov-report=term-missing -vv "${{ matrix.file }}"
-
-  check:
-    name: Checks
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    runs-on: [self-hosted]
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: System info
-        run: |
-          set -x
-          python --version
-          uname -a
-          lsb_release -a
-          virtualenv --version
-          pip --version
-          tox --version
-      - name: Run checks
-        run: tox -v -e check
-
-  docs:
-    name: Documentation
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    runs-on: [self-hosted]
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: System info
-        run: |
-          set -x
-          python --version
-          uname -a
-          lsb_release -a
-          virtualenv --version
-          pip --version
-          tox --version
-      - name: Build documentation
-        run: tox -v -e docs


### PR DESCRIPTION
Would fix #1122

Not entirely sure if this is worthwhile, but thought I'd put out there for discussion!

This PR separates the existing `.github/workflows/CI.yml` workflow file into three separate workflows `.github/workflows/tests.yaml`, `.github/workflows/docs.yaml` and `.github/workflows/checks.yaml`, corresponding respectively to the test (find tests + test <file> matrix job), documentation and checks jobs in the existing single workflow. This allows differentiating the `on` triggers for each workflow, with in particular [a `on.pull_request.paths` key](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) added for the tests and documentation workflows to only run the jobs when files are updated in a PR which will lead to changes in the job status. The checks workflow is continued to be run for all pull request triggers without filtering on the basis that one of the checks is checking the manifest against the checked out repository which potentially is affected by changes to any files and also that this job is quick to run so limited gain to be had  from running selectively.

As there is currently a branch protection rule set up on `master` which requests the `Find tests files` step in the current `CI.yml` file to be run before merging is allowed (as well as the checks job) this would need to be updated if this was to be merged, as the tests workflow would by design not run for all PRs.

The PR also switches to using GitHub hosted test runners for all jobs other that the matrix job in which tests are run, on the basis that this is where the self-hosted runners provide most value, and running the other jobs on GitHub runners means they won't be competing with the long running tests. 

I've also changed to only fetch Git-LFS files in the checkout action when running the tests and building documentation, as I believe no LFS tracked files are required for running checks and finding test files though I might be wrong on this?

We could also potentially apply similar `path` filtering rules for the `push` to `master` trigger, but for now I've left this on the assumption that running everything on merging to `master` is safest and happens less frequently than PR pushes so less gain.