### PR TITLE
Change write-up link for Contraception module to article

### DIFF
--- a/docs/writeups.rst
+++ b/docs/writeups.rst
@@ -35,7 +35,7 @@ Representation of the Healthcare System
 
 Contraception, Maternal and Newborn Health
 ===================================
-* **Contraception**: Determines fecundity, the usage of contraception (including switching between contraceptives) and the onset of pregnancy. `Journal article (Studies in Family Planning) <https://onlinelibrary.wiley.com/doi/10.1111/sifp.12255>`
+* **Contraception**: Determines fecundity, the usage of contraception (including switching between contraceptives) and the onset of pregnancy. :download:`.docx <./write-ups/Contraception.docx>` `Journal article (Studies in Family Planning) <https://onlinelibrary.wiley.com/doi/10.1111/sifp.12255>`
 
 * **Maternal and Newborn Health** Represents the antenatal period of pregnancy (the period from conception to the termination of pregnancy), labour, birth, the postnatal period, associated complications and healthcare delivered through routine and emergency maternity services. :download:`.pdf <./write-ups/MaternalNewbornHealth.pdf>`
 

--- a/docs/writeups.rst
+++ b/docs/writeups.rst
@@ -35,7 +35,7 @@ Representation of the Healthcare System
 
 Contraception, Maternal and Newborn Health
 ===================================
-* **Contraception**: Determines fecundity, the usage of contraception (including switching between contraceptives) and the onset of pregnancy. :download:`.docx <./write-ups/Contraception.docx>`
+* **Contraception**: Determines fecundity, the usage of contraception (including switching between contraceptives) and the onset of pregnancy. `Journal article (Studies in Family Planning) <https://onlinelibrary.wiley.com/doi/10.1111/sifp.12255>`
 
 * **Maternal and Newborn Health** Represents the antenatal period of pregnancy (the period from conception to the termination of pregnancy), labour, birth, the postnatal period, associated complications and healthcare delivered through routine and emergency maternity services. :download:`.pdf <./write-ups/MaternalNewbornHealth.pdf>`
 


### PR DESCRIPTION
Fixes #1247 

Changes link on documentation site write-ups page for _Contraception_ module to link to [published article in _Studies in Family Planning_](https://onlinelibrary.wiley.com/doi/10.1111/sifp.12255).

Currently this removes the link to the previous `.docx` write-up but doesn't remove the actual file. Alternatives would be to keep the link to the `.docx` file in addition to the article link or to remove the `.docx` file entirely.