### PR TITLE
Add DOI to citation and badge to README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@
 # Any manual updates to author list here may be overwritten
 cff-version: 1.2.0
 title: The Thanzi La Onse Model
-version: 1.0.0
+doi: 10.5281/zenodo.10144015
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 authors:

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.10144015.svg
+  :target: https://zenodo.org/doi/10.5281/zenodo.10144015
+
 =====================
 Getting Started
 =====================
-
-
-
 
 Prequisites
 ===========


### PR DESCRIPTION
Adds the Zenodo DOI to the `CITATION.cff` file (using DOI which represents all versions rather than version specific DOI) and removes the `version` property with the view that we are likely to not keep this up to date. Ideally we would automate updating this with GitHub Actions on creating a release but for now going with the simpler approach of just removing!

Also adds a DOI badge to the README. As this is automatically pulled in to the docs website at https://www.tlomodel.org/readme.html we might not want to include this - happy to get rid if we think unnecessary.