### PR TITLE
Fix removal of prefix in resource file documentation titles

### DIFF
--- a/docs/tlo_resources.py
+++ b/docs/tlo_resources.py
@@ -23,9 +23,17 @@ def rst_header(title: str, level: int = 0) -> str:
     return title + "\n" + (separator_character * len(title)) + "\n\n"
 
 
+def _remove_prefix(text, prefix):
+    """Remove prefix if present from text.
+
+    Equivalent to str.removeprefix method present in Python 3.9+.
+    """
+    return text[len(prefix) :] if text.startswith(prefix) else text
+
+
 def rst_resource_file_header(resource_file_path: Path) -> str:
     resource_file_name = (
-        resource_file_path.stem.lstrip("ResourceFile_").replace("_", " ")
+        _remove_prefix(resource_file_path.stem, "ResourceFile_").replace("_", " ")
         + f" ({resource_file_path.suffix})"
     )
     return (


### PR DESCRIPTION
I got mixed up between `str.lstrip` and `str.removeprefix` (which is only available Python 3.9+) when generating titles for resource file documentation pages. Current implementation strips all characters in `"ResourcesFile_"` from beginning of file name, rather than only those characters in that particular order so for example removes `co` from the beginning of `consumables` https://www.tlomodel.org/resources/ResourceFile_consumable_availability.csv.html