### PR TITLE
Use `inplace=True` in pandas functions to avoid Pylint E113[6|7] false positives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,6 @@ disable = [
     "E0110", # abstract class instantiated
     "E0611", # no-name-in-module
     "E0702", # raising NoneType
-    "E1136", # unsubscriptable type
-    "E1137", # doesn't support item assignment
     "E1101", # no-member
     "E1120", # no-value-for-parameter
     "E1130", # bad operand type for unary ~

--- a/src/tlo/methods/contraception.py
+++ b/src/tlo/methods/contraception.py
@@ -580,7 +580,7 @@ class Contraception(Module):
                 columns=sorted(self.all_contraception_states - {"not_using"})
             )
             p_pregnancy_with_contraception_per_month.loc[15, :] = p_pregnancy_by_method_per_month
-            p_pregnancy_with_contraception_per_month = p_pregnancy_with_contraception_per_month.ffill()
+            p_pregnancy_with_contraception_per_month.ffill(inplace=True)
             p_pregnancy_with_contraception_per_month.loc[
                 p_pregnancy_with_contraception_per_month.index < 25
                 ] *= self.parameters['rr_fail_under25']

--- a/src/tlo/methods/healthburden.py
+++ b/src/tlo/methods/healthburden.py
@@ -401,7 +401,7 @@ class HealthBurden(Module):
         period = pd.DataFrame(df.groupby(by=['year', 'age_range'])['days'].count())
         period['person_years'] = (period['days'] / 365).clip(lower=0.0, upper=1.0)
 
-        period = period.drop(columns=['days'], axis=1)
+        period.drop(columns=['days'], axis=1, inplace=True)
 
         return period
 

--- a/src/tlo/methods/hiv.py
+++ b/src/tlo/methods/hiv.py
@@ -3167,7 +3167,7 @@ def map_to_age_group(ser):
 
 def unpack_raw_output_dict(raw_dict):
     x = pd.DataFrame.from_dict(data=raw_dict, orient="index")
-    x = x.reset_index()
+    x.reset_index(inplace=True)
     x.rename(columns={"index": "age_group", 0: "value"}, inplace=True)
     x["age_group"] = set_age_group(x["age_group"])
     return x


### PR DESCRIPTION
Part of #1181.

Pylint has trouble dealing with pandas functions/ methods that may return `None` if `inplace=True` ([pylint-dev/pylint/issues/3637](https://github.com/pylint-dev/pylint/issues/3637#issuecomment-1481546000)) or a pandas type like `pandas.Dataframe` or `pandas.Series` otherwise, which results in a series of E1136 (unscriptable-object) and E1137 (unsupport-assignment-operation) false positives in our code. 

In all of the cases where we currently get false positives, we probably do however want to use `inplace=True` to avoid an unnecessary object creation rather than reassigning the variable name to a new object, hence this PR changes to this pattern and removes the global E1136 and E1137 Pylint rule ignores in `pyproject.toml`.