### PR TITLE
Get documentation version from installed `tlo` metadata

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ project = 'TLOmodel'
 year = '2021'
 author = 'The TLOmodel Team'
 copyright = '{0}, {1}'.format(year, author)
-release = get_version('setuptools_scm')
+release = get_version('tlo')
 version = ".".join(release.split('.')[:2])
 
 pygments_style = 'trac'


### PR DESCRIPTION
Fixes #1179 