### PR TITLE
Fix to `summarize`

### DIFF
--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -327,6 +327,7 @@ def summarize(results: pd.DataFrame, only_mean: bool = False, collapse_columns: 
         # Remove other metrics and simplify if 'only_mean' across runs for each draw is required:
         om: pd.DataFrame = summary.loc[:, (slice(None), "mean")]
         om.columns = [c[0] for c in om.columns.to_flat_index()]
+        om.columns.name = 'draw'
         return om
 
     elif collapse_columns and (len(summary.columns.levels[0]) == 1):

--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -319,8 +319,9 @@ def summarize(results: pd.DataFrame, only_mean: bool = False, collapse_columns: 
         },
         axis=1
     )
-    summary.columns = summary.columns.swaplevel(1, 0).sort_index(axis=1)
+    summary.columns = summary.columns.swaplevel(1, 0)
     summary.columns.names = ['draw', 'stat']
+    summary = summary.sort_index(axis=1)
 
     if only_mean and (not collapse_columns):
         # Remove other metrics and simplify if 'only_mean' across runs for each draw is required:

--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -311,14 +311,15 @@ def summarize(results: pd.DataFrame, only_mean: bool = False, collapse_columns: 
     Finds mean value and 95% interval across the runs for each draw.
     """
 
-    summary = pd.concat({
-        'mean': results.groupby(axis=1, by='draw', sort=False).mean(),
-        'lower': results.groupby(axis=1, by='draw', sort=False).quantile(0.025),
-        'upper': results.groupby(axis=1, by='draw', sort=False).quantile(0.975),
-    },
+    summary = pd.concat(
+        {
+            'mean': results.groupby(axis=1, by='draw', sort=False).mean(),
+            'lower': results.groupby(axis=1, by='draw', sort=False).quantile(0.025),
+            'upper': results.groupby(axis=1, by='draw', sort=False).quantile(0.975),
+        },
         axis=1
     )
-    summary.columns = summary.columns.swaplevel(1, 0)
+    summary.columns = summary.columns.swaplevel(1, 0).sort_index(axis=1)
     summary.columns.names = ['draw', 'stat']
 
     if only_mean and (not collapse_columns):


### PR DESCRIPTION
I noticed that this function previously relied on the order of the index from a `pd.groupby` using index groupers being the same as in the original data frame's index. This used to be fine, but with the change to the new version of pandas causes weird results. I could have made the fix just by adding `sort=False` as an argument to `groupby` .... but I thought it would be safer not rely on ordering and instead let the matching-up be done by `pd.concat`, using the actual indices.

This a **high priority fix** as, without it, results from `summarise` may become jumbled up between the draws, with no warning/errors raised.