### PR TITLE
Use correct JSON encoding of array of strings

### DIFF
--- a/.github/workflows/comment-triggered-ci.yml
+++ b/.github/workflows/comment-triggered-ci.yml
@@ -10,7 +10,7 @@ jobs:
   scaled_sim:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: "[self-hosted, test]"
+      runs-on: '["self-hosted", "test"]'
       keyword: scaled-sim
       commands: tox -v -e profile
       description: Profiled scale run of model
@@ -23,7 +23,7 @@ jobs:
   multiple_seed_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: "[self-hosted, test]"
+      runs-on: '["self-hosted", "test"]'
       keyword: multiple-seed-tests
       commands: |
         tox -v -e py311,report -- pytest --seed 2671936806 3512589365 --cov --cov-report=term-missing -vv tests
@@ -37,7 +37,7 @@ jobs:
   python311_pandas15_fast_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: "[self-hosted, test]"
+      runs-on: '["self-hosted", "test"]'
       keyword: python3.11-pandas1.5-fast-tests
       commands: |
         tox -v -e py311-pandas15,report -- pytest --skip-slow --cov --cov-report=term-missing -vv tests
@@ -51,7 +51,7 @@ jobs:
   python311_pandas15_all_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: "[self-hosted, test]"
+      runs-on: '["self-hosted", "test"]'
       keyword: python3.11-pandas1.5-all-tests
       commands: |
         tox -v -e py311-pandas15,report -- pytest --cov --cov-report=term-missing -vv tests
@@ -65,7 +65,7 @@ jobs:
   python311_pandas20_fast_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: "[self-hosted, test]"
+      runs-on: '["self-hosted", "test"]'
       keyword: python3.11-pandas2.0-fast-tests
       commands: |
         tox -v -e py311-pandas20,report -- pytest --skip-slow --cov --cov-report=term-missing -vv tests
@@ -79,7 +79,7 @@ jobs:
   python311_pandas20_all_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: "[self-hosted, test]"
+      runs-on: '["self-hosted", "test"]'
       keyword: python3.11-pandas2.0-all-tests
       commands: |
         tox -v -e py311-pandas20,report -- pytest --cov --cov-report=term-missing -vv tests
@@ -93,7 +93,7 @@ jobs:
   python311_pandas21_fast_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: "[self-hosted, test]"
+      runs-on: '["self-hosted", "test"]'
       keyword: python3.11-pandas2.1-fast-tests
       commands: |
         tox -v -e py311-pandas21,report -- pytest --skip-slow --cov --cov-report=term-missing -vv tests
@@ -107,7 +107,7 @@ jobs:
   python311_pandas21_all_tests:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: "[self-hosted, test]"
+      runs-on: '["self-hosted", "test"]'
       keyword: python3.11-pandas2.1-all-tests
       commands: |
         tox -v -e py311-pandas21,report -- pytest --cov --cov-report=term-missing -vv tests
@@ -121,7 +121,7 @@ jobs:
   dummy_job:
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: "[self-hosted, test]"
+      runs-on: '["self-hosted", "test"]'
       keyword: dummy-job
       commands: 'true'
       description: Dummy job for testing workflow

--- a/.github/workflows/run-profiling.yaml
+++ b/.github/workflows/run-profiling.yaml
@@ -60,7 +60,7 @@ jobs:
     needs: set-variables
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: "[self-hosted, test]"
+      runs-on: '["self-hosted", "test"]'
       keyword: profiling
       commands: |
         tox -vv -e profile -- \

--- a/.github/workflows/run-profiling.yaml
+++ b/.github/workflows/run-profiling.yaml
@@ -97,7 +97,7 @@ jobs:
         run: |
           tox -vv -e profile -- \
             --html \
-            --output-dir ${{ needs.set-variables.outputs.profiling-output-dir }} \
+            --root-output-dir ${{ needs.set-variables.outputs.profiling-output-dir }} \
             --output-name ${{ needs.set-variables.outputs.profiling-filename }} \
             --additional-stats \
             sha=${{ needs.set-variables.outputs.profiling-on-sha }} \


### PR DESCRIPTION
Second attempt at fixing #1215 - apologies for the PR noise.

Previous fix in #1216 changed the `runs-on` inputs to JSON arrays but did not make sure the entries in each array were strings meaning [we get an error](https://github.com/UCL/TLOmodel/actions/runs/7006391856)

```
Error when evaluating 'runs-on' for job 'run_test_on_keyword_and_reply_with_result'. UCL/TLOmodel/.github/workflows/run-on-comment.yml@e7cb080ca2b100c82b3d9c7063a6c91f73e63a25 (Line: 68, Col: 14): Error parsing fromJson,UCL/TLOmodel/.github/workflows/run-on-comment.yml@e7cb080ca2b100c82b3d9c7063a6c91f73e63a25 (Line: 68, Col: 14): Unexpected character encountered while parsing value: s. Path '', line 1, position 1.,UCL/TLOmodel/.github/workflows/run-on-comment.yml@e7cb080ca2b100c82b3d9c7063a6c91f73e63a25 (Line: 68, Col: 14): Unexpected value ''
```

when trying to parse the string as JSON in the reusable workflow. This is fixed here by (i) enclosing the whole value in single quotes (as YAML allows strings to be specified using both matched single and double quotes, with some minor differences in escaping behaviour) and (ii) wrapping the values in the array in double quotes (as JSON only allows double quotes around strings). I've verified this works this time on [test repository](https://github.com/matt-graham/pr-comment-workflows/issues/2#issuecomment-1827970158).

Also fixes an issue with a command line argument name passed to `run_profiling.py` script in the `run-profiling.yaml` workflow which should have been `--root-output-dir` not `--output-dir` (which was source of [error in run here](https://github.com/UCL/TLOmodel/actions/runs/7004664008/job/19052879158#step:3:1061)).