### PR TITLE
Fix profiling workflow failures

### DIFF
--- a/.github/workflows/run-profiling.yaml
+++ b/.github/workflows/run-profiling.yaml
@@ -39,20 +39,26 @@ jobs:
       profiling-on-sha: ${{ steps.determine-correct-sha.outputs.result }}
       profiling-event-trigger: ${{ steps.set-github-info.outputs.event }}
     steps:
+      - id: determine-if-pr-comment
+        name: Determine if this is a PR comment
+        run: |
+          if ! [ -z "${{ github.event.issue.pull_request }}" ]; then echo "is-pr=true" >> "${GITHUB_OUTPUT}"; else echo "is-pr=false" >> "${GITHUB_OUTPUT}"; fi
+
       - id: determine-correct-sha
+        name: Determine the SHA to run profiling on
         uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
-            if (!context.payload.issue.pull_request) {
-              return context.sha;
+            if ("${{ steps.determine-if-pr-comment.outputs.is-pr }}" === "true") {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.issue.owner,
+                repo: context.issue.repo,
+                pull_number: context.issue.number,
+              });
+              return pr.head.sha;
             };
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.issue.owner,
-              repo: context.issue.repo,
-              pull_number: context.issue.number,
-            });
-            return pr.head.sha;
+            return context.sha;
 
       - id: set-profiling-filename
         name: Set profiling output file name


### PR DESCRIPTION
Fixes the bug encountered in https://github.com/UCL/TLOmodel/actions/runs/8397884074, that was introduced in https://github.com/UCL/TLOmodel/pull/1301.

When profiling is triggered by comment on a pull request, the workflow needs to fetch the SHA of the PR branch, rather than the HEAD of `master` (which is the default for `issue_comment`-event triggers). This is in contrast to when it is triggered through scheduling, workflow dispatch, or comments on ISSUES - when it should run on `master`.

Since the `issue_comment` trigger is raised when comments on _issues_ and on _pull requests_ are made, we need to do some manual inspection to distinguish the two cases, hence the need for the additional logic in this pull request.