### PR TITLE
Avoid repeated dataframe access by querying all columns at once in `SymptomManager.has_what`

### DIFF
--- a/src/tlo/methods/symptommanager.py
+++ b/src/tlo/methods/symptommanager.py
@@ -484,7 +484,8 @@ class SymptomManager(Module):
             )
             return [s for s in self.symptom_names if person_has[f'sy_{s}']]
         else:
-            return [s for s in self.symptom_names if df.loc[person_id, f'sy_{s}'] > 0]
+            symptom_cols = df.loc[person_id, [f'sy_{s}' for s in self.symptom_names]]
+            return symptom_cols.index[symptom_cols > 0].str.removeprefix("sy_").to_list()
 
     def have_what(self, person_ids: Sequence[int]):
         """Find the set of symptoms for a list of person_ids.


### PR DESCRIPTION
When doing the memory profiling as part of #1163 I noticed the line

https://github.com/UCL/TLOmodel/blob/feea6b6face0bcedec47a6dce5348e2439344921/src/tlo/methods/symptommanager.py#L487

was registering a lot of memory allocations, presumably because of the repeated dataframe access a column at at time. This PR changes to use a single `loc` indexer with all required columns then uses boolean indexing to avoid a list comprehension.