### PR TITLE
Put into Health System Summary logger the annual summary of 'Fraction Time Used' broken down by officer type and facility level

### DIFF
--- a/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
+++ b/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
@@ -21,10 +21,10 @@ class LongRun(BaseScenario):
         super().__init__()
         self.seed = 0
         self.start_date = Date(2010, 1, 1)
-        self.end_date = Date(2031, 1, 1)  # The simulation will stop before reaching this date.
-        self.pop_size = 20_000
+        self.end_date = Date(2016, 1, 1)  # The simulation will stop before reaching this date.
+        self.pop_size = 10_000
         self.number_of_draws = 1
-        self.runs_per_draw = 10
+        self.runs_per_draw = 2
 
     def log_configuration(self):
         return {

--- a/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
+++ b/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
@@ -32,12 +32,10 @@ class LongRun(BaseScenario):
             'directory': './outputs',  # <- (specified only for local running)
             'custom_levels': {
                 '*': logging.WARNING,
-                'tlo.methods.demography': logging.INFO,
-                'tlo.methods.demography.detail': logging.WARNING,
-                'tlo.methods.healthburden': logging.INFO,
-                'tlo.methods.healthsystem': logging.INFO,
-                'tlo.methods.healthsystem.summary': logging.INFO,
-                "tlo.methods.contraception": logging.INFO,
+                'tlo.methods.demography': logging.INFO,  # turn on demography log
+                'tlo.methods.demography.detail': logging.WARNING,  # ensure detailed log is off
+                'tlo.methods.healthsystem.summary': logging.INFO,  # turn on healthsystem summary log
+                'tlo.methods.healthsystem': logging.INFO,  # keep the verbose log, just in case needed
             }
         }
 

--- a/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
+++ b/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
@@ -21,10 +21,10 @@ class LongRun(BaseScenario):
         super().__init__()
         self.seed = 0
         self.start_date = Date(2010, 1, 1)
-        self.end_date = Date(2016, 1, 1)  # The simulation will stop before reaching this date.
-        self.pop_size = 10_000
+        self.end_date = Date(2031, 1, 1)  # The simulation will stop before reaching this date.
+        self.pop_size = 20_000
         self.number_of_draws = 1
-        self.runs_per_draw = 2
+        self.runs_per_draw = 10
 
     def log_configuration(self):
         return {

--- a/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
+++ b/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
@@ -32,10 +32,12 @@ class LongRun(BaseScenario):
             'directory': './outputs',  # <- (specified only for local running)
             'custom_levels': {
                 '*': logging.WARNING,
-                'tlo.methods.demography': logging.INFO,  # turn on demography log
-                'tlo.methods.demography.detail': logging.WARNING,  # ensure detailed log is off
-                'tlo.methods.healthsystem.summary': logging.INFO,  # turn on healthsystem summary log
-                'tlo.methods.healthsystem': logging.INFO,  # keep the verbose log, just in case needed
+                'tlo.methods.demography': logging.INFO,
+                'tlo.methods.demography.detail': logging.WARNING,
+                'tlo.methods.healthburden': logging.INFO,
+                'tlo.methods.healthsystem': logging.INFO,
+                'tlo.methods.healthsystem.summary': logging.INFO,
+                "tlo.methods.contraception": logging.INFO,
             }
         }
 

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -2510,10 +2510,6 @@ class HealthSystemSummaryCounter:
         #                                                           treatment_id. Key is of the form:
         #                                                           "<TREATMENT_ID>:<HSI_EVENT_NAME>"
 
-        # <<<< todo FROM MY ORIGINAL APPROACH
-        self._frac_time_used_by_officertype_and_facilitylevel = []  # Running record of the usage of the healthcare
-        #                                                              system
-
     def record_hsi_event(self,
                          treatment_id: str,
                          hsi_event_name: str,
@@ -2562,10 +2558,6 @@ class HealthSystemSummaryCounter:
         self._frac_time_used_overall.append(fraction_time_used_across_all_facilities)
         for officer_type_facility_level, fraction_time in fraction_time_used_by_officer_type_and_level.items():
             self._sum_of_daily_frac_time_used_by_officer_type_and_level[officer_type_facility_level] += fraction_time
-
-        # <<<< todo FROM MY ORIGINAL APPROACH
-        self._frac_time_used_by_officertype_and_facilitylevel.append(
-            fraction_time_used_by_officer_type_and_level)
 
     def write_to_log_and_reset_counters(self):
         """Log summary statistics reset the data structures. This usually occurs at the end of the year."""

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -2583,8 +2583,8 @@ class HealthSystemSummaryCounter:
             key="Capacity_By_OfficerType_And_FacilityLevel",
             description="The fraction of healthcare worker time that is used each day, averaged over this "
                         "calendar year, for each officer type at each facility level.",
-            data=flatten_multi_index_series_into_dict_for_logging(mean_of_frac_time_used_by_officertype_and_facilitylevel),
-
+            data=flatten_multi_index_series_into_dict_for_logging(
+                mean_of_frac_time_used_by_officertype_and_facilitylevel),
         )
 
         self._reset_internal_stores()

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -2635,7 +2635,7 @@ class HealthSystemSummaryCounter:
             }
             return pd.Series(
                 index=pd.MultiIndex.from_tuples(
-                    self._sum_of_daily_frac_time_used_by_officer_type_and_level.keys(),
+                    mean_frac_time_used.keys(),
                     names=['OfficerType', 'FacilityLevel']
                 ),
                 data=mean_frac_time_used.values()


### PR DESCRIPTION
For the costing module developed by @sakshimohan, we would find it convenient to have an annual summary of the `Fraction Time Used` (broken down by office type and facility level) in the summary logger.


(When you come to use this, you'll find it helpful to use the utility function `unflatten_flattened_multi_index_in_logging`. See the tests associated with this for us. Basically, this can restruct the strings created in the logging process into a multi index). 

