### PR TITLE
Update calibration webpage in post-processing step

### DIFF
--- a/.github/workflows/calibration.yaml
+++ b/.github/workflows/calibration.yaml
@@ -163,6 +163,7 @@ jobs:
           mkdir -p "${task_output_dir}"
 
           python3 "${{ needs.setup.outputs.worktree_path }}/src/scripts/calibration_analyses/analysis_scripts/process.py" "${task_output_dir}" "${RUN_NAME}" "${{ needs.setup.outputs.worktree_path }}/resources"
+          python3 "${{ needs.setup.outputs.worktree_path }}/src/scripts/task_runner/generate_html.py" "${OUTPUT_ROOT}" > "${OUTPUT_ROOT}/index.html"
         working-directory: "${{ needs.setup.outputs.worktree_path }}"
 
   # Cleanup stage, to remove temporary directories and such

--- a/src/scripts/task_runner/generate_html.py
+++ b/src/scripts/task_runner/generate_html.py
@@ -39,9 +39,11 @@ def get_html_for_commit(commit_dir: Path) -> str:
 
     # from the info.txt file, we know the message of the commit & can link to GitHub page
     if (commit_dir / "info.txt").is_file():
-        commit_log = open(commit_dir / "info.txt", "r").readline().strip().split()
-        commit_title = date + " - " + " ".join(commit_log[2:])
-        gh_link = f"https://github.com/UCL/TLOmodel/commit/{commit_log[0]}"
+        with open(commit_dir / "info.txt") as info_file:
+            commit_id, _, *commit_msg = info_file.readline().strip().split()
+            commit_msg = " ".join(commit_msg)
+        commit_title = f"{date} - {commit_msg}"
+        gh_link = f"https://github.com/UCL/TLOmodel/commit/{commit_id}"
         commit_links.append(f"<a href='{gh_link}'>gh</a>")
 
     # link to raw log files

--- a/src/scripts/task_runner/generate_html.py
+++ b/src/scripts/task_runner/generate_html.py
@@ -99,9 +99,9 @@ page_template = Template("""<!DOCTYPE html>
 <body>
 <h1>$title</h1>
 <p style="font-size: small;">
-    This page was generated on $generated_time. 
-    The workflow runs every night on the latest new commit on the master branch. 
-    <a href="#" id="toggleIncomplete">toggle incomplete</a>
+    This page was generated on $generated_time. The 
+    <a href="https://github.com/UCL/TLOmodel/actions/workflows/calibration.yaml">calibration workflow</a> runs every 
+    night on the latest new commit on the master branch. <a href="#" id="toggleIncomplete">toggle incomplete</a>
 </p>
 $body
 </body>

--- a/src/scripts/task_runner/generate_html.py
+++ b/src/scripts/task_runner/generate_html.py
@@ -63,12 +63,13 @@ def get_html_for_commit(commit_dir: Path) -> str:
 commit_template = Template("""
 <p class="$p_class">
     $dir_title
-    $links<br />
+    $links<br>
 </p>
 """)
 
 page_template = Template("""
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <title>$title</title>
     <style>

--- a/src/scripts/task_runner/generate_html.py
+++ b/src/scripts/task_runner/generate_html.py
@@ -12,7 +12,7 @@ def main(output_directory: Path) -> None:
     """Generate and print the HTML page to stdout"""
     generated_time = datetime.datetime.now().strftime("%d %b %Y %H:%M")
 
-    commit_dirs = output_directory.glob("202?-[0-9a-f]*")
+    commit_dirs = [x for x in output_directory.iterdir() if x.is_dir()]
     commit_dirs = sorted(commit_dirs, reverse=True)
     commit_dirs = commit_dirs[:max_commits]
     body_html = "".join([get_html_for_commit(commit) for commit in commit_dirs])

--- a/src/scripts/task_runner/generate_html.py
+++ b/src/scripts/task_runner/generate_html.py
@@ -1,92 +1,115 @@
 import datetime
-import glob
-import os.path
 import re
 from pathlib import Path
+from string import Template
 
-import psutil  # this package must be installed manually - not part of the tlomodel requirements
-
-# This script must be run in the output directory
-output_directory = "."
-
-
-def do_task_directory(task_dir):
-    link = f"{task_dir}"
-    basename = '/'.join(task_dir.split('/')[1:])
-    exit_status_path = f"{task_dir}/exit_status.txt"
-    if os.path.exists(exit_status_path):
-        exit_status = open(f"{task_dir}/exit_status.txt", "r").read()
-        exit_status = exit_status.strip()
-        if exit_status.strip() in ("0", "99"):
-            status = "OK" if exit_status == "0" else "WAITING"
-            print(f"<li><a href='{link}' style='color: black'>{basename} - {status}</a></li>")
-        else:
-            print(f"<li style='color: red'><a href='{link}' style='color: red'>{basename} - ERR</a></li>")
-    else:
-        # task hasn't terminated - check the process!
-        task_info = f"{task_dir}/task.txt"
-        pid_exists = False
-        if os.path.exists(task_info):
-            for line in open(task_info, 'r'):
-                line = line.strip().split(' ')
-                if line[0].startswith("PID"):
-                    pid = line[1]
-                    pid_exists = psutil.pid_exists(int(pid))
-        status = "RUNNING" if pid_exists else "NO PROCESS"
-        color = "black" if pid_exists else "red"
-        print(f"<li style='color: {color}'><a href='{link}' style='color: {color}'>{basename} - {status}</a></li>")
+output_directory = Path(".")  # working directory must be the analyses output directory
+max_commits = 50  # Number of runs to show in the generated html
+page_title = "TLOmodel calibration analyses"
 
 
-def do_commit_directory(commit_dir):
-    if not os.path.isfile(f'{commit_dir}/stdout.txt'):
-        print(f'<h2>{commit_dir}</h2>')
-        print('WARNING: stdout.txt not found; cannot continue')
-        if not os.path.isfile(f'{commit_dir}/task.txt'):
-            print('<br />WARNING: task.txt file not found')
-        return
-    # get information about commit
-    for line in open(f'{commit_dir}/stdout.txt'):
-        if re.search("^HEAD is now at", line):
-            commit_message = line.rstrip().split(" ")[4:]
-            commit_header = ' '.join(commit_message)
-            print(f"<h2>{commit_header}</h2>")
-
-            commit_link = f"https://github.com/UCL/TLOmodel/commit/{commit_message[0]}"
-            top_dir = commit_dir.split("/")[-1]
-            print(f"{top_dir}: <a href='{commit_link}'>commit</a>")
-
-            pr_number = re.match(r"\(#(\d+)\)", commit_message[-1])
-            if pr_number is not None and pr_number.groups():
-                pr_link = f"https://github.com/UCL/TLOmodel/pull/{pr_number.groups()[0]}"
-                print(f" <a href='{pr_link}'>pr</a>")
-            break
-
-    print("<ul>")
-    #  for task in sorted(glob.glob(f'{commit_dir}/[0-9]*')):
-    for task in sorted(glob.glob(commit_dir + '/**/stderr.txt', recursive=True)):
-        do_task_directory(str(Path(task).parent))
-    print("</ul>")
+def main() -> None:
+    """Generate and print the HTML page to stdout"""
+    generated_time = datetime.datetime.now().strftime("%d %b %Y %H:%M")
+    body_html = get_html_for_all_commits()
+    page_html = page_template.substitute(title=page_title,
+                                         body=body_html,
+                                         generated_time=generated_time)
+    print(page_html)
 
 
-def run():
-    style = """
-    body {
-    font-family: Helvetica, Arial;
-    }
-    a, u {
-  text-decoration: none;
-}
-    """
-    print(f"""<html><head><title>TLOmodel runs</title><style>{style}</style></head><body>""")
-    print("<h1>TLOmodel runs</h1>")
-    generated_time = datetime.datetime.now().strftime('%Y-%b-%d %H:%M')
-    next_time = (datetime.datetime.now() + datetime.timedelta(minutes=5)).strftime('%Y-%b-%d %H:%M')
-    print(f"Generated {generated_time} (next {next_time})")
-    # loop over all commits that have been run (all begin with 202*
-    for commit in sorted(glob.glob(f'{output_directory}/202[0-9]*'), reverse=True):
-        do_commit_directory(commit)
-    print("</body></html>")
+def get_html_for_all_commits() -> str:
+    """Get the HTML for all commits analysed in the output directory"""
+    commit_dirs = output_directory.glob("202?-[0-9a-f]*")
+    commit_dirs = sorted(commit_dirs, reverse=True)
+    commit_dirs = commit_dirs[:max_commits]
+    body = [get_html_for_commit(commit) for commit in commit_dirs]
+    return "".join(body)
 
 
-if __name__ == '__main__':
-    run()
+def get_html_for_commit(commit_dir: Path) -> str:
+    """Get the HTML for a single commit directory"""
+
+    date = re.findall(r"\d{4}-\d{2}-\d{2}", commit_dir.name)[0]
+
+    # some default values
+    commit_title = commit_dir.name
+    commit_links = list()
+    commit_p_class = "incomplete"  # the commit is not shown by default
+
+    # from the info.txt file, we know the message of the commit & can link to GitHub page
+    if (commit_dir / "info.txt").is_file():
+        commit_log = open(commit_dir / "info.txt", "r").readline().strip().split()
+        commit_title = date + " - " + " ".join(commit_log[2:])
+        gh_link = f"https://github.com/UCL/TLOmodel/commit/{commit_log[0]}"
+        commit_links.append(f"<a href='{gh_link}'>gh</a>")
+
+    # link to raw log files
+    logs_dir = commit_dir / "021_long_run_all_diseases_run/0"
+    if logs_dir.is_dir():
+        commit_links.append(f"<a href='{logs_dir}'>logs</a>")
+
+    # if the post-process step has been completed, link to the results
+    results_file = commit_dir / "022_long_run_all_diseases_process/index.html"
+    if results_file.is_file():
+        commit_title = f"<a href='{results_file}'>{commit_title}</a>"
+        commit_p_class = "completed"
+
+    return commit_template.substitute(dir_title=commit_title,
+                                      links=" ".join(commit_links),
+                                      p_class=commit_p_class)
+
+
+commit_template = Template("""
+<p class="$p_class">
+    $dir_title
+    $links<br />
+</p>
+""")
+
+page_template = Template("""
+<html>
+<head>
+    <title>$title</title>
+    <style>
+        body {
+            font-family: Helvetica,Arial,sans-serif;
+            font-weight: 400;
+        }
+        .incomplete {
+            display: none;
+        }
+    </style>
+    <script>
+        // Toggle visibility of incomplete commits
+        document.addEventListener("DOMContentLoaded", function () {
+            let incompleteVisible = false;
+
+            function toggleIncomplete() {
+                document.querySelectorAll(".incomplete").forEach(incomplete => {
+                    incomplete.style.display = incompleteVisible ? "none" : "block";
+                });
+                incompleteVisible = !incompleteVisible;
+            }
+
+            document.getElementById("toggleIncomplete").addEventListener("click", function (event) {
+                event.preventDefault();
+                toggleIncomplete();
+            });
+        });
+    </script>
+</head>
+<body>
+<h1>$title</h1>
+<p style="font-size: small;">
+    This page was generated on $generated_time. 
+    The workflow runs every night on the latest new commit on the master branch. 
+    <a href="#" id="toggleIncomplete">toggle incomplete</a>
+</p>
+$body
+</body>
+</html>
+""")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Calibration webpage generation code has been cleaned up and simplified. Can be run from outside the output directory. Instead of cron job, we update the webpage in the post-processing step.
