### PR TITLE
[CI] Upgrade Python on test machines to v3.11

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install tox
         run: python3 -m pip install tox
       - name: Run checks with tox

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,6 +36,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install tox
-        run: python -m pip install tox
+        run: python3 -m pip install tox
       - name: Run checks with tox
         run: tox -v -e check

--- a/.github/workflows/comment-triggered-ci.yml
+++ b/.github/workflows/comment-triggered-ci.yml
@@ -26,7 +26,7 @@ jobs:
       runs-on: self-hosted
       keyword: multiple-seed-tests
       commands: |
-        tox -v -e py38,report -- pytest --seed 2671936806 3512589365 --cov --cov-report=term-missing -vv tests
+        tox -v -e py311,report -- pytest --seed 2671936806 3512589365 --cov --cov-report=term-missing -vv tests
       description: Run of tests over multiple seeds
       timeout-minutes: 8640
       application-organization: UCL

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install tox
-        run: python -m pip install tox
+        run: python3 -m pip install tox
       - name: Build HTML documentation with tox
         run: tox -v -e docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install tox
         run: python3 -m pip install tox
       - name: Build HTML documentation with tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
       - name: System info
         run: |
           set -x
-          python --version
+          python3 --version
           uname -a
           lsb_release -a
           virtualenv --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,4 +75,4 @@ jobs:
           tox --version
       - name: Test with tox
         run: |
-          tox -v -e py38,report -- pytest --cov --cov-report=term-missing -vv "${{ matrix.file }}"
+          tox -v -e py311,report -- pytest --cov --cov-report=term-missing -vv "${{ matrix.file }}"

--- a/deploy/gha-runners/provisioning/playbook.yml
+++ b/deploy/gha-runners/provisioning/playbook.yml
@@ -8,7 +8,7 @@
     runner_user: gha
     runner_user_homedir: "/home/{{ runner_user }}"
     runner_workdir: /mnt/tlo
-    python_version: "3.8"
+    python_version: "3.11"
     ## SSH hardening
     ssh_deny_users: "{{ runner_user }}"
     # In Azure VMs connection times out after every ~4.5 minutes, sending this

--- a/tox.ini
+++ b/tox.ini
@@ -14,11 +14,11 @@ envlist =
 
 [testenv]
 basepython =
-    {py38,docs,profile,citation}: {env:TOXPYTHON:python3.8}
+    py38: {env:TOXPYTHON:python3.8}
     {clean,check,report,codecov,spell}: {env:TOXPYTHON:python3}
     py39: {env:TOXPYTHON:python3.9}
     py310: {env:TOXPYTHON:python3.10}
-    py311: {env:TOXPYTHON:python3.11}
+    {py311,docs,profile,citation}: {env:TOXPYTHON:python3.11}
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes


### PR DESCRIPTION
We upgraded test machines to use Python 3.11, this PR updates the CI setup to use that one.