### PR TITLE
Fixes Pylint E1120 (`no-value-for-parameter`) violations and removes global ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ disable = [
     "E1136", # unsubscriptable type
     "E1137", # doesn't support item assignment
     "E1101", # no-member
-    "E1120", # no-value-for-parameter
     "E1130", # bad operand type for unary ~
 ]
 

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -52,7 +52,7 @@ def test_scale_run_script_deterministic(tmp_path):
             "Pickle of final population dataframe not found"
         )
         final_population_dataframes.append(pd.read_pickle(final_population_pickle_path))
-    pd.testing.assert_frame_equal(*final_population_dataframes), (
+    assert final_population_dataframes[0].equals(final_population_dataframes[1]), (
         f"Running {' '.join(command_args)} twice produces different final populations. "
         "This may be due to for example using an unseeded random number generator such "
         "as routines from `numpy.random` or the built-in `random` module, or due to "

--- a/tests/test_enhanced_lifestyle.py
+++ b/tests/test_enhanced_lifestyle.py
@@ -58,12 +58,3 @@ def test_properties_and_dtypes(simulation):
     df = simulation.population.props
     orig = simulation.population.new_row
     assert (df.dtypes == orig.dtypes).all()
-
-
-if __name__ == '__main__':
-    t0 = time.time()
-    simulation = simulation()
-    simulation.make_initial_population(n=popsize)
-    simulation.simulate(end_date=end_date)
-    t1 = time.time()
-    print('Time taken', t1 - t0)

--- a/tests/test_enhanced_lifestyle.py
+++ b/tests/test_enhanced_lifestyle.py
@@ -1,6 +1,5 @@
 
 import os
-import time
 from pathlib import Path
 
 import pytest

--- a/tests/test_rti.py
+++ b/tests/test_rti.py
@@ -434,10 +434,3 @@ def test_health_system_disabled(seed):
     sim.simulate(end_date=end_date)
     # check the datatypes
     check_dtypes(sim)
-
-
-if __name__ == '__main__':
-    t0 = time.time()
-    test_run()
-    t1 = time.time()
-    print('Time taken', t1 - t0)

--- a/tests/test_rti.py
+++ b/tests/test_rti.py
@@ -1,5 +1,4 @@
 import os
-import time
 from pathlib import Path
 
 import pandas as pd


### PR DESCRIPTION
Part of #1181.

Removes `if __name__ == "__main__"` blocks from `tests/test_enhanced_lifestyle.py` and `tests/test_rti.py` test modules which call out to test functions to allow running the modules as scripts. In both cases the call signatures of the test functions called have changed and so running as a script would have raised an error. As in both files this has been the case for a while, I suspect this means no-one is regularly using this approach for running tests, and in general using `pytest` should be preferred anyway, so I've just removed these blocks altogether rather than trying to fix. We probably also want to update [the wiki](https://github.com/UCL/TLOmodel/wiki/Implementing-a-disease-module#create-a-file-for-testing-the-new-module) to remove the example test module skeleton to remove the corresponding `if __name__ == "__main__"` block.

Also refactors `test_scale_run_script_deterministic` in `tests/test_determinism.py` to avoid a Pylint E1120 false positive on unpacking `final_population_dataframes` list in to call to `pandas.testing.assert_frame_equal` which appears to be because it cannot determine the length of the list and so whether both the required `left` and `right` arguments to `pandas.testing.assert_frame_equal` will be passed values. An error message was previously being constructed alongside the call to `pandas.testing.assert_frame_equal` but nothing was actually being done with it, presumably as I initially wrote this as a plain `assert` statement intending the error message to be the optional message component of the statement, but then changed to using the pandas function instead at some point. The code has now been refactored to use a plain `assert` with `pandas.DataFrame.equals` which both avoids the false positive and ensures the error message will be correctly displayed.
