### PR TITLE
Allowing passing multiple job IDs to `tlo batch-download` command

### DIFF
--- a/src/tlo/cli.py
+++ b/src/tlo/cli.py
@@ -469,11 +469,11 @@ def print_basic_job_details(job: dict):
 
 
 @cli.command()
-@click.argument("job_id", type=str)
+@click.argument("job_ids", type=str, nargs=-1)
 @click.option("--username", type=str, hidden=True)
 @click.option("--verbose", default=False, is_flag=True, hidden=True)
 @click.pass_context
-def batch_download(ctx, job_id, username, verbose):
+def batch_download(ctx, job_ids, username, verbose):
     """Download output files for a job."""
     config = load_config(ctx.obj["config_file"])
 
@@ -518,17 +518,18 @@ def batch_download(ctx, job_id, username, verbose):
     share_client = ShareClient.from_connection_string(config['STORAGE']['CONNECTION_STRING'],
                                                       config['STORAGE']['FILESHARE'])
 
-    # if the job directory exist, exit with error
-    top_level = f"{username}/{job_id}"
-    destination = Path(".", "outputs", top_level)
-    if os.path.exists(destination):
-        print("ERROR: Local directory already exists. Please move or delete.")
-        print("Directory:", destination)
-        return
+    for job_id in job_ids:
+        # if the job directory exist, print error and continue to next job_id
+        top_level = f"{username}/{job_id}"
+        destination = Path(".", "outputs", top_level)
+        if os.path.exists(destination):
+            print("ERROR: Local directory already exists. Please move or delete.")
+            print("Directory:", destination)
+            continue
 
-    print(f"Downloading {top_level}")
-    walk_fileshare(top_level)
-    print("\rDownload complete.              ")
+        print(f"Downloading {top_level}")
+        walk_fileshare(top_level)
+        print("\rDownload complete.              ")
 
 
 def load_config(config_file):


### PR DESCRIPTION
Fixes #828 

Renames `job_id` argument to `tlo batch-download` to `job_ids` and changes to allow accepting an unlimited number of values using [`click` `nargs=-1` option to specify variadic argument](https://click.palletsprojects.com/en/latest/arguments/#variadic-arguments, and changes implementation to loop over the resulting tuple of job IDs, and perform downloading for each in sequence. The current implementation continues to try to download subsequent job ID output files if the local directory for a previous job ID already exists rather than exiting altogether. When passed one job ID this should still match the behaviour of the current implementation.

As [recommended in the `click` documentation](https://click.palletsprojects.com/en/latest/arguments/#variadic-arguments), the implementation allows for no job IDs being passed rather than setting `required=True` to enforce at least one being provided, to provide more graceful behaviour when used with wildcard arguments which might expand to zero matches.