### PR TITLE
JSON encode sequences used as `runs-on` input to `run-on-comment` workflow

### DIFF
--- a/.github/workflows/comment-triggered-ci.yml
+++ b/.github/workflows/comment-triggered-ci.yml
@@ -10,7 +10,7 @@ jobs:
   scaled_sim:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: [self-hosted, test]
+      runs-on: "[self-hosted, test]"
       keyword: scaled-sim
       commands: tox -v -e profile
       description: Profiled scale run of model
@@ -23,7 +23,7 @@ jobs:
   multiple_seed_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: [self-hosted, test]
+      runs-on: "[self-hosted, test]"
       keyword: multiple-seed-tests
       commands: |
         tox -v -e py311,report -- pytest --seed 2671936806 3512589365 --cov --cov-report=term-missing -vv tests
@@ -37,7 +37,7 @@ jobs:
   python311_pandas15_fast_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: [self-hosted, test]
+      runs-on: "[self-hosted, test]"
       keyword: python3.11-pandas1.5-fast-tests
       commands: |
         tox -v -e py311-pandas15,report -- pytest --skip-slow --cov --cov-report=term-missing -vv tests
@@ -51,7 +51,7 @@ jobs:
   python311_pandas15_all_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: [self-hosted, test]
+      runs-on: "[self-hosted, test]"
       keyword: python3.11-pandas1.5-all-tests
       commands: |
         tox -v -e py311-pandas15,report -- pytest --cov --cov-report=term-missing -vv tests
@@ -65,7 +65,7 @@ jobs:
   python311_pandas20_fast_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: [self-hosted, test]
+      runs-on: "[self-hosted, test]"
       keyword: python3.11-pandas2.0-fast-tests
       commands: |
         tox -v -e py311-pandas20,report -- pytest --skip-slow --cov --cov-report=term-missing -vv tests
@@ -79,7 +79,7 @@ jobs:
   python311_pandas20_all_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: [self-hosted, test]
+      runs-on: "[self-hosted, test]"
       keyword: python3.11-pandas2.0-all-tests
       commands: |
         tox -v -e py311-pandas20,report -- pytest --cov --cov-report=term-missing -vv tests
@@ -93,7 +93,7 @@ jobs:
   python311_pandas21_fast_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: [self-hosted, test]
+      runs-on: "[self-hosted, test]"
       keyword: python3.11-pandas2.1-fast-tests
       commands: |
         tox -v -e py311-pandas21,report -- pytest --skip-slow --cov --cov-report=term-missing -vv tests
@@ -107,7 +107,7 @@ jobs:
   python311_pandas21_all_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: [self-hosted, test]
+      runs-on: "[self-hosted, test]"
       keyword: python3.11-pandas2.1-all-tests
       commands: |
         tox -v -e py311-pandas21,report -- pytest --cov --cov-report=term-missing -vv tests
@@ -121,7 +121,7 @@ jobs:
   dummy_job:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: [self-hosted, test]
+      runs-on: "[self-hosted, test]"
       keyword: dummy-job
       commands: 'true'
       description: Dummy job for testing workflow

--- a/.github/workflows/run-on-comment.yml
+++ b/.github/workflows/run-on-comment.yml
@@ -4,7 +4,8 @@ on:
   workflow_call:
     inputs:
       runs-on:
-        description: The type of machine to run job on
+        description: |
+          The type(s) of machine to run job on. Use JSON encoded strings for sequences.
         required: false
         type: string
         default: ubuntu-latest
@@ -64,7 +65,7 @@ on:
         required: true
 jobs:
   run_test_on_keyword_and_reply_with_result:
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     if: github.event.comment.body == format('/run {0}', inputs.keyword)
     steps:

--- a/.github/workflows/run-profiling.yaml
+++ b/.github/workflows/run-profiling.yaml
@@ -51,7 +51,7 @@ jobs:
     needs: set-variables
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: [self-hosted, test]
+      runs-on: "[self-hosted, test]"
       keyword: profiling
       commands: |
         tox -vv -e profile -- --output_name ${{ needs.set-variables.outputs.profiling-filename }}


### PR DESCRIPTION
Fixes #1215 

Makes all sequence values passed to `runs-on` input to` run-on-comment` reusable workflow JSON encoded strings rather than raw sequences and uses `fromJSON` function to decode string when passing to triggered workflow job's `run-on` property.
