### PR TITLE
Refactor lookup table computation in malaria poll to avoid memory spike

### DIFF
--- a/src/tlo/methods/malaria.py
+++ b/src/tlo/methods/malaria.py
@@ -303,7 +303,9 @@ class Malaria(Module):
         def _draw_incidence_for(_col, _where):
             """a helper function to perform random draw for selected individuals on column of probabilities"""
             # create an index from the individuals to lookup entries in the current incidence table
-            district_age_lookup = df[_where].set_index(['district_num_of_residence', 'ma_age_edited']).index
+            district_age_subset = df.loc[_where, ['district_num_of_residence', 'ma_age_edited']]
+            district_age_subset.set_index(district_age_subset.columns.to_list(), inplace=True)
+            district_age_lookup = district_age_subset.index
             # get the monthly incidence probabilities for these individuals
             monthly_prob = curr_inc.loc[district_age_lookup, _col]
             # update the index so it's the same as the original population dataframe for these individuals


### PR DESCRIPTION
In https://github.com/UCL/TLOmodel/issues/1163#issuecomment-1811438520 I noted that from memory profiling of a run of the `src/scripts/profiling/scale_run.py` script, there appeared to be sharp peaks in memory usage corresponding to `Malaria.malaria_poll2` method called at

https://github.com/UCL/TLOmodel/blob/4bffc1a3c8d5ae7336ea4534486830255a0173e1/src/tlo/methods/malaria.py#L652

which is in a monthly scheduled event `MalariaPollingEventDistrict`, with around ~300MB increase in memory usage during these peaks, as visible in the following plot of overall memory usage:

![image](https://github.com/UCL/TLOmodel/assets/6746980/4e3fd6ff-664c-4084-a6ae-4e2eee727211)

Looking at the flamegraph representation of the peak memory usage in a narrow window around one of these spikes we get the following breakdown for the `Malaria.malaria_poll2` method call

![image](https://github.com/UCL/TLOmodel/assets/6746980/bd7cbf54-3b04-4605-bc3d-82581384ea04)

with the width of the bars proportional to the total memory allocated by the function (and each bar a function / method in the call stack with lower bars further 'down' / nested in the call stack).

This suggested it was evaluations of the `_draw_incidence_for` nested function which was the key culprit, and in particular the line

https://github.com/UCL/TLOmodel/blob/4bffc1a3c8d5ae7336ea4534486830255a0173e1/src/tlo/methods/malaria.py#L306

This line selects a subset of the population dataframe rows, sets the index of this resulting new dataframe to use the values of the `district_num_of_residence` and `ma_age_edited` columns, and then gets just the index of this resulting dataframe. As the dataframe returned by the initial indexing by `_where` to get a row subset will still contain all the columns in the original population dataframe, I suspect this is what is leading to the large memory allocations. As we subsequently only need the `district_num_of_residence` and `ma_age_edited` columns, we can use the `loc` indexer to simultaenously select a subset of rows using `_where` and the two relevant columns, then reindex this much smaller (in terms of number of columns) dataframe inplace avoiding a further dataframe copy and memory allocation, before extracting the index. With these changes as implemented in this PR we get the following overall memory usage plot

![image](https://github.com/UCL/TLOmodel/assets/6746980/e798f2e0-ea75-4f5e-81a5-74a8a2eaabb8)

which does seems to have had the desired effect of substantially decreasing the amplitude of the spikes.
