### PR TITLE
[CI] Add GitHub Actions workflow to run calibration analysis

### DIFF
--- a/.github/workflows/calibration.yaml
+++ b/.github/workflows/calibration.yaml
@@ -3,11 +3,16 @@ name: Calibration
 on:
   push:
     branches: "mg/calibration-workflow"
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Commit'
+        required: true
+        default: ""
+        type: string
 
 env:
-  WORKTREE_PATH:   /mnt/tlo/${{ github.sha }}
   REPO_PATH:       /mnt/tlo/TLOmodel
-  ENV:             /mnt/tlo/env-${{ github.sha }}
   OUTPUT_ROOT:     /mnt/tlo/output
   RUNS_NUMBER:     4
   PYTHON_VER:      3.8
@@ -26,20 +31,42 @@ jobs:
     strategy:
       fail-fast: false
     outputs:
+      environment_path: ${{ steps.vars.outputs.environment_path }}
+      worktree_path: ${{ steps.vars.outputs.worktree_path }}
       output_dir: ${{ steps.out-dir.outputs.output_dir }}
       tasks: ${{ steps.tasks.outputs.tasks }}
     steps:
-      - name: Clone remote TLO repository
+      - name: Generate environment variables
+        id: vars
         run: |
-          if [[ -d "${REPO_PATH}" ]]; then
-              git -C "${REPO_PATH}" fetch --depth 1 origin "${GITHUB_REF_NAME}"
+          if [[ ${{ github.event_name }} == 'workflow_dispatch' ]] && [[ -n "${{ inputs.commit }}" ]]; then
+              SHA=${{ inputs.commit }}
           else
-              git clone --depth 1 --branch "${GITHUB_REF_NAME}" "https://github.com/${{ github.repository }}.git" "${REPO_PATH}"
+              SHA=${{ github.sha }}
           fi
+          ENV="/mnt/tlo/env-${SHA}"
+          WORKTREE_PATH="/mnt/tlo/${SHA}"
+          echo "SHA=${SHA}"
+          echo "SHA=${SHA}" >> "${GITHUB_ENV}"
+          echo "ENV=${ENV}"
+          echo "ENV=${ENV}" >> "${GITHUB_ENV}"
+          echo "environment_path=${ENV}" >> "${GITHUB_OUTPUT}"
+          echo "WORKTREE_PATH=${WORKTREE_PATH}"
+          echo "WORKTREE_PATH=${WORKTREE_PATH}" >> "${GITHUB_ENV}"
+          echo "worktree_path=${WORKTREE_PATH}" >> "${GITHUB_OUTPUT}"
+
+      - name: Clone remote TLO repository and fetch desired commit
+        run: |
+          # If the repository doesn't exist on disk, clone it.
+          if [[ ! -d "${REPO_PATH}" ]]; then
+              git clone --depth=1 --branch="${{ github.ref_name }}" "https://github.com/${{ github.repository }}.git" "${REPO_PATH}"
+          fi
+          # In any case, fetch the requested commit.
+          git -C "${REPO_PATH}" fetch --depth=1 origin "${SHA}"
 
       - name: Create worktree
         run: |
-          git -C "${REPO_PATH}" worktree add "${WORKTREE_PATH}" ${{ github.sha }}
+          git -C "${REPO_PATH}" worktree add "${WORKTREE_PATH}" ${SHA}
 
       - name: Create virtual environment
         run: |
@@ -52,7 +79,7 @@ jobs:
       - name: Generate output directory
         id: out-dir
         run: |
-          commit_dir=$(git show -s --date=format:'%Y-%m-%d_%H%M%S' --format=%cd_%h "${{ github.sha }}")
+          commit_dir=$(git show -s --date=format:'%Y-%m-%d_%H%M%S' --format=%cd_%h "${SHA}")
           output_dir="${OUTPUT_ROOT}/${commit_dir}"
           echo "output_dir=${output_dir}"
           echo "output_dir=${output_dir}" >> "${GITHUB_OUTPUT}"
@@ -82,15 +109,13 @@ jobs:
     steps:
       - name: Run the task
         run: |
-          source "${ENV}/bin/activate"
+          source "${{ needs.setup.outputs.environment_path }}/bin/activate"
           draw=0
-          task_output_dir="${output_dir}/${RUN_NAME}/${draw}/${{ matrix.index }}"
+          task_output_dir="${{ needs.setup.outputs.output_dir }}/${RUN_NAME}/${draw}/${{ matrix.index }}"
           mkdir -p "${task_output_dir}"
 
-          tlo scenario-run --output-dir "${task_output_dir}" --draw "${draw}" ${{ matrix.index }} "${WORKTREE_PATH}/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py"
-        working-directory: "${{ env.WORKTREE_PATH }}"
-        env:
-          output_dir: "${{ needs.setup.outputs.output_dir }}"
+          tlo scenario-run --output-dir "${task_output_dir}" --draw "${draw}" ${{ matrix.index }} "${{ needs.setup.outputs.worktree_path }}/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py"
+        working-directory: "${{ needs.setup.outputs.worktree_path }}"
 
   # Do the postprocessing
   postprocess:
@@ -102,14 +127,12 @@ jobs:
     steps:
       - name: Run post-processing
         run: |
-          source "${ENV}/bin/activate"
-          task_output_dir="${output_dir}/${PROCESS_NAME}"
+          source "${{ needs.setup.outputs.environment_path }}/bin/activate"
+          task_output_dir="${{ needs.setup.outputs.output_dir }}/${PROCESS_NAME}"
           mkdir -p "${task_output_dir}"
 
-          python3 "${WORKTREE_PATH}/src/scripts/calibration_analyses/analysis_scripts/process.py" "${task_output_dir}" "${RUN_NAME}" "${WORKTREE_PATH}/resources"
-        working-directory: "${{ env.WORKTREE_PATH }}"
-        env:
-          output_dir: "${{ needs.setup.outputs.output_dir }}"
+          python3 "${{ needs.setup.outputs.worktree_path }}/src/scripts/calibration_analyses/analysis_scripts/process.py" "${task_output_dir}" "${RUN_NAME}" "${{ needs.setup.outputs.worktree_path }}/resources"
+        working-directory: "${{ needs.setup.outputs.worktree_path }}"
 
   # Cleanup stage, to remove temporary directories and such
   cleanup:
@@ -126,8 +149,8 @@ jobs:
     steps:
       - name: Cleanup worktree
         run: |
-          git -C "${REPO_PATH}" worktree remove -f "${WORKTREE_PATH}" || true
+          git -C "${REPO_PATH}" worktree remove -f "${{ needs.setup.outputs.worktree_path }}" || true
 
       - name: Cleanup virtual environment
         run: |
-          rm -rvf "${ENV}"
+          rm -rvf "${{ needs.setup.outputs.environment_path }}"

--- a/.github/workflows/calibration.yaml
+++ b/.github/workflows/calibration.yaml
@@ -14,7 +14,7 @@ on:
 env:
   REPO_PATH:       /mnt/tlo/TLOmodel
   OUTPUT_ROOT:     /mnt/tlodev2stg/tlo-dev-fs-2/task-runner/output
-  RUNS_NUMBER:     4
+  RUNS_NUMBER:     14
   PYTHON_VER:      3.11
   RUN_NAME:        021_long_run_all_diseases_run
   PROCESS_NAME:    022_long_run_all_diseases_process

--- a/.github/workflows/calibration.yaml
+++ b/.github/workflows/calibration.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   REPO_PATH:       /mnt/tlo/TLOmodel
-  OUTPUT_ROOT:     /mnt/tlo/output
+  OUTPUT_ROOT:     /mnt/tlodev2stg/tlo-dev-fs-2/task-runner/output
   RUNS_NUMBER:     4
   PYTHON_VER:      3.11
   RUN_NAME:        021_long_run_all_diseases_run

--- a/.github/workflows/calibration.yaml
+++ b/.github/workflows/calibration.yaml
@@ -2,7 +2,7 @@ name: Calibration
 
 on:
   push:
-    branches: "mg/calibration-workflow"
+    branches: "master"
   workflow_dispatch:
     inputs:
       commit:

--- a/.github/workflows/calibration.yaml
+++ b/.github/workflows/calibration.yaml
@@ -2,7 +2,7 @@ name: Calibration
 
 on:
   push:
-    branches: "master"
+    branches: "mg/calibration-workflow"
 
 env:
   WORKTREE_PATH:   /mnt/tlo/${{ github.sha }}

--- a/.github/workflows/calibration.yaml
+++ b/.github/workflows/calibration.yaml
@@ -1,0 +1,133 @@
+name: Calibration
+
+on:
+  push:
+    branches: "master"
+
+env:
+  WORKTREE_PATH:   /mnt/tlo/${{ github.sha }}
+  REPO_PATH:       /mnt/tlo/TLOmodel
+  ENV:             /mnt/tlo/env-${{ github.sha }}
+  OUTPUT_ROOT:     /mnt/tlo/output
+  RUNS_NUMBER:     4
+  PYTHON_VER:      3.8
+  RUN_NAME:        021_long_run_all_diseases_run
+  PROCESS_NAME:    022_long_run_all_diseases_process
+
+jobs:
+
+  # Do a single clone from the remote repository, to reduce bandwidth usage.
+  # The repo is cloned to a directory outside of the runner workspace, because
+  # we want it to survive the current job, but this also means we can't use the
+  # `actions/checkout` workflow.
+  setup:
+    name: Setup
+    runs-on: [tlo-dev-vm-3]
+    strategy:
+      fail-fast: false
+    outputs:
+      output_dir: ${{ steps.out-dir.outputs.output_dir }}
+      tasks: ${{ steps.tasks.outputs.tasks }}
+    steps:
+      - name: Clone remote TLO repository
+        run: |
+          if [[ -d "${REPO_PATH}" ]]; then
+              git -C "${REPO_PATH}" fetch --depth 1 origin "${GITHUB_REF_NAME}"
+          else
+              git clone --depth 1 --branch "${GITHUB_REF_NAME}" "https://github.com/${{ github.repository }}.git" "${REPO_PATH}"
+          fi
+
+      - name: Create worktree
+        run: |
+          git -C "${REPO_PATH}" worktree add "${WORKTREE_PATH}" ${{ github.sha }}
+
+      - name: Create virtual environment
+        run: |
+          python${PYTHON_VER} -m venv "${ENV}"
+          source "${ENV}/bin/activate"
+          pip install -r requirements/dev.txt
+          pip install -e .
+        working-directory: "${{ env.WORKTREE_PATH }}"
+
+      - name: Generate output directory
+        id: out-dir
+        run: |
+          commit_dir=$(git show -s --date=format:'%Y-%m-%d_%H%M%S' --format=%cd_%h "${{ github.sha }}")
+          output_dir="${OUTPUT_ROOT}/${commit_dir}"
+          echo "output_dir=${output_dir}"
+          echo "output_dir=${output_dir}" >> "${GITHUB_OUTPUT}"
+        working-directory: "${{ env.WORKTREE_PATH }}"
+
+      - name: Generate list of tasks
+        id: tasks
+        run: |
+          RUNS="["
+          for run in $(seq 0 $((${RUNS_NUMBER} - 1))); do
+              RUNS="${RUNS}\"${run}\","
+          done
+          RUNS="${RUNS}]"
+          echo "tasks=${RUNS}"
+          echo "tasks=${RUNS}" >> "${GITHUB_OUTPUT}"
+
+  # Run the tasks.
+  tasks:
+    needs: setup
+    name: Run task ${{ matrix.index }}
+    runs-on: [tlo-dev-vm-3, tasks] # Use only runners dedicated to running the tasks.
+    timeout-minutes: 5760 # = 4 * 24 * 60 minutes = 4 days
+    strategy:
+      fail-fast: false
+      matrix:
+        index: ${{ fromJSON(needs.setup.outputs.tasks) }}
+    steps:
+      - name: Run the task
+        run: |
+          source "${ENV}/bin/activate"
+          draw=0
+          task_output_dir="${output_dir}/${RUN_NAME}/${draw}/${{ matrix.index }}"
+          mkdir -p "${task_output_dir}"
+
+          tlo scenario-run --output-dir "${task_output_dir}" --draw "${draw}" ${{ matrix.index }} "${WORKTREE_PATH}/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py"
+        working-directory: "${{ env.WORKTREE_PATH }}"
+        env:
+          output_dir: "${{ needs.setup.outputs.output_dir }}"
+
+  # Do the postprocessing
+  postprocess:
+    name: Post processing
+    needs: [setup, tasks]
+    runs-on: [tlo-dev-vm-3, postprocess] # Use only the runners dedicated to postprocessing
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Run post-processing
+        run: |
+          source "${ENV}/bin/activate"
+          task_output_dir="${output_dir}/${PROCESS_NAME}"
+          mkdir -p "${task_output_dir}"
+
+          python3 "${WORKTREE_PATH}/src/scripts/calibration_analyses/analysis_scripts/process.py" "${task_output_dir}" "${RUN_NAME}" "${WORKTREE_PATH}/resources"
+        working-directory: "${{ env.WORKTREE_PATH }}"
+        env:
+          output_dir: "${{ needs.setup.outputs.output_dir }}"
+
+  # Cleanup stage, to remove temporary directories and such
+  cleanup:
+    name: Cleanup job
+    # It depends on all the previous jobs, but it always runs, regardless of
+    # their success (or maybe check that only `setup` was
+    # successful?)
+    if: ${{ always() }}
+    timeout-minutes: 10
+    needs: [setup, tasks, postprocess]
+    runs-on: [tlo-dev-vm-3]
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Cleanup worktree
+        run: |
+          git -C "${REPO_PATH}" worktree remove -f "${WORKTREE_PATH}" || true
+
+      - name: Cleanup virtual environment
+        run: |
+          rm -rvf "${ENV}"

--- a/.github/workflows/calibration.yaml
+++ b/.github/workflows/calibration.yaml
@@ -27,7 +27,7 @@ jobs:
   # `actions/checkout` workflow.
   setup:
     name: Setup
-    runs-on: [tlo-dev-vm-3]
+    runs-on: [tlo-dev-vm-1]
     strategy:
       fail-fast: false
     outputs:
@@ -100,7 +100,7 @@ jobs:
   tasks:
     needs: setup
     name: Run task ${{ matrix.index }}
-    runs-on: [tlo-dev-vm-3, tasks] # Use only runners dedicated to running the tasks.
+    runs-on: [tlo-dev-vm-1, tasks] # Use only runners dedicated to running the tasks.
     timeout-minutes: 5760 # = 4 * 24 * 60 minutes = 4 days
     strategy:
       fail-fast: false
@@ -121,7 +121,7 @@ jobs:
   postprocess:
     name: Post processing
     needs: [setup, tasks]
-    runs-on: [tlo-dev-vm-3, postprocess] # Use only the runners dedicated to postprocessing
+    runs-on: [tlo-dev-vm-1, postprocess] # Use only the runners dedicated to postprocessing
     strategy:
       fail-fast: false
     steps:
@@ -143,7 +143,7 @@ jobs:
     if: ${{ always() }}
     timeout-minutes: 10
     needs: [setup, tasks, postprocess]
-    runs-on: [tlo-dev-vm-3]
+    runs-on: [tlo-dev-vm-1]
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/calibration.yaml
+++ b/.github/workflows/calibration.yaml
@@ -15,7 +15,7 @@ env:
   REPO_PATH:       /mnt/tlo/TLOmodel
   OUTPUT_ROOT:     /mnt/tlo/output
   RUNS_NUMBER:     4
-  PYTHON_VER:      3.8
+  PYTHON_VER:      3.11
   RUN_NAME:        021_long_run_all_diseases_run
   PROCESS_NAME:    022_long_run_all_diseases_process
 

--- a/.github/workflows/comment-triggered-ci.yml
+++ b/.github/workflows/comment-triggered-ci.yml
@@ -10,7 +10,7 @@ jobs:
   scaled_sim:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: self-hosted
+      runs-on: [self-hosted, test]
       keyword: scaled-sim
       commands: tox -v -e profile
       description: Profiled scale run of model
@@ -23,7 +23,7 @@ jobs:
   multiple_seed_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: self-hosted
+      runs-on: [self-hosted, test]
       keyword: multiple-seed-tests
       commands: |
         tox -v -e py311,report -- pytest --seed 2671936806 3512589365 --cov --cov-report=term-missing -vv tests
@@ -37,7 +37,7 @@ jobs:
   python311_pandas15_fast_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: self-hosted
+      runs-on: [self-hosted, test]
       keyword: python3.11-pandas1.5-fast-tests
       commands: |
         tox -v -e py311-pandas15,report -- pytest --skip-slow --cov --cov-report=term-missing -vv tests
@@ -51,7 +51,7 @@ jobs:
   python311_pandas15_all_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: self-hosted
+      runs-on: [self-hosted, test]
       keyword: python3.11-pandas1.5-all-tests
       commands: |
         tox -v -e py311-pandas15,report -- pytest --cov --cov-report=term-missing -vv tests
@@ -65,7 +65,7 @@ jobs:
   python311_pandas20_fast_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: self-hosted
+      runs-on: [self-hosted, test]
       keyword: python3.11-pandas2.0-fast-tests
       commands: |
         tox -v -e py311-pandas20,report -- pytest --skip-slow --cov --cov-report=term-missing -vv tests
@@ -79,7 +79,7 @@ jobs:
   python311_pandas20_all_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: self-hosted
+      runs-on: [self-hosted, test]
       keyword: python3.11-pandas2.0-all-tests
       commands: |
         tox -v -e py311-pandas20,report -- pytest --cov --cov-report=term-missing -vv tests
@@ -93,7 +93,7 @@ jobs:
   python311_pandas21_fast_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: self-hosted
+      runs-on: [self-hosted, test]
       keyword: python3.11-pandas2.1-fast-tests
       commands: |
         tox -v -e py311-pandas21,report -- pytest --skip-slow --cov --cov-report=term-missing -vv tests
@@ -107,7 +107,7 @@ jobs:
   python311_pandas21_all_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: self-hosted
+      runs-on: [self-hosted, test]
       keyword: python3.11-pandas2.1-all-tests
       commands: |
         tox -v -e py311-pandas21,report -- pytest --cov --cov-report=term-missing -vv tests
@@ -121,7 +121,7 @@ jobs:
   dummy_job:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: self-hosted
+      runs-on: [self-hosted, test]
       keyword: dummy-job
       commands: 'true'
       description: Dummy job for testing workflow

--- a/.github/workflows/run-profiling.yaml
+++ b/.github/workflows/run-profiling.yaml
@@ -51,7 +51,7 @@ jobs:
     needs: set-variables
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: self-hosted
+      runs-on: [self-hosted, test]
       keyword: profiling
       commands: |
         tox -vv -e profile -- --output_name ${{ needs.set-variables.outputs.profiling-filename }}
@@ -69,7 +69,7 @@ jobs:
     name: Scheduled / dispatch triggered profiling
     if: ${{ github.event_name != 'issue_comment' }}
     needs: set-variables
-    runs-on: self-hosted
+    runs-on: [self-hosted, test]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
   test:
     needs: gen-test-matrix
     name: Test ${{ matrix.file }}
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, test]
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.gen-test-matrix.outputs.matrix) }}

--- a/deploy/gha-runners/provisioning/task-runner-playbook.yml
+++ b/deploy/gha-runners/provisioning/task-runner-playbook.yml
@@ -1,0 +1,34 @@
+- name: Install GitHub Actions runners
+  import_playbook: playbook.yml
+
+- hosts: all
+  vars:
+    runner_user: gha
+    mount_path: /mnt/tlodev2stg/tlo-dev-fs-2
+
+  tasks:
+
+   - name: install packages from apt
+     become: true
+     apt:
+       name:
+         - nfs-common
+       state: present
+
+   - name: "Create {{ mount_path }} directory"
+     become: true
+     ansible.builtin.file:
+       path: "{{ mount_path }}"
+       state: directory
+       owner: "{{ runner_user }}"
+       group: "{{ runner_user }}"
+       mode: '755'
+
+   - name: Mount output storage
+     become: true
+     ansible.posix.mount:
+       path: "{{ mount_path }}"
+       src: tlodev2stg.file.core.windows.net:/tlodev2stg/tlo-dev-fs-2
+       fstype: nfs
+       opts: vers=4,minorversion=1,sec=sys,nconnect=4
+       state: mounted

--- a/src/scripts/calibration_analyses/analysis_scripts/process.py
+++ b/src/scripts/calibration_analyses/analysis_scripts/process.py
@@ -3,49 +3,15 @@ import sys
 from pathlib import Path
 
 
-def check_completed(scenario_outputs, number_of_runs):
-    print(f'Looking in {scenario_outputs}')
-    # check each scenario run
-    for scenario_number in range(0, number_of_runs):
-        scenario_output = scenario_outputs / str(scenario_number)
-        # if output directory doesn't exist
-        if not os.path.isdir(scenario_output):
-            print(f'{scenario_output} doesnt exist')
-            return None
-        # if exit status file doesn't exist
-        exit_status_file = f'{scenario_output}/exit_status.txt'
-        if not os.path.isfile(exit_status_file):
-            print(f'{exit_status_file} doesnt exist')
-            return None
-    # both the output directory and the exit status exists - all runs of scenario are finish
-    # begin analysis here:
-    return scenario_outputs
-
-
-def process(output_dir, scenario_runs_dir):
+def process(output_dir, scenario_runs_dir, resources_dir):
     from importlib import import_module
 
     function = getattr(import_module('analysis_all_calibration'), 'apply')
-    function(scenario_runs_dir, output_dir, Path('/home/azureuser/TLOmodel/resources'))
-
-    # function = getattr(import_module('analysis_demography_calibrations'), 'apply')
-    # function(scenario_runs_dir, output_dir, Path('/home/azureuser/TLOmodel/resources'))
-    #
-    # function = getattr(import_module('analysis_cause_of_death_and_disability_calibrations'), 'apply')
-    # function(scenario_runs_dir, output_dir, Path('/home/azureuser/TLOmodel/resources'))
-    #
-    # function = getattr(import_module('analysis_hsi_descriptions'), 'apply')
-    # function(scenario_runs_dir, output_dir, Path('/home/azureuser/TLOmodel/resources'))
+    function(scenario_runs_dir, output_dir, resources_dir)
 
 
 if __name__ == '__main__':
     _output_dir_for_processed = Path(sys.argv[1])
     _run_directory_name = sys.argv[2]
-    _number_of_runs = int(sys.argv[3])
-    _output_dir_for_scenario_runs = _output_dir_for_processed.parent / _run_directory_name / '0'
-    _scenario_output_dir = check_completed(_output_dir_for_scenario_runs, _number_of_runs)
-    if _scenario_output_dir is not None:
-        process(_output_dir_for_processed, _output_dir_for_processed.parent / _run_directory_name)
-    else:
-        # exit status 99 to signal we're not ready to process results, resubmit this task
-        sys.exit(99)
+    _resources_dir = Path(sys.argv[3])
+    process(_output_dir_for_processed, _output_dir_for_processed.parent / _run_directory_name, _resources_dir)

--- a/src/scripts/calibration_analyses/analysis_scripts/process.py
+++ b/src/scripts/calibration_analyses/analysis_scripts/process.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from pathlib import Path
 
@@ -14,4 +13,6 @@ if __name__ == '__main__':
     _output_dir_for_processed = Path(sys.argv[1])
     _run_directory_name = sys.argv[2]
     _resources_dir = Path(sys.argv[3])
-    process(_output_dir_for_processed, _output_dir_for_processed.parent / _run_directory_name, _resources_dir)
+    process(_output_dir_for_processed,
+            _output_dir_for_processed.parent / _run_directory_name,
+            _resources_dir)

--- a/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
+++ b/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
@@ -21,8 +21,8 @@ class LongRun(BaseScenario):
         super().__init__()
         self.seed = 0
         self.start_date = Date(2010, 1, 1)
-        self.end_date = Date(2030, 1, 1)
-        self.pop_size = 20_000
+        self.end_date = Date(2020, 1, 1)
+        self.pop_size = 1000
         self.number_of_draws = 1
         self.runs_per_draw = 10
 

--- a/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
+++ b/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
@@ -21,8 +21,8 @@ class LongRun(BaseScenario):
         super().__init__()
         self.seed = 0
         self.start_date = Date(2010, 1, 1)
-        self.end_date = Date(2020, 1, 1)
-        self.pop_size = 1000
+        self.end_date = Date(2030, 1, 1)
+        self.pop_size = 20_000
         self.number_of_draws = 1
         self.runs_per_draw = 10
 


### PR DESCRIPTION
Opening as draft as I'm running some more tests in [my fork](https://github.com/giordano/TLOmodel), but I had some successful runs in another (private) repositories.

### TODO

* [x] Add `test` label to all other runners
  * Question: do we need to reprovision all virtual machines with #1149, or we keep the existing runners and manually add the labels?
* [x] Should we mount the temp directory with the output of the calibrations to a permanent storage?
* [x] Increase runs number to 14
* [x] Revert the extra commit for testing before merging