### PR TITLE
[calibration] Do not write `info.txt` if skipping tasks

### DIFF
--- a/.github/workflows/calibration.yaml
+++ b/.github/workflows/calibration.yaml
@@ -110,6 +110,7 @@ jobs:
               SKIP_TASKS="true"
           fi
           echo "SKIP_TASKS=${SKIP_TASKS}"
+          echo "SKIP_TASKS=${SKIP_TASKS}" >> "${GITHUB_ENV}"
           echo "skip_tasks=${SKIP_TASKS}" >> "${GITHUB_OUTPUT}"
           RUNS="["
           for run in $(seq 0 $((${RUNS_NUMBER} - 1))); do
@@ -120,6 +121,7 @@ jobs:
           echo "tasks=${RUNS}" >> "${GITHUB_OUTPUT}"
 
       - name: Write info.txt file
+        if: ${{ env.SKIP_TASKS == 'false' }}
         run: |
           mkdir -p "${output_dir}"
           info_txt="${output_dir}/info.txt"


### PR DESCRIPTION
Fix issue reported at https://github.com/UCL/TLOmodel/issues/1244#issuecomment-1869350303