### PR TITLE
Update tests to work with Pytest v8

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -51,7 +51,7 @@ class TestLoadParametersFromDataframe:
 
     No explicit tests for correct parsing of boolean because of how python evaluates truthiness
     """
-    def setup(self):
+    def setup_method(self):
         class ParameterModule(Module):
             def __init__(self):
                 super().__init__(name=None)
@@ -169,7 +169,7 @@ class TestLoadParametersFromDataframe:
 
 class TestLoadParametersFromDataframe_Bools_From_Csv:
     """Tests for the load_parameters_from_dataframe method, including handling of bools when loading from csv"""
-    def setup(self):
+    def setup_method(self):
         class ParameterModule(Module):
             def __init__(self):
                 super().__init__(name=None)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -137,7 +137,7 @@ class TestStructuredLogging:
 
 
 class TestConvertLogData:
-    def setup(self):
+    def setup_method(self):
         self.expected_output = {'item_1': 1, 'item_2': 2}
         self.logger = logging.getLogger('tlo.test.logger')
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,9 +27,7 @@ passenv =
 usedevelop = false
 deps =
     -r{toxinidir}/requirements/base.txt
-    ; Pin pytest version as some tests use features deprecated in v8
-    ; See https://github.com/UCL/TLOmodel/issues/1264
-    pytest==7.4.4
+    pytest
     pytest-cov
 commands =
     {posargs:pytest --cov --cov-report=term-missing -vv tests}
@@ -40,9 +38,7 @@ deps =
     pandas15: pandas==1.5.3
     pandas20: pandas==2.0.0
     pandas21: pandas==2.1.0
-    ; Pin pytest version as some tests use features deprecated in v8
-    ; See https://github.com/UCL/TLOmodel/issues/1264
-    pytest==7.4.4
+    pytest
     pytest-cov
 
 [testenv:spell]


### PR DESCRIPTION
Fixes #1264 

Removes pinning of Pytest version in `tox.ini` and fixes tests to avoid use of features deprecated in Pytest v8.