### PR TITLE
Fix in handling of `Causes`

### DIFF
--- a/src/tlo/methods/causes.py
+++ b/src/tlo/methods/causes.py
@@ -3,6 +3,7 @@ Classes and functions that support declarations of causes of death and disabilit
 """
 
 from collections import defaultdict
+from copy import copy
 from typing import Union
 
 import pandas as pd
@@ -67,8 +68,9 @@ def collect_causes_from_disease_modules(all_modules, collect, acceptable_causes:
                         f"Conflict in declared cause {tlo_cause} by {m.name}. " \
                         f"A different specification has already been registered."
 
-                # If ok, update these causes to the master dict of all causes of death
-                collected_causes.update({tlo_cause: cause})
+                # If ok, update these causes to the master dict of all causes of death  (copies to prevent any
+                # accidental editing of the modules' declarations).
+                collected_causes.update({copy(tlo_cause): copy(cause)})
 
     # Check that each gbd_cause is not defined in respect of more than one label
     gbd_causes = dict()  # dict(<gbd_cause: label>)

--- a/src/tlo/methods/healthburden.py
+++ b/src/tlo/methods/healthburden.py
@@ -2,6 +2,7 @@
 This Module runs the counting of Life-years Lost, Life-years Lived with Disability,
 and Disability-Adjusted Life-years (DALYS).
 """
+from copy import copy
 from pathlib import Path
 from typing import Dict
 
@@ -179,13 +180,14 @@ class HealthBurden(Module):
                 for _tlo_cause_name, _cause in d.items():
                     if _cause.label not in labels_seen:
                         # If label is not already included, add this cause to the merged dict
-                        merged_causes[_tlo_cause_name] = _cause
+                        merged_causes[_tlo_cause_name] = copy(_cause)  # Use copy to avoid the merged dict being linked
+                        #                                                to the passed argument
                         labels_seen[_cause.label] = _tlo_cause_name
                     else:
                         # If label is already included, merge the gbd_causes into the cause defined.
                         tlo_cause_name_to_merge_into = labels_seen[_cause.label]
                         merged_causes[tlo_cause_name_to_merge_into].gbd_causes = \
-                            merged_causes[tlo_cause_name_to_merge_into].gbd_causes.union(_cause.gbd_causes)
+                            merged_causes[tlo_cause_name_to_merge_into].gbd_causes.union(_cause.gbd_causes)  # M0
             return merged_causes
 
         causes_of_death = collect_causes_from_disease_modules(


### PR DESCRIPTION
It was noted that `merge_dicts_of_causes` over-writing the module's delcaration of the causes. (This gave rise to an error when changing defintion of CAUSES_OF_DEATHS and CAUSES_OF_DISABILITY that was hard to catch and it only occured on the "second" run of the model, after which the declaration had been written-to.)

The main fix is that the `merge_dicts_of_causes` now uses `copy` to prevent mutating the `dicts` that are passed in.

A secondary ("belt and braces") fix is in the `collect_causes_from_disease_modules` helper function, which also uses `copy` to prevent there ever being a link created from the module declaration of CAUSES_OF_DEATHS and CAUSES_OF_DISABILITY to anything used in the simulation.