### PR TITLE
Correct setting of package version from metadata

### DIFF
--- a/src/tlo/__init__.py
+++ b/src/tlo/__init__.py
@@ -15,7 +15,7 @@ from .population import Population  # noqa
 from .simulation import Simulation  # noqa
 
 try:
-    __version__ = version("package-name")
+    __version__ = version("tlo")
 except PackageNotFoundError:
     # package is not installed
     pass


### PR DESCRIPTION
I mistakenly didn't change `package-name` placeholder in [example from `setuptools_scm` docs](https://setuptools-scm.readthedocs.io/en/latest/usage/#version-at-runtime) for setting `__version__` at package level from metadata.