### PR TITLE
Each run in scenario has same seed, across all draws

### DIFF
--- a/src/tlo/scenario.py
+++ b/src/tlo/scenario.py
@@ -275,7 +275,6 @@ class DrawGenerator:
     def get_draw(self, draw_number):
         return {
             "draw_number": draw_number,
-            "draw_seed": self.scenario.rng.randint(MAX_INT),
             "parameters": self.scenario.draw_parameters(draw_number, self.scenario.rng),
         }
 
@@ -327,7 +326,7 @@ class SampleRunner:
         # Instead of using the random number generator to create a seed for the simulation, we use an integer hash
         # function to create an integer based on the sum of the draw_number and sample_number. This means the
         # seed can be created independently and out-of-order (i.e. instead of sampling a seed for each sample in order)
-        sample["simulation_seed"] = SampleRunner.low_bias_32(sample["draw_seed"] + sample_number)
+        sample["simulation_seed"] = SampleRunner.low_bias_32(self.run_config["scenario_seed"] + sample_number)
         return sample
 
     def run_sample_by_number(self, output_directory, draw_number, sample_number):

--- a/src/tlo/scenario.py
+++ b/src/tlo/scenario.py
@@ -324,7 +324,7 @@ class SampleRunner:
         sample["sample_number"] = sample_number
 
         # Instead of using the random number generator to create a seed for the simulation, we use an integer hash
-        # function to create an integer based on the sum of the draw_number and sample_number. This means the
+        # function to get an integer based on the sum of the scenario seed and sample_number. This means the
         # seed can be created independently and out-of-order (i.e. instead of sampling a seed for each sample in order)
         sample["simulation_seed"] = SampleRunner.low_bias_32(self.run_config["scenario_seed"] + sample_number)
         return sample


### PR DESCRIPTION
Part of #86.

Each scenario has a seed. Each draw has runs. Each numbered run has a seed which is the same across all draws.

This can be tested using `tlo scenario-run` on a small pop size & run for 1 month then check the log file for the seed for "Simulation RNG".