### PR TITLE
Access individual properties lazily with memoization in `PatientDetails` type

### DIFF
--- a/src/tlo/methods/hsi_generic_first_appts.py
+++ b/src/tlo/methods/hsi_generic_first_appts.py
@@ -97,7 +97,10 @@ class HSI_BaseGenericFirstAppt(HSI_Event, IndividualScopeEventMixin):
                 }
 
         # Perform any DataFrame updates that were requested, all in one go.
-        df.loc[self.target, proposed_patient_details_updates.keys()] = proposed_patient_details_updates.values()
+        if proposed_patient_details_updates:
+            df.loc[
+                self.target, proposed_patient_details_updates.keys()
+            ] = proposed_patient_details_updates.values()
 
     def apply(self, person_id, squeeze_factor=0.) -> None:
         """

--- a/src/tlo/population.py
+++ b/src/tlo/population.py
@@ -1,8 +1,7 @@
 """The Person and Population classes."""
 
 import math
-from collections import namedtuple
-from typing import Any, Tuple, Type, TypeAlias
+from typing import Any, Dict
 
 import pandas as pd
 
@@ -11,8 +10,31 @@ from tlo import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-PatientDetails: TypeAlias = Tuple[Any]
-PatientDetailsType: TypeAlias = Type[Tuple[Any]]
+
+class PatientDetails:
+    """Read-only memoized view of population dataframe row."""
+    
+    def __init__(self, population_dataframe: pd.DataFrame, person_id: int):
+        self._population_dataframe = population_dataframe
+        self._person_id = person_id
+        self._property_cache: Dict[str, Any] = {}
+        
+    def __getitem__(self, key: str) -> Any:
+        cached_value = self._property_cache.get(key)
+        if cached_value is not None:
+            return cached_value
+        else:
+            value = self._population_dataframe.at[self._person_id, key]
+            self._property_cache[key] = value
+            return value     
+        
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self[name]
+        except KeyError as e:
+            msg = f"'{type(self).__name__}' object has no attribute '{name}'"
+            raise AttributeError(msg) from e
+    
 
 
 class Population:
@@ -71,12 +93,6 @@ class Population:
 
         # use the person_id of the next person to be added to the dataframe to increase capacity
         self.next_person_id = initial_size
-
-        # create the PatientDetails type now the DataFrame rows have been fixed.
-        # This saves reconstructing the PatientDetailsType each time we want to read a row.
-        self._patient_details_readonly_type: PatientDetailsType = namedtuple(
-            "PatientDetails", self.props.columns
-        )
 
     def _create_props(self, size):
         """Internal helper function to create a properties dataframe.
@@ -141,13 +157,13 @@ class Population:
 
     def row_in_readonly_form(self, patient_index: int) -> PatientDetails:
         """
-        Extract a row from the population DataFrame in read-only format.
+        Extract a lazily evaluated, read-only view of a row of the population dataframe.
         
-        The object returned is a subclass of Tuple, with named attributes
-        corresponding to the DataFrame columns. tHese attributes can be
-        referenced by the . syntax or getattr methods.
+        The object returned represents the properties of an individual with properties
+        accessible either using dot based attribute access or squared bracket based 
+        indexing using string column names.
 
-        :param patient_index: Row index of the DataFrame row to extract.
-        :returns: DataFrame row values for the requested row.
+        :param patient_index: Row index of the dataframe row to extract.
+        :returns: Object allowing read-only access to an individuals properties.
         """
-        return self._patient_details_readonly_type(*self.props.loc[patient_index])
+        return PatientDetails(self.props, patient_index)

--- a/src/tlo/population.py
+++ b/src/tlo/population.py
@@ -20,10 +20,9 @@ class PatientDetails:
         self._property_cache: Dict[str, Any] = {}
         
     def __getitem__(self, key: str) -> Any:
-        cached_value = self._property_cache.get(key)
-        if cached_value is not None:
-            return cached_value
-        else:
+        try:
+            return self._property_cache[key]
+        except KeyError:
             value = self._population_dataframe.at[self._person_id, key]
             self._property_cache[key] = value
             return value     


### PR DESCRIPTION
Follow on from #1292 

Changes the `PatientDetails` type used to mediate access to individual property values in the generic first appointments HSI event to be a class with provides a read-only memoized view of the relevant population dataframe row as opposed to a `namedtuple` instance generated from the `Series` object representing a particular row. On first access the individual properties are read from the dataframe using the `at` indexer, with the read values cached in a dictionary to allow subsequent lookup without accessing the dataframe. This avoids reading in all properties from the dataframe on construction of instanced of `PatientDetails`, of which only a subset may be used downstream, however, it comes with the potential of greater overhead from multiple dataframe accesses (which is what I thought was the performance bottleneck in discussion in #1237). Not clear overall which is the big factor - from some short profiling runs locally looks like the approach in this PR might be slightly more performant but unclear if this is just due to variance in profiling runs. 

Also adds in an unrelated change of wrapping the update to individual properties in `_do_on_generic_first_appt` in an `if` block to only perform if `proposed_patient_details_updates` is non-empty (to avoid overhead from entering Pandas `__setitem__` logic with an empty set of updates).