### PR TITLE
Locally disable pylint E0110 as false positive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ disable = [
     "R",
     "C",
     "W",
-    "E0110", # abstract class instantiated
     "E0611", # no-name-in-module
     "E0702", # raising NoneType
     "E1136", # unsubscriptable type

--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -96,17 +96,15 @@ def write_log_to_excel(filename, log_dataframes):
                 sheet_count += 1
                 metadata.append([module, key, sheet_count, dataframes['_metadata'][module][key]['description']])
 
-    writer = pd.ExcelWriter(filename)
-    index = pd.DataFrame(data=metadata, columns=['module', 'key', 'sheet', 'description'])
-    index.to_excel(writer, sheet_name='Index')
-
-    sheet_count = 0
-    for module, dataframes in log_dataframes.items():
-        for key, df in dataframes.items():
-            if key != '_metadata':
-                sheet_count += 1
-                df.to_excel(writer, sheet_name=f'Sheet {sheet_count}')
-    writer.save()
+    with pd.ExcelWriter(filename) as writer:  # https://github.com/PyCQA/pylint/issues/3060 pylint: disable=E0110
+        index = pd.DataFrame(data=metadata, columns=['module', 'key', 'sheet', 'description'])
+        index.to_excel(writer, sheet_name='Index')
+        sheet_count = 0
+        for module, dataframes in log_dataframes.items():
+            for key, df in dataframes.items():
+                if key != '_metadata':
+                    sheet_count += 1
+                    df.to_excel(writer, sheet_name=f'Sheet {sheet_count}')
 
 
 def make_calendar_period_lookup():


### PR DESCRIPTION
Part of #1181.

The E0110 (abstract-class-instantiated) violation flagged by Pylint by instantiating `pandas.ExcelWriter` is a false positive (https://github.com/pylint-dev/pylint/issues/3060), so this PR locally disables the rule at this usage.

Also refactors to use `pandas.ExcelWriter` as context manager [as recommended in docs](http://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.ExcelWriter.html#pandas-excelwriter), which incidentally fixes a `E1101: Instance of 'ExcelWriter' has no 'save' member; maybe '_save'? (no-member)` Pylint violation (docs seem to suggest `close` is an alias of `save` but don't specifically document `save` suggesting it may not be an intended part of API) and removes global ignore of E0110 in `pyproject.toml`.