### PR TITLE
Ignore `profiling_results` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,7 @@ coverage.xml
 .pytest_cache/
 
 # Profiling results files
-src/scripts/profiling/results/
-results/
+profiling_results
 
 # Translations
 *.mo


### PR DESCRIPTION
Adds `profiling_results` (default directory `src/scripts/profiling/run_profiling.py` script, and associated `profiling` `tox` environment, output to) to `.gitignore` and remove the previous `src/scripts/profiling/results/` and `results` ignores (as we typically won't be outputting to either of these and `results` might be a bit broad as could be non-profiling related).