### PR TITLE
Ensure clean transition between mode 1 and mode 2

### DIFF
--- a/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
+++ b/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:006711b1519405e21ae2599975a51d45093a7ae887a33c8b553c27a45edf91ed
-size 337
+oid sha256:b06f61949b83b93f08f187af4cb9c7515b21ab8c28613e1df7ea04d0150a12bb
+size 304

--- a/resources/healthsystem/priority_policies/ResourceFile_PriorityRanking_ALLPOLICIES.xlsx
+++ b/resources/healthsystem/priority_policies/ResourceFile_PriorityRanking_ALLPOLICIES.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a739aa2434da26777afe312ca8ec8ba440feefe269875e745ad1a721ba5e6e27
-size 33201
+oid sha256:58fe0ff2c4d89323e9ece2979f16b944215e34b974c961b21901347c1321864c
+size 33211

--- a/resources/healthsystem/priority_policies/ResourceFile_PriorityRanking_ALLPOLICIES.xlsx
+++ b/resources/healthsystem/priority_policies/ResourceFile_PriorityRanking_ALLPOLICIES.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a10eb13154221475ed3b3ba03b62936b8dfc79c023475a4930a25a5b666599a9
-size 30493
+oid sha256:a739aa2434da26777afe312ca8ec8ba440feefe269875e745ad1a721ba5e6e27
+size 33201

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -2500,8 +2500,10 @@ class HealthSystemScheduler(RegularEvent, PopulationScopeEventMixin):
 
             event = next_event_tuple.hsi_event
 
-            # If the event is lower than lowest_priority_considered, schedule a call_never_ran on tclose
-            # regardless of whether appt is due today or any other time
+            # If the priority of the event is lower than lowest_priority_considered, schedule a call_never_ran
+            # on tclose regardless of whether appt is due today or any other time. (Although in mode 2 HSIs with
+            # priority > lowest_priority_considered are never added to the queue, some such HSIs may still be present
+            # in the queue if mode 2 was preceded by a period in mode 1).
             if next_event_tuple.priority > self.module.lowest_priority_considered:
                 self.module.schedule_to_call_never_ran_on_date(hsi_event=event,
                                                                tdate=next_event_tuple.tclose)

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -2258,7 +2258,7 @@ class HealthSystemScheduler(RegularEvent, PopulationScopeEventMixin):
                 hp.heappush(_list_of_events_not_due_today, next_event_tuple)
 
                 # Only stop querying when reaching lowest_priority_considered in mode 2
-                if (self.module.mode_appt_constraints == 2) and
+                if (self.module.mode_appt_constraints == 2) and  \
                    (next_event_tuple.priority == self.module.lowest_priority_considered):
                     # Check the priority
                     # If the next event is not due and has lowest allowed priority, then stop looking

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -2257,7 +2257,9 @@ class HealthSystemScheduler(RegularEvent, PopulationScopeEventMixin):
                 # The event is not yet due (before topen)
                 hp.heappush(_list_of_events_not_due_today, next_event_tuple)
 
-                if next_event_tuple.priority == self.module.lowest_priority_considered:
+                # Only stop querying when reaching lowest_priority_considered in mode 2
+                if (self.module.mode_appt_constraints == 2) and
+                   (next_event_tuple.priority == self.module.lowest_priority_considered):
                     # Check the priority
                     # If the next event is not due and has lowest allowed priority, then stop looking
                     # through the heapq as all other events will also not be due.

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -658,9 +658,9 @@ class HealthSystem(Module):
         # Check that the name of policy being evaluated is included
         self.priority_policy = None
         if policy_name is not None:
-            assert policy_name in ['', 'Default', 'Test', 'Random', 'Naive', 'RMNCH',
+            assert policy_name in ['', 'Default', 'Test', 'Test Mode 1', 'Random', 'Naive', 'RMNCH',
                                        'VerticalProgrammes', 'ClinicallyVulnerable', 'EHP_III',
-                                       'LCOA_EHP', 'No Services']
+                                       'LCOA_EHP']
         self.arg_policy_name = policy_name
 
         self.tclose_overwrite = None

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -660,7 +660,7 @@ class HealthSystem(Module):
         if policy_name is not None:
             assert policy_name in ['', 'Default', 'Test', 'Random', 'Naive', 'RMNCH',
                                        'VerticalProgrammes', 'ClinicallyVulnerable', 'EHP_III',
-                                       'LCOA_EHP']
+                                       'LCOA_EHP', 'No Services']
         self.arg_policy_name = policy_name
 
         self.tclose_overwrite = None

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -2257,14 +2257,6 @@ class HealthSystemScheduler(RegularEvent, PopulationScopeEventMixin):
                 # The event is not yet due (before topen)
                 hp.heappush(_list_of_events_not_due_today, next_event_tuple)
 
-                # Only stop querying when reaching lowest_priority_considered in mode 2
-                if (self.module.mode_appt_constraints == 2) and  \
-                   (next_event_tuple.priority == self.module.lowest_priority_considered):
-                    # Check the priority
-                    # If the next event is not due and has lowest allowed priority, then stop looking
-                    # through the heapq as all other events will also not be due.
-                    break
-
             else:
                 # The event is now due to run today and the person is confirmed to be still alive
                 # Add it to the list of events due today (individual or population level)

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -533,7 +533,7 @@ class HealthSystem(Module):
         'policy_name': Parameter(
             Types.STRING, "Name of priority policy assumed to have been adopted until policy switch"),
         'year_mode_switch': Parameter(
-            Types.INT, "Year in which priority policy switch in enforced"),
+            Types.INT, "Year in which mode switch in enforced"),
 
         'priority_rank': Parameter(
             Types.DICT, "Data on the priority ranking of each of the Treatment_IDs to be adopted by "
@@ -557,8 +557,7 @@ class HealthSystem(Module):
                        ' to the module initialiser.',
         ),
         'mode_appt_constraints_postSwitch': Parameter(
-            Types.INT, 'If considering a mode switch alongside priority policy switch, specify in this parameter. '
-                       'The switch occcurs in the year given in `year_mode_switch`.')
+            Types.INT, 'Mode considered after a mode switch in year_mode_switch.')
     }
 
     PROPERTIES = {
@@ -873,7 +872,7 @@ class HealthSystem(Module):
             self.healthsystemscheduler = HealthSystemScheduler(self)
             sim.schedule_event(self.healthsystemscheduler, sim.date)
 
-        # Schedule priority policy and mode_appt_constraints change
+        # Schedule a mode_appt_constraints change
         sim.schedule_event(HealthSystemChangeMode(self),
                            Date(self.parameters["year_mode_switch"], 1, 1))
 

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -193,7 +193,6 @@ def test_run_no_interventions_allowed(tmpdir, seed):
     assert not any(sim.population.props['mi_status'] == 'P')  # No cures
 
 
-
 @pytest.mark.slow
 def test_policy_has_no_effect_on_mode1(tmpdir, seed):
     # Events ran in mode 1 should be identical regardless of policy assumed.
@@ -201,7 +200,7 @@ def test_policy_has_no_effect_on_mode1(tmpdir, seed):
     # in mode 1 they should all be scheduled and delivered regardless
 
     output = []
-    for i,policy in enumerate(["Naive", "No Services"]):
+    for i, policy in enumerate(["Naive", "No Services"]):
         # Establish the simulation object
         sim = Simulation(
             start_date=start_date,
@@ -239,9 +238,11 @@ def test_policy_has_no_effect_on_mode1(tmpdir, seed):
 
         # read the results
         output.append(parse_log_file(sim.log_filepath, level=logging.DEBUG))
-    assert len(output[0]['tlo.methods.healthsystem']['HSI_Event']) == len(output[1]['tlo.methods.healthsystem']['HSI_Event'])
-    assert output[1]['tlo.methods.healthsystem']['HSI_Event']['did_run'].all()
 
+    # Check that the outputs are the same and that all HSIs ran even with policy specifying "No Services"
+    assert len(output[0]['tlo.methods.healthsystem']['HSI_Event']) == \
+           len(output[1]['tlo.methods.healthsystem']['HSI_Event'])
+    assert output[1]['tlo.methods.healthsystem']['HSI_Event']['did_run'].all()
 
 
 @pytest.mark.slow

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -232,10 +232,11 @@ def test_policy_has_no_effect_on_mode1(tmpdir, seed):
         output.append(parse_log_file(sim.log_filepath, level=logging.DEBUG))
 
     # Check that the outputs are the same
-    for i in range(1,len(policy_list)):
+    for i in range(1, len(policy_list)):
         pd.testing.assert_frame_equal(output[0]['tlo.methods.healthsystem']['HSI_Event'],
                                       output[i]['tlo.methods.healthsystem']['HSI_Event'])
-     
+
+
 @pytest.mark.slow
 def test_run_in_mode_0_with_capacity(tmpdir, seed):
     # Events should run and there be no squeeze factors

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -1665,6 +1665,7 @@ def test_policy_and_lowest_priority_and_fasttracking_enforced(seed, tmpdir):
                      disable=False,
                      randomise_queue=True,
                      ignore_priority=False,
+                     mode_appt_constraints=2,
                      policy_name="Test",  # Test policy enforcing lowest_priority_policy
                                           # assumed in this test. This allows us to check policies
                                           # are loaded correctly.

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -200,7 +200,8 @@ def test_policy_has_no_effect_on_mode1(tmpdir, seed):
     in mode 1 they should all be scheduled and delivered regardless"""
 
     output = []
-    for _, policy in enumerate(["Naive", "Test Mode 1", "", "ClinicallyVulnerable"]):
+    policy_list = ["Naive", "Test Mode 1", "", "ClinicallyVulnerable"]
+    for _, policy in enumerate(policy_list):
         # Establish the simulation object
         sim = Simulation(
             start_date=start_date,
@@ -231,10 +232,10 @@ def test_policy_has_no_effect_on_mode1(tmpdir, seed):
         output.append(parse_log_file(sim.log_filepath, level=logging.DEBUG))
 
     # Check that the outputs are the same
-    pd.testing.assert_frame_equal(output[0]['tlo.methods.healthsystem']['HSI_Event'],
-                                  output[1]['tlo.methods.healthsystem']['HSI_Event'])
-
-
+    for i in range(1,len(policy_list)):
+        pd.testing.assert_frame_equal(output[0]['tlo.methods.healthsystem']['HSI_Event'],
+                                      output[i]['tlo.methods.healthsystem']['HSI_Event'])
+     
 @pytest.mark.slow
 def test_run_in_mode_0_with_capacity(tmpdir, seed):
     # Events should run and there be no squeeze factors

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -200,7 +200,7 @@ def test_policy_has_no_effect_on_mode1(tmpdir, seed):
     in mode 1 they should all be scheduled and delivered regardless"""
 
     output = []
-    for i, policy in enumerate(["Naive", "Test Mode 1"]):
+    for _, policy in enumerate(["Naive", "Test Mode 1", "", "ClinicallyVulnerable"]):
         # Establish the simulation object
         sim = Simulation(
             start_date=start_date,


### PR DESCRIPTION
Currently, policies can exclude certain HSIs by setting their priority below (i.e. higher than) the "lowest_priority_considered". At time of scheduling the event, if the priority is higher than the lowest_priority_considered the HSI is not added to the queue, but rather  schedule_to_call_never_ran_on_date is scheduled on date tclose. 

Because the "lowest_priority_considered" check happens only at time of scheduling and not at time of queue querying, when transitioning from mode 1 to mode 2 HSIs which were scheduled in mode 1 but may no longer be allowed to run under the policy in mode 2 are still running. We therefore add an additional priority check at time of querying. 

A lingering issue is that the priority assumed when scheduling HSIs during the "mode 1" phase is policy-dependent, and hence may be above the "lowest_priority_considered" assumed by the policy we want to actually consider in mode 2. Therefore, if we wanted to ensure a "clean" transition we should always run with the same policy, even in mode 1 [but ensuring that the lowest_priority_considered check at time of scheduling only occurs in mode 2], and never allow for a policy transition, but only a mode transition. This PR ensures this by additionally removing the policy switch completely, and making the "lowest_priority_considered" check at time of scheduling only occur in mode_appt_constraints=2. 