### PR TITLE
Include task-shifting

### DIFF
--- a/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
+++ b/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd5b508bfbb7b430cc05f116fd92df79e4663aff9d480e4ebd94dfa73530677e
-size 420
+oid sha256:df273f1a413b6d6c2cc81f392aa62e00fea78f67631d2bc802a78e3474a7356d
+size 426

--- a/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
+++ b/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e36cbd225191f893f2de5f0f34adc251046af5ec58daaf7c86b09a6c83c1e31d
-size 379
+oid sha256:cd5b508bfbb7b430cc05f116fd92df79e4663aff9d480e4ebd94dfa73530677e
+size 420

--- a/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
+++ b/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df273f1a413b6d6c2cc81f392aa62e00fea78f67631d2bc802a78e3474a7356d
-size 426
+oid sha256:a2e9d24736e254c3eabba58e83612c8f7615d65e52402b42c07b3e7f6b26e85d
+size 424

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -568,7 +568,7 @@ class HealthSystem(Module):
             Types.STRING, "Name of global task-shifting mode adopted"),
         
         'global_task_shifting': Parameter(
-            Types.DICT, "Global task-shifting policy adopted by the health care system. It includes a list of the officers"
+            Types.DICT, " Global task-shifting policy adopted by the health care system. It includes a list of the officers"
                         " eligible for task shifting. For each of those officers, it specifies which officers"
                         " can take over the officer's tasks, and a factor explaining how the originally scheduled time "
                         " should be scaled if performed by a different officer."),

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -2021,9 +2021,7 @@ def test_task_shifting_in_mode_2(seed, tmpdir):
 
     for i in range(0, int(tot_population)):
         sim.population.props.at[i, 'district_of_residence'] = keys_district[0]
-        
-    # Get facility ID
-    facID = int((re.search(r'\d+', next(iter(hsi1.expected_time_requests)))).group())
+
 
     # Schedule an identical appointment for all individuals
     for i in range(0, tot_population):
@@ -2046,6 +2044,9 @@ def test_task_shifting_in_mode_2(seed, tmpdir):
                          appt_type='MinorSurg',
                          level='1a')
     hsi1.initialise()
+    
+    # Get facility ID
+    facID = int((re.search(r'\d+', next(iter(hsi1.expected_time_requests)))).group())
 
     pharmacy_task_time = hsi1.expected_time_requests['FacilityID_' + str(facID) + '_Officer_Pharmacy']
     nursing_task_time = hsi1.expected_time_requests['FacilityID_' + str(facID) + '_Officer_Nursing_and_Midwifery']

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -2045,7 +2045,6 @@ def test_task_shifting_in_mode_2(seed, tmpdir):
                              level='1a')
         hsi1.initialise()
         
-        # Get facility ID
         facID = int((re.search(r'\d+', next(iter(hsi1.expected_time_requests)))).group())
 
         pharmacy_task_time = hsi1.expected_time_requests['FacilityID_' + str(facID) + '_Officer_Pharmacy']

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -1,12 +1,12 @@
 import heapq as hp
 import os
+import re
 from pathlib import Path
 from typing import Set, Tuple
 
 import numpy as np
 import pandas as pd
 import pytest
-import re
 
 from tlo import Date, Module, Simulation, logging
 from tlo.analysis.hsi_events import get_details_of_defined_hsi_events


### PR DESCRIPTION
Initial task-shifting implementation, currently assuming that the health-system adopts a "global policy" on task shifting. We will potentially transition to treatment-specific after health-econ discussion on 8th March.

PR includes test (test_task_shifting_in_mode_2)

Other notes:
- We assume ranking in preferred option for task-shifting (e.g. first choice for task-shifting pharmacists are nurses, followed by clinicians);
- We assume that task-shifting occurs immediately when appt is extracted from the queue (i.e. we don't wait until the end of the day to check if we could have performed extra appts by allowing task-shifting). This seems consistent with the fact that appts are ranked by priority: earlier appts in the queue are higher priority, and therefore the health system does everything possible, including task-shifting, to complete them first.
- We assume that tasks performed by different medical officers don't have to be performed simultaneously, i.e. if appt requires both nurse and pharmacist, nurse will be able to perform own task *and* that of pharmacist if the latter is no longer available.
- Currently we have no way of logging occurrences of task-shifting (although of course in mode 2 it will impact the number of appts performed) because we don't have appt_footprints that reflect the task shifting. We can discuss whether we want to address this or not.