### PR TITLE
Separate out malaria test in to two test functions to avoid reinitialising simulation

### DIFF
--- a/tests/test_malaria.py
+++ b/tests/test_malaria.py
@@ -208,7 +208,6 @@ def _setup_simulation_for_dx_algorithm_test(sim):
 
             self.EXPECTED_APPT_FOOTPRINT = the_appt_footprint
             self.ACCEPTED_FACILITY_LEVEL = '1a'
-            self.ALERT_OTHER_DISEASES = []
 
         def apply(self, person_id, squeeze_factor):
             pass


### PR DESCRIPTION
Fixes #1230 

Separates out the previous `test_dx_algorithm_for_malaria_outcomes` into two separate test functions `test_dx_algorithm_for_malaria_outcomes_clinical` and `test_dx_algorithm_for_malaria_outcomes_severe`, with the previous nested function `make_blank_simulation` now moved outside of the function definition and renamed to `_setup_simulation_for_dx_algorithm_test` so it can be used in both tests. Separating out the test functions ensures the `sim` simulation fixture only has `simulate` method called once per test, and as far as I could see the tests for the clinical and severe cases were not dependent on each other.