### PR TITLE
Change default profiling simulation length to 5 years

### DIFF
--- a/src/scripts/profiling/run_profiling.py
+++ b/src/scripts/profiling/run_profiling.py
@@ -342,7 +342,7 @@ if __name__ == "__main__":
         "--simulation-years",
         type=int,
         help="Number of years to simulate for (plus --simulation-months months)",
-        default=20,
+        default=5,
     )
     parser.add_argument(
         "-m",


### PR DESCRIPTION
I unintentionally set the default value for the `--years` argument to `run_profiling.py` script to 20 rather than 5 (which is the default value in the associated `run_profiling` function).

A workflow run which was manually triggered to run using this configuration seems to [have hung with simulation 60% complete](https://github.com/UCL/TLOmodel/actions/runs/7018520195/job/19094097221) (last update of progress bar is showing ~30 hours elapsed despite it having been running for more than 52 hours), which I suspect is because of the test runner running out of memory 😬 over such a long run. From that run it looks like a 5 year run (which should still be sufficient to give reflective profiling results) should complete in roughly 11 hours which is more reasonable, and we also have more assurance it won't max out memory within that window given the run linked above continued past the 10 year mark without issues.