### PR TITLE
Fix brittle relative path to resource file in contraception and add test to catch problems like this in future

### DIFF
--- a/src/tlo/methods/contraception.py
+++ b/src/tlo/methods/contraception.py
@@ -194,7 +194,9 @@ class Contraception(Module):
         ))
 
         # Temporary fix of loading the boolean  parameter 'use_interventions':
-        co_params = pd.read_csv('resources/ResourceFile_ContraceptionParams.csv')
+        co_params = pd.read_csv(
+            Path(self.resourcefilepath) / 'ResourceFile_ContraceptionParams.csv'
+        )
         self.parameters['use_interventions_loaded'] =\
             co_params['value'].loc[co_params['parameter_name'] == 'use_interventions'].values[0]
         self.parameters['use_interventions'] = self.parameters['use_interventions_loaded'] == 'On'

--- a/tests/test_fullmodel.py
+++ b/tests/test_fullmodel.py
@@ -1,7 +1,9 @@
 """A set of tests on the models with all the disease modules registered."""
 
 import os
+from contextlib import contextmanager
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pandas as pd
 import pytest
@@ -22,6 +24,17 @@ def check_dtypes(simulation):
     assert (df.dtypes == orig.dtypes).all()
 
 
+@contextmanager
+def temporarily_change_working_directory(new_working_directory: Path):
+    """Context manager for temporarily changing working directory."""
+    previous_working_directory = os.getcwd()
+    os.chdir(new_working_directory)
+    try:
+        yield
+    finally:
+        os.chdir(previous_working_directory)
+
+
 @pytest.mark.slow
 def test_dtypes_and_checksum(seed):
     """Check that types of all properties are as expected and that the checksum can be generated."""
@@ -33,3 +46,13 @@ def test_dtypes_and_checksum(seed):
         sim.simulate(end_date=start_date + pd.DateOffset(months=12))
         check_dtypes(sim)
         logger.info(key="msg", data=f"Population checksum: {hash_dataframe(sim.population.props)}")
+
+
+def test_resourcefilepath(seed):
+    # Try register all fullmodel modules with current working directory set to a
+    # temporary directory but resourcefilepath set correctly to ensure that it is being
+    # used to construct paths to resource files as expected
+    with TemporaryDirectory() as temporary_directory:
+        with temporarily_change_working_directory(temporary_directory):
+            sim = Simulation(start_date=start_date, seed=seed)
+            sim.register(*fullmodel(resourcefilepath=resourcefilepath))


### PR DESCRIPTION
Fixes #1137 

Adds a new test which checks that we can register all modules (which calls `read_parameters` method for each module) defined by `tlo.methods.fullmodel.fullmodel` function when running from a working directory not corresponding to default of root of `TLOmodel` repository, but where the `resourcefilepath` argument is set to correct absolute path to `resources` directory. This should catch cases where we try to load resource files with relative paths that will only work when the current working directory is the root of `TLOmodel` repository.

This test fails on current `master` due to the line

https://github.com/UCL/TLOmodel/blob/894ab2ae864f7e3624ac5b969d53f0d48ba97548/src/tlo/methods/contraception.py#L197

which is also updated here to use `self.resourcefilepath` instead.