### PR TITLE
Ensure name of policy after switch is among policies loaded

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -830,6 +830,11 @@ class HealthSystem(Module):
         self.tclose_overwrite = self.parameters['tclose_overwrite']
         self.tclose_days_offset_overwrite = self.parameters['tclose_days_offset_overwrite']
 
+        # Ensure name of policy we want to consider before/after switch is among the policies loaded
+        # in the self.parameters['priority_rank']
+        assert self.parameters['policy_name'] in self.parameters['priority_rank'].keys()
+        assert self.parameters['policy_name_post_switch'] in self.parameters['priority_rank'].keys()
+
         # Set up framework for considering a priority policy
         self.setup_priority_policy()
 

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -832,8 +832,8 @@ class HealthSystem(Module):
 
         # Ensure name of policy we want to consider before/after switch is among the policies loaded
         # in the self.parameters['priority_rank']
-        assert self.parameters['policy_name'] in self.parameters['priority_rank'].keys()
-        assert self.parameters['policy_name_post_switch'] in self.parameters['priority_rank'].keys()
+        assert self.parameters['policy_name'] in self.parameters['priority_rank']
+        assert self.parameters['policy_name_post_switch'] in self.parameters['priority_rank']
 
         # Set up framework for considering a priority policy
         self.setup_priority_policy()


### PR DESCRIPTION
Micro-PR to ensure that we check  *at the start* of the simulation whether the name of the policy to be considered after the switch is among the loaded priorities. Otherwise risk running the simulation until 'year_policy_switch' (so 13 years if considering a policy switch in 2023) before realising that there's a problem with that parameter. 