### PR TITLE
Increase HTML docs content column width on wide screens

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,0 +1,10 @@
+
+/*
+On wide format screens increase content width to avoid horizontal scroll bars on code
+blocks with 120 character line length
+*/
+@media screen and (min-width: 1280px) {
+    div.wy-nav-content {
+      max-width: 960px;
+    }
+  }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,12 @@ html_static_path = ['_static']
 html_extra_path = ['./.nojekyll', './.gitattributes']
 html_favicon = 'favicon.png'
 
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',
+    ],
+}
+
 rawfiles = ['.github']
 
 napoleon_use_ivar = True


### PR DESCRIPTION
Fixes #1175 

Increases content column width in HTML documentation from maximum of 800px to 960px, when on screens 1280px or wider, which should avoid overflow of fixed width text content in source code blocks with the current default line length of 120 characters.

Building locally the CSS override seems to be getting picked up for the relevant `div` without needing any `!important` directives.