### PR TITLE
Enable LFS in profiling workflow checkout + reduce frame recording interval

### DIFF
--- a/.github/workflows/run-profiling.yaml
+++ b/.github/workflows/run-profiling.yaml
@@ -91,6 +91,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
+          lfs: true
 
       ## The profile environment produces outputs in the /results directory
       - name: Run profiling in dev environment

--- a/src/scripts/profiling/run_profiling.py
+++ b/src/scripts/profiling/run_profiling.py
@@ -176,7 +176,7 @@ def run_profiling(
     output_name: str = "profiling",
     write_html: bool = False,
     write_pyisession: bool = False,
-    interval: float = 1e-1,
+    interval: float = 2e-1,
     initial_population: int = 50000,
     simulation_years: int = 5,
     simulation_months: int = 0,


### PR DESCRIPTION
Possible fixes for #1277 though not linking to that issue as will need to test workflow does reliably run after these changes have been made to be sure.

Adds `lfs: true` option in `actions/checkout` Action in `run-profiling` workflow to ensure LFS files are checked out correctly (necessary for profiling as this includes resource files we need for running simulation).

Also reduces the default interval at which frames are recorded during profiling from 0.1s to 0.2s with the hope this will reduce memory requirements when rendering profiling record to HTML which currently seems to be exceeding memory available on runners.