### PR TITLE
Use unsigned integer type for bitset columns

### DIFF
--- a/src/tlo/core.py
+++ b/src/tlo/core.py
@@ -142,7 +142,6 @@ class Property(Specifiable):
         "category": float("nan"),
         object: float("nan"),
         np.uint32: 0,
-        np.uint64: 0,
     }
 
     def __init__(self, type_, description, categories=None, *, ordered=False):

--- a/src/tlo/core.py
+++ b/src/tlo/core.py
@@ -69,7 +69,7 @@ class Specifiable:
         Types.DATA_FRAME: object,
         Types.STRING: object,
         Types.DICT: object,
-        Types.BITSET: 'uint64',
+        Types.BITSET: np.uint64,
     }
 
     # Map our Types to Python types
@@ -141,7 +141,7 @@ class Property(Specifiable):
         float: float("nan"),
         "category": float("nan"),
         object: float("nan"),
-        "uint64": 0,
+        np.uint64: 0,
     }
 
     def __init__(self, type_, description, categories=None, *, ordered=False):

--- a/src/tlo/core.py
+++ b/src/tlo/core.py
@@ -50,6 +50,7 @@ class Types(Enum):
     DATA_FRAME = auto()
     STRING = auto()
     DICT = auto()
+    BITSET = auto()
 
 
 class Specifiable:
@@ -67,7 +68,8 @@ class Specifiable:
         Types.SERIES: object,
         Types.DATA_FRAME: object,
         Types.STRING: object,
-        Types.DICT: object
+        Types.DICT: object,
+        Types.BITSET: 'uint64',
     }
 
     # Map our Types to Python types
@@ -82,7 +84,8 @@ class Specifiable:
         Types.SERIES: pd.Series,
         Types.DATA_FRAME: pd.DataFrame,
         Types.STRING: object,
-        Types.DICT: dict
+        Types.DICT: dict,
+        Types.BITSET: int,
     }
 
     def __init__(self, type_, description, categories=None):
@@ -138,6 +141,7 @@ class Property(Specifiable):
         float: float("nan"),
         "category": float("nan"),
         object: float("nan"),
+        "uint64": 0,
     }
 
     def __init__(self, type_, description, categories=None, *, ordered=False):

--- a/src/tlo/core.py
+++ b/src/tlo/core.py
@@ -69,7 +69,7 @@ class Specifiable:
         Types.DATA_FRAME: object,
         Types.STRING: object,
         Types.DICT: object,
-        Types.BITSET: np.uint64,
+        Types.BITSET: np.uint32,
     }
 
     # Map our Types to Python types
@@ -141,6 +141,7 @@ class Property(Specifiable):
         float: float("nan"),
         "category": float("nan"),
         object: float("nan"),
+        np.uint32: 0,
         np.uint64: 0,
     }
 

--- a/src/tlo/methods/labour.py
+++ b/src/tlo/methods/labour.py
@@ -607,8 +607,8 @@ class Labour(Module):
                                                          'antihypertensives'),
         'la_postpartum_haem': Property(Types.BOOL, 'whether the woman has experienced an postpartum haemorrhage in this'
                                                    'delivery'),
-        'la_postpartum_haem_treatment': Property(Types.INT, ' Treatment for received for postpartum haemorrhage '
-                                                            '(bitset)'),
+        'la_postpartum_haem_treatment': Property(Types.BITSET, ' Treatment for received for postpartum haemorrhage '
+                                                               '(bitset)'),
         'la_has_had_hysterectomy': Property(Types.BOOL, 'whether this woman has had a hysterectomy as treatment for a '
                                                         'complication of labour, and therefore is unable to conceive'),
         'la_date_most_recent_delivery': Property(Types.DATE, 'date of on which this mother last delivered'),

--- a/src/tlo/methods/newborn_outcomes.py
+++ b/src/tlo/methods/newborn_outcomes.py
@@ -265,7 +265,7 @@ class NewbornOutcomes(Module):
         'nb_preterm_birth_disab': Property(Types.CATEGORICAL, 'Disability associated with preterm delivery',
                                            categories=['none', 'mild_motor_and_cog', 'mild_motor', 'moderate_motor',
                                                        'severe_motor']),
-        'nb_congenital_anomaly': Property(Types.INT, 'Types of congenital anomaly of the newborn stored as bitset'),
+        'nb_congenital_anomaly': Property(Types.BITSET, 'Types of congenital anomaly of the newborn stored as bitset'),
         'nb_early_onset_neonatal_sepsis': Property(Types.BOOL, 'whether this neonate has developed neonatal sepsis'
                                                                ' following birth'),
         'nb_inj_abx_neonatal_sepsis': Property(Types.BOOL, 'If this neonate has injectable antibiotics as treatment '

--- a/src/tlo/methods/pregnancy_supervisor.py
+++ b/src/tlo/methods/pregnancy_supervisor.py
@@ -403,7 +403,7 @@ class PregnancySupervisor(Module):
 
         'ps_anc4': Property(Types.BOOL, 'Whether this woman is predicted to attend 4 or more antenatal care visits '
                                         'during her pregnancy'),
-        'ps_abortion_complications': Property(Types.INT, 'Bitset column holding types of abortion complication'),
+        'ps_abortion_complications': Property(Types.BITSET, 'Bitset column holding types of abortion complication'),
         'ps_prev_spont_abortion': Property(Types.BOOL, 'Whether this woman has had any previous pregnancies end in '
                                                        'spontaneous abortion'),
         'ps_prev_stillbirth': Property(Types.BOOL, 'Whether this woman has had any previous pregnancies end in '

--- a/src/tlo/methods/symptommanager.py
+++ b/src/tlo/methods/symptommanager.py
@@ -272,7 +272,7 @@ class SymptomManager(Module):
         SymptomManager.PROPERTIES = dict()
         for symptom_name in sorted(self.symptom_names):
             symptom_column_name = self.get_column_name_for_symptom(symptom_name)
-            SymptomManager.PROPERTIES[symptom_column_name] = Property(Types.INT, f'Presence of symptom {symptom_name}')
+            SymptomManager.PROPERTIES[symptom_column_name] = Property(Types.BITSET, f'Presence of symptom {symptom_name}')
 
     def initialise_population(self, population):
         """

--- a/src/tlo/util.py
+++ b/src/tlo/util.py
@@ -125,7 +125,7 @@ class BitsetHandler:
     """Provides methods to operate on int column(s) in the population dataframe as a bitset"""
 
     def __init__(self, population: Population, column: Optional[str], elements: List[str]):
-        """""
+        """
         :param population: The TLO Population object (not the props dataframe).
         :param column: The integer property column that will be used as a bitset. If
             set to ``None`` then the optional `columns` argument to methods which act
@@ -136,7 +136,10 @@ class BitsetHandler:
         assert isinstance(population, Population), (
             'First argument is the population object (not the `props` dataframe)'
         )
-        assert len(elements) <= 64, 'A maximum of 64 elements are supported'
+        dtype_bitwidth = BitsetDType(0).nbytes * 8
+        assert len(elements) <= dtype_bitwidth, (
+            f"A maximum of {dtype_bitwidth} elements are supported"
+        )
         self._elements = elements
         self._element_to_int_map = {el: 2 ** i for i, el in enumerate(elements)}
         self._population = population

--- a/src/tlo/util.py
+++ b/src/tlo/util.py
@@ -141,8 +141,8 @@ class BitsetHandler:
             assert column in population.props.columns, (
                 'Column not found in population dataframe'
             )
-            assert population.props[column].dtype == np.int64, (
-                'Column must be of int64 type'
+            assert population.props[column].dtype == np.uint64, (
+                'Column must be of uint64 type'
             )
         self._column = column
 
@@ -150,11 +150,11 @@ class BitsetHandler:
     def df(self) -> pd.DataFrame:
         return self._population.props
 
-    def element_repr(self, *elements: str) -> np.int64:
+    def element_repr(self, *elements: str) -> np.uint64:
         """Returns integer representation of the specified element(s)"""
-        return np.int64(sum(self._element_to_int_map[el] for el in elements))
+        return np.uint64(sum(self._element_to_int_map[el] for el in elements))
 
-    def to_strings(self, integer: np.int64) -> Set[str]:
+    def to_strings(self, integer: np.uint64) -> Set[str]:
         """Given an integer value, returns the corresponding set of strings.
 
         :param integer: The integer value for the bitset.

--- a/src/tlo/util.py
+++ b/src/tlo/util.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from pandas import DateOffset
 
-from tlo import Population
+from tlo import Population, Property, Types
 
 # Default mother_id value, assigned to individuals initialised as adults at the start of the simulation.
 DEFAULT_MOTHER_ID = -1e7
@@ -118,6 +118,9 @@ def sample_outcome(probs: pd.DataFrame, rng: np.random.RandomState):
     return outcome.loc[outcome != '_'].to_dict()
 
 
+BitsetDType = Property.PANDAS_TYPE_MAP[Types.BITSET]
+
+
 class BitsetHandler:
     """Provides methods to operate on int column(s) in the population dataframe as a bitset"""
 
@@ -141,8 +144,8 @@ class BitsetHandler:
             assert column in population.props.columns, (
                 'Column not found in population dataframe'
             )
-            assert population.props[column].dtype == np.uint64, (
-                'Column must be of uint64 type'
+            assert population.props[column].dtype == BitsetDType, (
+                f'Column must be of {BitsetDType} type'
             )
         self._column = column
 
@@ -150,11 +153,11 @@ class BitsetHandler:
     def df(self) -> pd.DataFrame:
         return self._population.props
 
-    def element_repr(self, *elements: str) -> np.uint64:
+    def element_repr(self, *elements: str) -> BitsetDType:
         """Returns integer representation of the specified element(s)"""
-        return np.uint64(sum(self._element_to_int_map[el] for el in elements))
+        return BitsetDType(sum(self._element_to_int_map[el] for el in elements))
 
-    def to_strings(self, integer: np.uint64) -> Set[str]:
+    def to_strings(self, integer: BitsetDType) -> Set[str]:
         """Given an integer value, returns the corresponding set of strings.
 
         :param integer: The integer value for the bitset.

--- a/tests/test_bitset.py
+++ b/tests/test_bitset.py
@@ -13,9 +13,9 @@ from tlo.util import BitsetHandler
 def dataframe():
     return pd.DataFrame(
         data={
-            'symptoms': pd.Series(0, index=range(5), dtype=np.dtype('int64')),
-            'sy_stomachache': pd.Series(0, index=range(5), dtype=np.dtype('int64')),
-            'sy_injury':  pd.Series(0, index=range(5), dtype=np.dtype('int64')),
+            'symptoms': pd.Series(0, index=range(5), dtype=np.dtype('uint64')),
+            'sy_stomachache': pd.Series(0, index=range(5), dtype=np.dtype('uint64')),
+            'sy_injury':  pd.Series(0, index=range(5), dtype=np.dtype('uint64')),
             'is_alive': pd.Series(True, index=range(5), dtype=np.dtype('bool')),
             'age': pd.Series([5, 10, 20, 30, 40], index=range(5), dtype=np.dtype('int'))
         }
@@ -65,7 +65,7 @@ def test_error_on_too_many_elements(population):
 
 
 def test_error_on_incorrect_column_dtype(population):
-    with pytest.raises(AssertionError, match='int64'):
+    with pytest.raises(AssertionError, match='uint64'):
         BitsetHandler(population, 'is_alive', [str(i) for i in range(8)])
 
 
@@ -338,12 +338,14 @@ def test_linearmodel_with_bitset(dataframe, symptoms):
 
     out = lm.predict(dataframe)
     assert pytest.approx(21.0) == out.loc[3]
+    
+    vomitting_element_repr = symptoms.element_repr('vomiting')
 
     # has specific symptoms - vomiting
     lm = LinearModel(
         LinearModelType.ADDITIVE,
         0.0,
-        Predictor('symptoms').apply(lambda x: 2.0 if x & symptoms.element_repr('vomiting') else 20.0)
+        Predictor('symptoms').apply(lambda x: 2.0 if np.uint64(x) & symptoms.element_repr('vomiting') else 20.0)
     )
 
     out = lm.predict(dataframe)
@@ -351,8 +353,8 @@ def test_linearmodel_with_bitset(dataframe, symptoms):
 
     # put more complex rules in its own function
     def symptom_coeff_calc(bitset):
-        if bitset & symptoms.element_repr('fever'):
-            if bitset & symptoms.element_repr('vomiting'):
+        if np.uint64(bitset) & symptoms.element_repr('fever'):
+            if np.uint64(bitset) & symptoms.element_repr('vomiting'):
                 return 1
             else:
                 return 2

--- a/tests/test_bitset.py
+++ b/tests/test_bitset.py
@@ -338,8 +338,6 @@ def test_linearmodel_with_bitset(dataframe, symptoms):
 
     out = lm.predict(dataframe)
     assert pytest.approx(21.0) == out.loc[3]
-    
-    vomitting_element_repr = symptoms.element_repr('vomiting')
 
     # has specific symptoms - vomiting
     lm = LinearModel(

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -29,6 +29,7 @@ from tlo.methods.consumables import Consumables, create_dummy_data_for_cons_avai
 from tlo.methods.fullmodel import fullmodel
 from tlo.methods.healthsystem import HealthSystem, HealthSystemChangeParameters
 from tlo.methods.hsi_event import HSI_Event
+from tlo.util import BitsetDType
 
 resourcefilepath = Path(os.path.dirname(__file__)) / '../resources'
 
@@ -188,7 +189,11 @@ def test_run_no_interventions_allowed(tmpdir, seed):
     # Do the checks for the symptom manager: some symptoms should be registered
     assert sim.population.props.loc[:, sim.population.props.columns.str.startswith('sy_')] \
         .apply(lambda x: x != set()).any().any()
-    assert (sim.population.props.loc[:, sim.population.props.columns.str.startswith('sy_')].dtypes == 'int64').all()
+    assert (
+        sim.population.props.loc[
+            :, sim.population.props.columns.str.startswith('sy_')
+        ].dtypes == BitsetDType
+    ).all()
     assert not pd.isnull(sim.population.props.loc[:, sim.population.props.columns.str.startswith('sy_')]).any().any()
 
     # Check that no one was cured of mockitis:

--- a/tests/test_rti.py
+++ b/tests/test_rti.py
@@ -91,7 +91,9 @@ def test_all_injuries_run(seed):
     assert "none" not in sim.population.props['rt_injury_1'].unique()
     assert not sim.population.props['rt_injury_1'].str.contains('P').any()
     # Assign people the emergency care triggering symptom so they enter the health system
-    sim.population.props['sy_severe_trauma'] = 2
+    sim.modules["SymptomManager"].change_symptom(
+        sim.population.props.index, "severe_trauma", "+", sim.modules["RTI"]
+    )
     # Assign an injury date
     sim.population.props['rt_date_inj'] = sim.start_date
     # Show that they have been injured

--- a/tests/test_rti.py
+++ b/tests/test_rti.py
@@ -162,7 +162,9 @@ def test_all_injuries_run_no_healthsystem(seed):
     assert "none" not in sim.population.props['rt_injury_1'].unique()
     assert not sim.population.props['rt_injury_1'].str.contains('P').any()
     # Assign people the emergency care triggering symptom so they enter the health system
-    sim.population.props['sy_severe_trauma'] = 2
+    sim.modules["SymptomManager"].change_symptom(
+        sim.population.props.index, "severe_trauma", "+", sim.modules["RTI"]
+    )
     # Assign an injury date
     sim.population.props['rt_date_inj'] = sim.start_date
     # Show that they have been injured


### PR DESCRIPTION
Fixes #814 

Adds a new property type `Types.BITSET` which maps to a NumPy `uint64` dtype, updates implementation in `BitsetHandler` to return `uint64` instances and changes downstream usages in module properties to use the new type.

As well as resolving #814 this makes columns intended to be used as bitsets 'self-documented' by their type and abstracts the details of the particular representation away from the user.

I've tested the bitset specific tests locally but haven't run full tests so it's possible this breaks something elsewhere.