### PR TITLE
Add --more-memory option for simulations with larger population sizes

### DIFF
--- a/src/tlo/cli.py
+++ b/src/tlo/cli.py
@@ -224,6 +224,7 @@ def batch_submit(ctx, scenario_file, asserts_on, more_memory, keep_pool_alive):
     git fetch origin {commit.hexsha}
     git checkout {commit.hexsha}
     pip install -r requirements/base.txt
+    env | grep "^AZ_" | while read line; do echo "$line"; done
     {py_opt} tlo --config-file tlo.example.conf batch-run {azure_run_json} {working_dir} {{draw_number}} {{run_number}}
     cp {task_dir}/std*.txt {working_dir}/{{draw_number}}/{{run_number}}/.
     gzip {working_dir}/{{draw_number}}/{{run_number}}/*.{gzip_pattern_match}

--- a/src/tlo/cli.py
+++ b/src/tlo/cli.py
@@ -86,9 +86,11 @@ def scenario_run(scenario_file, draw_only, draw: tuple, output_dir=None):
 @cli.command()
 @click.argument("scenario_file", type=click.Path(exists=True))
 @click.option("--asserts-on", type=bool, default=False, is_flag=True, help="Enable assertions in simulation run.")
+@click.option("--more-memory", type=bool, default=False, is_flag=True,
+              help="Request machine wth more memory (for larger population sizes).")
 @click.option("--keep-pool-alive", type=bool, default=False, is_flag=True, hidden=True)
 @click.pass_context
-def batch_submit(ctx, scenario_file, asserts_on, keep_pool_alive):
+def batch_submit(ctx, scenario_file, asserts_on, more_memory, keep_pool_alive):
     """Submit a scenario to the batch system.
 
     SCENARIO_FILE is path to file containing scenario class.
@@ -147,7 +149,10 @@ def batch_submit(ctx, scenario_file, asserts_on, keep_pool_alive):
                       )
 
     # Configuration of the pool: type of machines and number of nodes.
-    vm_size = config["BATCH"]["POOL_VM_SIZE"]
+    if more_memory:
+        vm_size = config["BATCH"]["POOL_VM_SIZE_MORE_MEMORY"]
+    else:
+        vm_size = config["BATCH"]["POOL_VM_SIZE"]
     # TODO: cap the number of nodes in the pool?  Take the number of nodes in
     # input from the user, but always at least 2?
     pool_node_count = max(2, math.ceil(scenario.number_of_draws * scenario.runs_per_draw))


### PR DESCRIPTION
For #1163 

The option `--more-memory` for `batch-submit` requests a machine with more RAM for simulations with larger population sizes. At the moment, deciding whether a run requires it will have to be determined through trial-and-error. We know initial pop size of 150k requires more memory. We're switching the [Standard_DS2_v2](https://azureprice.net/vm/Standard_DS2_v2) for [Standard_D11_v2](https://azureprice.net/vm/Standard_D11_v2), which is the same machine (same performance characteristics + local storage for log-file writing) but with 14GB (vs 7GB) memory. The actual machine name is stored in the Azure Batch config (in key-value store), so machine changes don't require a code change.

I am also saving the Azure Batch environment variables for the run to standard out stream, which makes it a bit easier to monitoring/trace jobs -> pools -> vms. Looks like this:

```
AZ_BATCH_NODE_MOUNTS_DIR=/mnt/batch/tasks/fsmounts
AZ_BATCH_TASK_WORKING_DIR=/mnt/batch/tasks/workitems/playing_22-2023-11-15T120122Z/job-1/draw_0-run_0/wd
AZ_BATCH_TASK_DIR=/mnt/batch/tasks/workitems/playing_22-2023-11-15T120122Z/job-1/draw_0-run_0
AZ_BATCH_NODE_SHARED_DIR=/mnt/batch/tasks/shared
AZ_BATCH_TASK_USER=_azbatchtask_1
AZ_BATCH_NODE_IS_DEDICATED=true
AZ_BATCH_NODE_STARTUP_DIR=/mnt/batch/tasks/startup
AZ_BATCH_JOB_ID=playing_22-2023-11-15T120122Z
AZ_BATCH_NODE_STARTUP_WORKING_DIR=/mnt/batch/tasks/startup/wd
AZ_BATCH_TASK_ID=draw_0-run_0
AZ_BATCH_ACCOUNT_NAME=tlob1ba
AZ_BATCH_RESERVED_EPHEMERAL_DISK_SPACE_BYTES=2101743288
AZ_BATCH_NODE_ROOT_DIR=/mnt/batch/tasks
AZ_BATCH_POOL_ID=E48BFEFA-D117-401B-A5C2-5E7C017A67A2
AZ_BATCH_RESERVED_DISK_SPACE_BYTES=2101743288
AZ_BATCH_ACCOUNT_URL=https://tlob1ba.uksouth.batch.azure.com/
AZ_BATCH_NODE_ID=tvmps_637a11a2713a5f353b077be370de302abb92f00cc7b390cd8cb8eaac3eb38771_d
AZ_BATCH_TASK_USER_IDENTITY=TaskAdmin
AZ_BATCH_OS_RESERVED_EPHEMERAL_DISK_SPACE_BYTES=1000000000
AZ_BATCH_CERTIFICATES_DIR=/mnt/batch/tasks/workitems/playing_22-2023-11-15T120122Z/job-1/draw_0-run_0/certs
```
