### PR TITLE
Pin `pytest` version installed by `tox`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     -r{toxinidir}/requirements/base.txt
     ; Pin pytest version as some tests use features deprecated in v8
     ; See https://github.com/UCL/TLOmodel/issues/1264
-    pytest==7.44
+    pytest==7.4.4
     pytest-cov
 commands =
     {posargs:pytest --cov --cov-report=term-missing -vv tests}
@@ -42,7 +42,7 @@ deps =
     pandas21: pandas==2.1.0
     ; Pin pytest version as some tests use features deprecated in v8
     ; See https://github.com/UCL/TLOmodel/issues/1264
-    pytest==7.44
+    pytest==7.4.4
     pytest-cov
 
 [testenv:spell]

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,9 @@ passenv =
 usedevelop = false
 deps =
     -r{toxinidir}/requirements/base.txt
-    pytest
+    ; Pin pytest version as some tests use features deprecated in v8
+    ; See https://github.com/UCL/TLOmodel/issues/1264
+    pytest==7.44
     pytest-cov
 commands =
     {posargs:pytest --cov --cov-report=term-missing -vv tests}
@@ -38,7 +40,9 @@ deps =
     pandas15: pandas==1.5.3
     pandas20: pandas==2.0.0
     pandas21: pandas==2.1.0
-    pytest
+    ; Pin pytest version as some tests use features deprecated in v8
+    ; See https://github.com/UCL/TLOmodel/issues/1264
+    pytest==7.44
     pytest-cov
 
 [testenv:spell]


### PR DESCRIPTION
Quick fix for #1264 - not linking to close that issue as ideally we should in the longer term fix the tests to work with Pytest v8 and remove the pins.