### PR TITLE
Update ScenarioSwitcher to allow changes to occur midway through the simulation.

### DIFF
--- a/src/scripts/healthsystem/impact_of_const_capabilities_expansion/scenario_impact_of_const_capabilities_expansion.py
+++ b/src/scripts/healthsystem/impact_of_const_capabilities_expansion/scenario_impact_of_const_capabilities_expansion.py
@@ -20,7 +20,6 @@ import pandas as pd
 from tlo import Date, logging
 from tlo.analysis.utils import get_parameters_for_status_quo, mix_scenarios
 from tlo.methods.fullmodel import fullmodel
-from tlo.methods.scenario_switcher import ScenarioSwitcher
 from tlo.scenario import BaseScenario
 
 
@@ -49,7 +48,7 @@ class ImpactOfHealthSystemMode(BaseScenario):
         }
 
     def modules(self):
-        return fullmodel(resourcefilepath=self.resources) + [ScenarioSwitcher(resourcefilepath=self.resources)]
+        return fullmodel(resourcefilepath=self.resources)
 
     def draw_parameters(self, draw_number, rng):
         if draw_number < self.number_of_draws:
@@ -86,7 +85,7 @@ class ImpactOfHealthSystemMode(BaseScenario):
                       },
                     }
                 ),
-                
+
             "GDP growth":
                 mix_scenarios(
                     get_parameters_for_status_quo(),
@@ -104,7 +103,7 @@ class ImpactOfHealthSystemMode(BaseScenario):
                       },
                     }
                 ),
-                
+
             "GDP growth fHE growth case 1":
                 mix_scenarios(
                     get_parameters_for_status_quo(),
@@ -122,7 +121,7 @@ class ImpactOfHealthSystemMode(BaseScenario):
                       },
                     }
                 ),
-                                
+
             "GDP growth fHE growth case 3":
                 mix_scenarios(
                     get_parameters_for_status_quo(),
@@ -140,7 +139,7 @@ class ImpactOfHealthSystemMode(BaseScenario):
                       },
                     }
                 ),
-                                                
+
             "GDP growth fHE growth case 4":
                 mix_scenarios(
                     get_parameters_for_status_quo(),
@@ -158,7 +157,7 @@ class ImpactOfHealthSystemMode(BaseScenario):
                       },
                     }
                 ),
-                                                
+
             "GDP growth fHE growth case 6":
                 mix_scenarios(
                     get_parameters_for_status_quo(),

--- a/src/scripts/healthsystem/impact_of_policy/scenario_impact_of_policy.py
+++ b/src/scripts/healthsystem/impact_of_policy/scenario_impact_of_policy.py
@@ -20,7 +20,6 @@ import pandas as pd
 from tlo import Date, logging
 from tlo.analysis.utils import get_parameters_for_status_quo, mix_scenarios
 from tlo.methods.fullmodel import fullmodel
-from tlo.methods.scenario_switcher import ScenarioSwitcher
 from tlo.scenario import BaseScenario
 
 
@@ -49,7 +48,7 @@ class ImpactOfHealthSystemMode(BaseScenario):
         }
 
     def modules(self):
-        return fullmodel(resourcefilepath=self.resources) + [ScenarioSwitcher(resourcefilepath=self.resources)]
+        return fullmodel(resourcefilepath=self.resources)
 
     def draw_parameters(self, draw_number, rng):
         if draw_number < self.number_of_draws:

--- a/src/scripts/overview_paper/C_impact_of_healthsystem_assumptions/scenario_impact_of_healthsystem.py
+++ b/src/scripts/overview_paper/C_impact_of_healthsystem_assumptions/scenario_impact_of_healthsystem.py
@@ -19,7 +19,7 @@ from typing import Dict
 from tlo import Date, logging
 from tlo.analysis.utils import get_parameters_for_status_quo, mix_scenarios
 from tlo.methods.fullmodel import fullmodel
-from tlo.methods.scenario_switcher import ScenarioSwitcher
+from tlo.methods.scenario_switcher import ImprovedHealthSystemAndCareSeekingScenarioSwitcher
 from tlo.scenario import BaseScenario
 
 
@@ -48,7 +48,8 @@ class ImpactOfHealthSystemAssumptions(BaseScenario):
         }
 
     def modules(self):
-        return fullmodel(resourcefilepath=self.resources) + [ScenarioSwitcher(resourcefilepath=self.resources)]
+        return fullmodel(resourcefilepath=self.resources) + [
+            ImprovedHealthSystemAndCareSeekingScenarioSwitcher(resourcefilepath=self.resources)]
 
     def draw_parameters(self, draw_number, rng):
         if draw_number < len(self._scenarios):
@@ -89,19 +90,28 @@ class ImpactOfHealthSystemAssumptions(BaseScenario):
             "Perfect Healthcare Seeking":
                 mix_scenarios(
                     get_parameters_for_status_quo(),
-                    {'ScenarioSwitcher': {'max_healthsystem_function': False, 'max_healthcare_seeking': True}},
+                    {'ScenarioSwitcher': {
+                        'max_healthsystem_function': [False] * 2,
+                        'max_healthcare_seeking': [True] * 2
+                    }},
+                    # (These changes start immediately and last for the full length of the simulation.)
                 ),
 
             "+ Perfect Clinical Practice":
                 mix_scenarios(
                     get_parameters_for_status_quo(),
-                    {'ScenarioSwitcher': {'max_healthsystem_function': True, 'max_healthcare_seeking': True}},
+                    {'ScenarioSwitcher': {
+                        'max_healthsystem_function': [True] * 2,
+                        'max_healthcare_seeking': [True] * 2
+                    }},
                 ),
 
             "+ Perfect Consumables Availability":
                 mix_scenarios(
                     get_parameters_for_status_quo(),
-                    {'ScenarioSwitcher': {'max_healthsystem_function': False, 'max_healthcare_seeking': True}},
+                    {'ScenarioSwitcher': {
+                        'max_healthsystem_function': [False] * 2,
+                        'max_healthcare_seeking': [True] * 2}},
                     {'HealthSystem': {'cons_availability': 'all'}}
                 ),
         }

--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -85,8 +85,8 @@ class Demography(Module):
         self.other_death_poll = None    # will hold pointer to the OtherDeathPoll object
         self.districts = None  # will store all the districts in a list
 
-    OPTIONAL_INIT_DEPENDENCIES = {'ScenarioSwitcher'}  # <-- Forces the 'ScenarioSwitcher' to be the first registered
-    #                                                        module, if it's registered.
+    OPTIONAL_INIT_DEPENDENCIES = {'ImprovedHealthSystemAndCareSeekingScenarioSwitcher'}
+    # <-- this forces that module to be the first registered module, if it's registered.
 
     AGE_RANGE_CATEGORIES, AGE_RANGE_LOOKUP = create_age_range_lookup(
         min_age=MIN_AGE_FOR_RANGE,

--- a/src/tlo/methods/scenario_switcher.py
+++ b/src/tlo/methods/scenario_switcher.py
@@ -1,18 +1,22 @@
 import warnings
 
-from tlo import Module, Parameter, Types
+from tlo import Date, Module, Parameter, Types
 from tlo.analysis.utils import get_parameters_for_improved_healthsystem_and_healthcare_seeking
+from tlo.events import Event, PopulationScopeEventMixin
 
 
-class ScenarioSwitcher(Module):
-    """The ScenarioSwitcher module.
-    This is a utility module that can be used to make changes to parameters in registered simulation models, including
-    parameters of the form `pd.Series` and `pd.DataFrame` that cannot be changed via the `Scenario` class (see
-    https://github.com/UCL/TLOmodel/issues/988). It loads a ResourceFile that contains parameter value to be updated,
+class ImprovedHealthSystemAndCareSeekingScenarioSwitcher(Module):
+    """This is the `ImprovedHealthSystemAndCareSeekingScenarioSwitcher` module.
+    It provides switches that can used by the `Scenario` class to control the overall performance of the HealthSystem
+    and healthcare seeking, which are mediated by many parameters across many modules, and which are of the types
+    `pd.Series` and `pd.DataFrame`, which cannot be changed via the `Scenario` class (see
+    https://github.com/UCL/TLOmodel/issues/988).
+    It does this by loading a ResourceFile that contains parameter value to be updated,
     and makes these changes at the point `pre_initialise_population`. As this module is declared as an (Optional)
     dependency of the module that would be loaded first in the simulation (i.e. `Demography`), this module is
     registered first and so this module's `pre_initialise_population` method is called before any other. This provides
-    a close approximation to what would happen if the parameters were being changed by the `Scenario` class."""
+    a close approximation to what would happen if the parameters were being changed by the `Scenario` class.
+    """
 
     def __init__(self, name=None, resourcefilepath=None):
         super().__init__(name)
@@ -25,32 +29,59 @@ class ScenarioSwitcher(Module):
     METADATA = set()
 
     PARAMETERS = {
+        # Each of these parameter is a list of two booleans -- [bool, bool] -- which represent (i) the state during the
+        # period before the date of a switch in state, (ii) the state at the date of switch and the period thereafter.
+
+        # -- Health System Strengthening Switches
         "max_healthsystem_function": Parameter(
-            Types.BOOL, "If True, over-writes parameters that define maximal health system function."
+            Types.LIST, "If True, over-writes parameters that define maximal health system function."
                         "Parameter passed through to `get_parameters_for_improved_healthsystem_and_healthcare_seeking`."
         ),
         "max_healthcare_seeking": Parameter(
-            Types.BOOL, "If True, over-writes parameters that define maximal healthcare-seeking behaviour. "
+            Types.LIST, "If True, over-writes parameters that define maximal healthcare-seeking behaviour. "
                         "Parameter passed through to `get_parameters_for_improved_healthsystem_and_healthcare_seeking`."
+        ),
+
+        # This parameter specifies the year in which the state changes. The change occurs on 1st January of that year.
+        # If there should not be any switch, then this year can be set to a year that is beyond the end of the
+        # simulation.
+        "year_of_switch": Parameter(
+            Types.INT, "The year in which the state changes. The state changes on 1st January of that year."
         ),
     }
 
     PROPERTIES = {}
 
     def read_parameters(self, data_folder):
-        """Default values for parameters. These are hard-coded."""
-        self.parameters["max_healthsystem_function"] = False
-        self.parameters["max_healthcare_seeking"] = False
+        """Read-in parameters and process them into the internal storage structures required."""
 
-    def initialise_population(self, population):
-        pass
+        # Parameters are hard-coded for this module to not make any changes. (The expectation is that some of these
+        # are over-written by the Scenario class.)
+        # The first value in the list is used before the year of change, and the second value is used after.
+        self.parameters["max_healthsystem_function"] = [False] * 2  # (No use of the "max" scenarios)
+        self.parameters["max_healthcare_seeking"] = [False] * 2
+        self.parameters["year_of_switch"] = 2100  # (Any change occurs very far in the future)
 
     def pre_initialise_population(self):
-        """Retrieve parameters to be updated and update them in the other registered disease modules."""
+        """Set the parameters for the first period of the simulation.
+         Note that this is happening here and not in initialise_simulation because we want to make sure that the
+         parameters are changed before other modules call `pre_initialise_population`. We ensure that this module's
+         method is the first to be called as this module is declared as an (Optional) dependency of the module that is
+         loaded first in the simulation (i.e. `Demography`). This provides a close approximation to what would happen if
+         the parameters were being changed by the `Scenario` class."""
+        self.update_parameters()
+
+    def update_parameters(self):
+        """Update the parameters in the simulation's modules."""
+
+        # Check whether we are currently in the first or second phase of the simulation (i.e., before or after the
+        # time of the change, which is at the beginning of the year `year_of_switch`.)
+        phase_of_simulation = 0 if self.sim.date.year < self.parameters["year_of_switch"] else 1
 
         params_to_update = get_parameters_for_improved_healthsystem_and_healthcare_seeking(
             resourcefilepath=self.resourcefilepath,
-            **self.parameters
+            max_healthsystem_function=self.parameters['max_healthsystem_function'][phase_of_simulation],
+            max_healthcare_seeking=self.parameters['max_healthcare_seeking'][phase_of_simulation],
         )
 
         for module, params in params_to_update.items():
@@ -63,8 +94,26 @@ class ScenarioSwitcher(Module):
                         f"module={module}, name={name}.",
                     )
 
-    def initialise_simulation(self, sim):
+    def initialise_population(self, population):
         pass
+
+    def initialise_simulation(self, sim):
+        """Schedule an event at which the parameters are changed."""
+
+        date_of_switch_event = Date(self.parameters["year_of_switch"], 1, 1)  # 1st January of the year specified.
+        sim.schedule_event(ScenarioSwitchEvent(module=self), date_of_switch_event)
 
     def on_birth(self, mother_id, child_id):
         pass
+
+
+class ScenarioSwitchEvent(Event, PopulationScopeEventMixin):
+
+    def __init__(self, module):
+        super().__init__(module)
+
+    def apply(self, population):
+        """Run the function that updates the simulation parameters."""
+        self.module.update_parameters()
+
+

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -28,9 +28,7 @@ from tlo.analysis.utils import (
 from tlo.events import PopulationScopeEventMixin, RegularEvent
 from tlo.methods import demography
 from tlo.methods.fullmodel import fullmodel
-from tlo.methods.scenario_switcher import (
-    ImprovedHealthSystemAndCareSeekingScenarioSwitcher,
-)
+from tlo.methods.scenario_switcher import ImprovedHealthSystemAndCareSeekingScenarioSwitcher
 
 resourcefilepath = Path(os.path.dirname(__file__)) / "../resources"
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -28,35 +28,41 @@ from tlo.analysis.utils import (
 from tlo.events import PopulationScopeEventMixin, RegularEvent
 from tlo.methods import demography
 from tlo.methods.fullmodel import fullmodel
-from tlo.methods.scenario_switcher import ImprovedHealthSystemAndCareSeekingScenarioSwitcher
+from tlo.methods.scenario_switcher import (
+    ImprovedHealthSystemAndCareSeekingScenarioSwitcher,
+)
 
-resourcefilepath = Path(os.path.dirname(__file__)) / '../resources'
+resourcefilepath = Path(os.path.dirname(__file__)) / "../resources"
 
 
 def test_parse_log():
-    log_file = Path(__file__).parent / 'resources' / 'structured_log.txt'
+    log_file = Path(__file__).parent / "resources" / "structured_log.txt"
 
     output = parse_log_file(log_file)
 
-    assert 'tlo.methods.epilepsy' in output
-    assert set(output['tlo.methods.epilepsy'].keys()) == {'incidence_epilepsy', 'epilepsy_logging', '_metadata'}
+    assert "tlo.methods.epilepsy" in output
+    assert set(output["tlo.methods.epilepsy"].keys()) == {
+        "incidence_epilepsy",
+        "epilepsy_logging",
+        "_metadata",
+    }
 
 
 def test_parse_log_levels(tmpdir):
     # setup a toy simulation to test logging
-    logger = logging.getLogger('tlo.methods.dummy')
+    logger = logging.getLogger("tlo.methods.dummy")
     start_date = Date(2010, 1, 1)
     end_date = Date(2011, 1, 1)
     pop_size = 100
 
     class DummyEvent(RegularEvent, PopulationScopeEventMixin):
         def apply(self, population):
-            logger.info(key="info_level1", data={'number': np.random.randint(0, 100)})
-            logger.info(key="info_level2", data={'number': np.random.randint(0, 100)})
-            logger.debug(key="debug_level", data={'number': np.random.randint(0, 100)})
+            logger.info(key="info_level1", data={"number": np.random.randint(0, 100)})
+            logger.info(key="info_level2", data={"number": np.random.randint(0, 100)})
+            logger.debug(key="debug_level", data={"number": np.random.randint(0, 100)})
 
     class Dummy(Module):
-        PROPERTIES = {'dummy': Property(Types.INT, description='dummy')}
+        PROPERTIES = {"dummy": Property(Types.INT, description="dummy")}
 
         def read_parameters(self, data_folder):
             pass
@@ -68,10 +74,14 @@ def test_parse_log_levels(tmpdir):
             pass
 
         def initialise_simulation(self, sim: Simulation):
-            sim.schedule_event(DummyEvent(self, frequency=DateOffset(months=1)), start_date)
+            sim.schedule_event(
+                DummyEvent(self, frequency=DateOffset(months=1)), start_date
+            )
 
     # test parsing when log level is INFO
-    sim = Simulation(start_date=start_date, log_config={'filename': 'temp', 'directory': tmpdir})
+    sim = Simulation(
+        start_date=start_date, log_config={"filename": "temp", "directory": tmpdir}
+    )
     sim.register(Dummy())
     logger.setLevel(logging.INFO)
     sim.make_initial_population(n=pop_size)
@@ -79,28 +89,34 @@ def test_parse_log_levels(tmpdir):
     output = parse_log_file(sim.log_filepath)
 
     # At INFO level
-    assert len(output['tlo.methods.dummy']['_metadata']['tlo.methods.dummy']) == 2  # should have two tables
+    assert (
+        len(output["tlo.methods.dummy"]["_metadata"]["tlo.methods.dummy"]) == 2
+    )  # should have two tables
 
     # tables should be at level INFO
-    for k, v in output['tlo.methods.dummy']['_metadata']['tlo.methods.dummy'].items():
-        assert v['level'] == 'INFO'
+    for k, v in output["tlo.methods.dummy"]["_metadata"]["tlo.methods.dummy"].items():
+        assert v["level"] == "INFO"
 
     # test parsing when log level is DEBUG
-    sim = Simulation(start_date=start_date, log_config={'filename': 'temp2', 'directory': tmpdir})
+    sim = Simulation(
+        start_date=start_date, log_config={"filename": "temp2", "directory": tmpdir}
+    )
     sim.register(Dummy())
     logger.setLevel(logging.DEBUG)
     sim.make_initial_population(n=pop_size)
     sim.simulate(end_date=end_date)
-    output = parse_log_file(sim.log_filepath, level=logging.INFO)  # we're parsing everything above INFO level
+    output = parse_log_file(
+        sim.log_filepath, level=logging.INFO
+    )  # we're parsing everything above INFO level
 
     # logged DEBUG but parsed at INFO levels
-    assert len(output['tlo.methods.dummy']['_metadata']['tlo.methods.dummy']) == 2
-    assert 'debug_level' not in output['tlo.methods.dummy']
+    assert len(output["tlo.methods.dummy"]["_metadata"]["tlo.methods.dummy"]) == 2
+    assert "debug_level" not in output["tlo.methods.dummy"]
 
     # logged DEBUG and parsed at DEBUG level
     output = parse_log_file(sim.log_filepath, level=logging.DEBUG)
-    assert len(output['tlo.methods.dummy']['_metadata']['tlo.methods.dummy']) == 3
-    assert 'debug_level' in output['tlo.methods.dummy']
+    assert len(output["tlo.methods.dummy"]["_metadata"]["tlo.methods.dummy"]) == 3
+    assert "debug_level" in output["tlo.methods.dummy"]
 
 
 def test_flattening_and_unflattening_multiindex(tmpdir):
@@ -113,7 +129,7 @@ def test_flattening_and_unflattening_multiindex(tmpdir):
         log it to a particular key on the first date of the simulation, and return the pd.DataFrame created by
         `parse_log` for that key."""
 
-        logger = logging.getLogger('tlo.methods.demography')
+        logger = logging.getLogger("tlo.methods.demography")
         logger.setLevel(logging.INFO)
 
         class DummyModule(Module):
@@ -125,39 +141,45 @@ def test_flattening_and_unflattening_multiindex(tmpdir):
 
             def initialise_simulation(self, sim):
                 logger.info(
-                    key='key',
-                    data=flatten_multi_index_series_into_dict_for_logging(series_to_log)
+                    key="key",
+                    data=flatten_multi_index_series_into_dict_for_logging(
+                        series_to_log
+                    ),
                 )
 
-        sim = Simulation(start_date=sim_start_date, seed=0, log_config={
-            'filename': 'temp',
-            'directory': tmpdir,
-        })
+        sim = Simulation(
+            start_date=sim_start_date,
+            seed=0,
+            log_config={"filename": "temp", "directory": tmpdir,},
+        )
         sim.register(
-            demography.Demography(resourcefilepath=resourcefilepath),
-            DummyModule()
+            demography.Demography(resourcefilepath=resourcefilepath), DummyModule()
         )
         sim.make_initial_population(n=100)
         sim.simulate(end_date=sim_start_date)
 
-        return parse_log_file(sim.log_filepath)['tlo.methods.demography']['key']
+        return parse_log_file(sim.log_filepath)["tlo.methods.demography"]["key"]
 
     sim_start_date = Date(2010, 1, 1)
 
     for num_of_levels in range(1, 4):
         # Make original pd.Series with column-wise multi-index (with the specified number of levels).
         idx = pd.MultiIndex.from_product(
-            [['1', '2', '3'] for _ in range(num_of_levels)],
-            names=[f'col_level_{_x}' for _x in range(num_of_levels)]
+            [["1", "2", "3"] for _ in range(num_of_levels)],
+            names=[f"col_level_{_x}" for _x in range(num_of_levels)],
         )
-        original = pd.Series(index=idx, data=100*np.random.random([len(idx)]).round(4))
+        original = pd.Series(
+            index=idx, data=100 * np.random.random([len(idx)]).round(4)
+        )
 
         # Let this original series be logged in the simulation and get the parsed log;
         df_rtn = run_simulation_and_parse_log(series_to_log=original)
 
         # Confirm that the original can retrieved from the log using `unflatten_flattened_multi_index_in_logging`
         series_unflattened = unflatten_flattened_multi_index_in_logging(
-            df_rtn.loc[pd.to_datetime(df_rtn.date) == sim_start_date].drop(columns=['date'])
+            df_rtn.loc[pd.to_datetime(df_rtn.date) == sim_start_date].drop(
+                columns=["date"]
+            )
         ).iloc[0]
 
         # Check equal
@@ -167,9 +189,7 @@ def test_flattening_and_unflattening_multiindex(tmpdir):
 def test_get_root_path():
     """Check that `get_root_path` works as expected."""
 
-    ROOT_PATH = Path(os.path.abspath(
-        Path(os.path.dirname(__file__)) / '../'
-    ))
+    ROOT_PATH = Path(os.path.abspath(Path(os.path.dirname(__file__)) / "../"))
 
     def is_correct_absolute_path(_path):
         return (ROOT_PATH == _path) and _path.is_absolute() and isinstance(_path, Path)
@@ -177,27 +197,35 @@ def test_get_root_path():
     assert is_correct_absolute_path(get_root_path())
 
     for test_dir in [
-        os.path.abspath(Path(os.path.dirname(__file__)) / '../src/'),
-        os.path.abspath(Path(os.path.dirname(__file__)) / '../resources/'),
-        os.path.abspath(Path(os.path.dirname(__file__)) / '../tests/'),
-        os.path.abspath(Path(os.path.dirname(__file__)) / '../'),
+        os.path.abspath(Path(os.path.dirname(__file__)) / "../src/"),
+        os.path.abspath(Path(os.path.dirname(__file__)) / "../resources/"),
+        os.path.abspath(Path(os.path.dirname(__file__)) / "../tests/"),
+        os.path.abspath(Path(os.path.dirname(__file__)) / "../"),
         os.path.abspath(Path(os.path.dirname(__file__))),
     ]:
-        assert is_correct_absolute_path(get_root_path(test_dir)), f"Failed on {test_dir=}"
+        assert is_correct_absolute_path(
+            get_root_path(test_dir)
+        ), f"Failed on {test_dir=}"
 
 
 def test_coarse_appt_type():
     """Check the function that maps each appt_types to a coarser definition."""
     appt_types = pd.read_csv(
-        resourcefilepath / 'healthsystem' / 'human_resources' / 'definitions' / 'ResourceFile_Appt_Types_Table.csv'
-    )['Appt_Type_Code'].values
+        resourcefilepath
+        / "healthsystem"
+        / "human_resources"
+        / "definitions"
+        / "ResourceFile_Appt_Types_Table.csv"
+    )["Appt_Type_Code"].values
 
-    appts = pd.DataFrame({
+    appts = pd.DataFrame(
+        {
             "original": pd.Series(appt_types),
-            "coarse": pd.Series(appt_types).map(get_coarse_appt_type)
-    })
+            "coarse": pd.Series(appt_types).map(get_coarse_appt_type),
+        }
+    )
 
-    coarse_appts = appts['coarse'].drop_duplicates()
+    coarse_appts = appts["coarse"].drop_duplicates()
 
     assert not pd.isnull(appts).any().any()
     assert 13 == len(coarse_appts)  # 12 coarse categories
@@ -208,9 +236,18 @@ def test_coarse_appt_type():
 
 def test_colormap_coarse_appts():
     """Check the function that allocates a unique colour to each coarse appointment type."""
-    coarse_appt_types = pd.read_csv(
-            resourcefilepath / 'healthsystem' / 'human_resources' / 'definitions' / 'ResourceFile_Appt_Types_Table.csv'
-        )['Appt_Type_Code'].map(get_coarse_appt_type).drop_duplicates().values
+    coarse_appt_types = (
+        pd.read_csv(
+            resourcefilepath
+            / "healthsystem"
+            / "human_resources"
+            / "definitions"
+            / "ResourceFile_Appt_Types_Table.csv"
+        )["Appt_Type_Code"]
+        .map(get_coarse_appt_type)
+        .drop_duplicates()
+        .values
+    )
 
     coarse_appt_types = sorted(coarse_appt_types, key=order_of_coarse_appt)
 
@@ -218,15 +255,21 @@ def test_colormap_coarse_appts():
 
     assert len(set(colors)) == len(colors)  # No duplicates
     assert all([isinstance(_x, str) for _x in colors])  # All strings
-    assert np.nan is get_color_coarse_appt('????')  # Return `np.nan` if appt_type not recognised.
-    assert all(map(lambda x: x in colors_in_matplotlib(), colors))  # All colors recognised
+    assert np.nan is get_color_coarse_appt(
+        "????"
+    )  # Return `np.nan` if appt_type not recognised.
+    assert all(
+        map(lambda x: x in colors_in_matplotlib(), colors)
+    )  # All colors recognised
 
 
 def test_get_treatment_ids(tmpdir):
     """Check the function that generates the list of TREATMENT_IDs defined in the model."""
 
     x = get_filtered_treatment_ids()  # All TREATMENT_IDs
-    y = get_filtered_treatment_ids(depth=1)  # TREATMENT_IDs to the first level of depth (i.e. module level)
+    y = get_filtered_treatment_ids(
+        depth=1
+    )  # TREATMENT_IDs to the first level of depth (i.e. module level)
 
     assert isinstance(x, list)
     assert all([isinstance(_x, str) for _x in x])
@@ -240,13 +283,19 @@ def test_get_treatment_ids(tmpdir):
 def test_colormap_short_treatment_id():
     """Check the function that allocates a unique colour to each shortened TREATMENT_ID (i.e. each module)"""
 
-    short_treatment_ids = sorted(get_filtered_treatment_ids(depth=1), key=order_of_short_treatment_ids)
+    short_treatment_ids = sorted(
+        get_filtered_treatment_ids(depth=1), key=order_of_short_treatment_ids
+    )
     colors = [get_color_short_treatment_id(x) for x in short_treatment_ids]
 
     assert len(set(colors)) == len(colors)  # No duplicates
     assert all([isinstance(_x, str) for _x in colors])  # All strings
-    assert np.nan is get_color_coarse_appt('????')  # Return `np.nan` if appt_type not recognised.
-    assert all(map(lambda x: x in colors_in_matplotlib(), colors))  # All colors recognised
+    assert np.nan is get_color_coarse_appt(
+        "????"
+    )  # Return `np.nan` if appt_type not recognised.
+    assert all(
+        map(lambda x: x in colors_in_matplotlib(), colors)
+    )  # All colors recognised
 
 
 def test_colormap_cause_of_death_label(seed):
@@ -257,10 +306,14 @@ def test_colormap_cause_of_death_label(seed):
         """Return list of all the causes of death defined in the full model."""
         start_date = Date(2010, 1, 1)
         sim = Simulation(start_date=start_date, seed=seed)
-        sim.register(*fullmodel(resourcefilepath=resourcefilepath, use_simplified_births=False))
+        sim.register(
+            *fullmodel(resourcefilepath=resourcefilepath, use_simplified_births=False)
+        )
         sim.make_initial_population(n=1_000)
         sim.simulate(end_date=start_date)
-        mapper, _ = (sim.modules['Demography']).create_mappers_from_causes_of_death_to_label()
+        mapper, _ = (
+            sim.modules["Demography"]
+        ).create_mappers_from_causes_of_death_to_label()
         return sorted(set(mapper.values()))
 
     all_labels = get_all_cause_of_death_labels(seed)
@@ -269,8 +322,12 @@ def test_colormap_cause_of_death_label(seed):
 
     assert len(set(colors)) == len(colors)  # No duplicates
     assert all([isinstance(_x, str) for _x in colors])  # All strings
-    assert np.nan is get_color_coarse_appt('????')  # Return `np.nan` if label is not recognised.
-    assert all(map(lambda x: x in colors_in_matplotlib(), colors))  # All colors recognised
+    assert np.nan is get_color_coarse_appt(
+        "????"
+    )  # Return `np.nan` if label is not recognised.
+    assert all(
+        map(lambda x: x in colors_in_matplotlib(), colors)
+    )  # All colors recognised
 
 
 def test_get_parameter_functions(seed):
@@ -281,20 +338,20 @@ def test_get_parameter_functions(seed):
     funcs = [
         get_parameters_for_status_quo,
         lambda: get_parameters_for_improved_healthsystem_and_healthcare_seeking(
-                resourcefilepath=resourcefilepath,
-                max_healthsystem_function=True,
-                max_healthcare_seeking=False
-            ),
+            resourcefilepath=resourcefilepath,
+            max_healthsystem_function=True,
+            max_healthcare_seeking=False,
+        ),
         lambda: get_parameters_for_improved_healthsystem_and_healthcare_seeking(
             resourcefilepath=resourcefilepath,
             max_healthsystem_function=False,
-            max_healthcare_seeking=True
-            ),
+            max_healthcare_seeking=True,
+        ),
         lambda: get_parameters_for_improved_healthsystem_and_healthcare_seeking(
             resourcefilepath=resourcefilepath,
             max_healthsystem_function=True,
-            max_healthcare_seeking=True
-        )
+            max_healthcare_seeking=True,
+        ),
     ]
 
     # Create simulation
@@ -312,256 +369,277 @@ def test_get_parameter_functions(seed):
             for name, updated_value in params[module].items():
 
                 # Check that the parameter identified exists in the simulation
-                assert name in sim.modules[module].parameters, f"Parameter not recognised: {module}:{name}."
+                assert (
+                    name in sim.modules[module].parameters
+                ), f"Parameter not recognised: {module}:{name}."
 
                 # Check that the original value and the updated value are of the same type.
                 original = sim.modules[module].parameters[name]
 
-                assert type(original) is type(updated_value), \
-                    f"Updated value type does not match original type: " \
-                    f"{module}:{name} >> {updated_value=}, " \
+                assert type(original) is type(updated_value), (
+                    f"Updated value type does not match original type: "
+                    f"{module}:{name} >> {updated_value=}, "
                     f"{type(original)=}, {type(updated_value)=}"
+                )
 
                 def is_df_same_size_and_dtype(df1, df2):
                     return (
-                        df1.index.equals(df2.index) and
-                        all(df1.dtypes == df2.dtypes) and
-                        all(df1.columns == df2.columns) if isinstance(df1, pd.DataFrame) else True
+                        df1.index.equals(df2.index)
+                        and all(df1.dtypes == df2.dtypes)
+                        and all(df1.columns == df2.columns)
+                        if isinstance(df1, pd.DataFrame)
+                        else True
                     )
 
                 def is_list_same_size_and_dtype(l1, l2):
-                    return (
-                        (len(l1) == len(l2)) and
-                        all([type(_i) is type(_j) for _i, _j in zip(l1, l2)])
+                    return (len(l1) == len(l2)) and all(
+                        [type(_i) is type(_j) for _i, _j in zip(l1, l2)]
                     )
 
                 # Check that, if the updated value is a pd.DataFrame, it has the same indicies as the original
                 if isinstance(original, (pd.DataFrame, pd.Series)):
-                    assert is_df_same_size_and_dtype(original, updated_value), \
-                        print(f"Dataframe or series if not of the expected size and shape:"
-                              f"{module}:{name} >> {updated_value=}, {type(original)=}, {type(updated_value)=}")
+                    assert is_df_same_size_and_dtype(original, updated_value), print(
+                        f"Dataframe or series if not of the expected size and shape:"
+                        f"{module}:{name} >> {updated_value=}, {type(original)=}, {type(updated_value)=}"
+                    )
 
                 # Check that, if the updated value is a list/tuple, it has the same dimensions as the original
                 elif isinstance(original, (list, tuple)):
-                    assert is_list_same_size_and_dtype(original, updated_value), \
-                        print(f"List/tuple is not of the expected size and containing elements of expected type: "
-                              f"{module}:{name} >> {updated_value=}, {type(original)=}, {type(updated_value)=}")
+                    assert is_list_same_size_and_dtype(original, updated_value), print(
+                        f"List/tuple is not of the expected size and containing elements of expected type: "
+                        f"{module}:{name} >> {updated_value=}, {type(original)=}, {type(updated_value)=}"
+                    )
 
 
 def test_mix_scenarios():
     """Check that `mix_scenarios` works as expected."""
 
-    d1 = {
-        'Mod1': {
-            'param_a': 'value_in_d1',
-            'param_b': 'value_in_d1',
-        }
-    }
+    d1 = {"Mod1": {"param_a": "value_in_d1", "param_b": "value_in_d1",}}
 
-    d2 = {
-        'Mod2': {
-            'param_a': 'value_in_d2',
-            'param_b': 'value_in_d2',
-        }
-    }
+    d2 = {"Mod2": {"param_a": "value_in_d2", "param_b": "value_in_d2",}}
 
-    d3 = {
-        'Mod1': {
-            'param_b': 'value_in_d3',
-            'param_c': 'value_in_d3'
-        }
-    }
+    d3 = {"Mod1": {"param_b": "value_in_d3", "param_c": "value_in_d3"}}
 
     with pytest.warns(UserWarning) as record:
         assert mix_scenarios(d1, d2, d3) == {
-            'Mod1': {
-                'param_a': 'value_in_d1',  # <- only appears in d1, and is included despite d3 also having 'Mod1' key
-                'param_b': 'value_in_d3',  # <- appears in d1 and d3, but d3 is right-most, so 'wins' (raises Warning)
-                'param_c': 'value_in_d3',  # <- only appears in d3
+            "Mod1": {
+                "param_a": "value_in_d1",  # <- only appears in d1, and is included despite d3 also having 'Mod1' key
+                "param_b": "value_in_d3",  # <- appears in d1 and d3, but d3 is right-most, so 'wins' (raises Warning)
+                "param_c": "value_in_d3",  # <- only appears in d3
             },
-            'Mod2': {
-                'param_a': 'value_in_d2',  # <- only appears in d2 (& attaches to Mod2 despite name being duplicated)
-                'param_b': 'value_in_d2',  # <- only appears in d2 (& attaches to Mod2 despite name being duplicated)
-            }
+            "Mod2": {
+                "param_a": "value_in_d2",  # <- only appears in d2 (& attaches to Mod2 despite name being duplicated)
+                "param_b": "value_in_d2",  # <- only appears in d2 (& attaches to Mod2 despite name being duplicated)
+            },
         }
 
     assert 1 == len(record)
-    assert record.list[0].message.args[0] == 'Parameter is being updated more than once: module=Mod1, parameter=param_b'
+    assert (
+        record.list[0].message.args[0]
+        == "Parameter is being updated more than once: module=Mod1, parameter=param_b"
+    )
 
     # Test the behaviour of the `mix_scenarios` taking the value in the right-most dict.
     assert mix_scenarios(
-        {'Mod1': {
-            'param_a': 'value_in_dict1',
-            'param_b': 'value_in_dict1',
-            'param_c': 'value_in_dict1',
-        }},
-        {'Mod1': {
-            'param_a': 'value_in_dict2',
-            'param_b': 'value_in_dict2',
-            'param_c': 'value_in_dict2',
-        }},
-        {'Mod1': {
-            'param_a': 'value_in_dict3',
-            'param_b': 'value_in_dict_right_most',
-            'param_c': 'value_in_dict3',
-        }},
-        {'Mod1': {
-            'param_a': 'value_in_dict_right_most',
-            'param_c': 'value_in_dict4',
-        }},
-        {"Mod1": {
-            "param_c": "value_in_dict_right_most",
-        }},
+        {
+            "Mod1": {
+                "param_a": "value_in_dict1",
+                "param_b": "value_in_dict1",
+                "param_c": "value_in_dict1",
+            }
+        },
+        {
+            "Mod1": {
+                "param_a": "value_in_dict2",
+                "param_b": "value_in_dict2",
+                "param_c": "value_in_dict2",
+            }
+        },
+        {
+            "Mod1": {
+                "param_a": "value_in_dict3",
+                "param_b": "value_in_dict_right_most",
+                "param_c": "value_in_dict3",
+            }
+        },
+        {"Mod1": {"param_a": "value_in_dict_right_most", "param_c": "value_in_dict4",}},
+        {"Mod1": {"param_c": "value_in_dict_right_most",}},
     ) == {
-        'Mod1': {'param_a': 'value_in_dict_right_most',
-                 'param_b': 'value_in_dict_right_most',
-                 'param_c': 'value_in_dict_right_most',
-                 }
+        "Mod1": {
+            "param_a": "value_in_dict_right_most",
+            "param_b": "value_in_dict_right_most",
+            "param_c": "value_in_dict_right_most",
+        }
     }
 
 
 def test_improved_healthsystem_and_care_seeking_scenario_switcher(seed):
-    """Check the `ScenarioSwitcher` module can update parameter values in a manner similar to them being changed
-    directly after registration in the simulation (as would be done by the Scenario class).
-    And check that these parameters can be changed mid-way through the simulation."""
+    """Check the `ImprovedHealthSystemAndCareSeekingScenarioSwitcher` module can update complex parameter values in a
+     manner similar to them being changed directly or mid-way through the simulation."""
 
-    sim = Simulation(start_date=Date(2010, 1, 1), seed=seed)
-    sim.register(*(
-        fullmodel(resourcefilepath=resourcefilepath) +
-        [ImprovedHealthSystemAndCareSeekingScenarioSwitcher(resourcefilepath=resourcefilepath)]
-    ))
-
-    # Check that the 'ImprovedHealthSystemAndCareSeekingScenarioSwitcher` is the first registered module.
-    assert 'ImprovedHealthSystemAndCareSeekingScenarioSwitcher' == list(sim.modules.keys())[0]
-    module = sim.modules['ImprovedHealthSystemAndCareSeekingScenarioSwitcher']
-
-    # Change the parameters for max_healthsystem_function and max_healthcare_seeking via the ScenarioSwitcher
+    # Define the changes we want the ScenarioSwitcher to implement
     max_healthsystem_function = [False, True]
     max_healthcare_seeking = [False, True]
-    year_of_change = sim.date.year + 1
+    year_of_change = 2011
 
-    module.parameters['year_of_switch'] = year_of_change
-    module.parameters['max_healthsystem_function'] = max_healthsystem_function
-    module.parameters['max_healthcare_seeking'] = max_healthcare_seeking
+    # Set up a simulation in which the parameters are checked regularly to see if they are correct, given the
+    # phase of the simulation.
+
+    class CheckParametersEvent(RegularEvent, PopulationScopeEventMixin):
+        def __init__(self, module):
+            super().__init__(module, frequency=DateOffset(months=1))  # repeats every month
+
+        def apply(self, population):
+            self.module.check_parameters()  # Checks parameters are as expected
+
+    class DummyModule(Module):
+        def read_parameters(self, data_folder):
+            pass
+
+        def initialise_population(self, population):
+            pass
+
+        def initialise_simulation(self, sim):
+            # Schedule `CheckParametersEvent` to run immediately (and it will then repeat monthly).
+            sim.schedule_event(CheckParametersEvent(self), sim.date)
+
+        def on_birth(self, *args, **kwargs):
+            pass
+
+        def check_parameters(self) -> None:
+            """Check that the parameter values in the simulation currently match expectations for this phase of the
+            simulation."""
+
+            sim = self.sim
+
+            # Work out if we expect to be using the first or the second values for switchers (first value is
+            # for times before 1st Jan on the year of the change.
+            phase_of_simulation = 0 if sim.date.year < year_of_change else 1
+
+            # Load the parameters that should be being used currently.
+            correct_param_values = get_parameters_for_improved_healthsystem_and_healthcare_seeking(
+                resourcefilepath=resourcefilepath,
+                max_healthsystem_function=max_healthsystem_function[phase_of_simulation],
+                max_healthcare_seeking=max_healthcare_seeking[phase_of_simulation],
+            )
+
+            for mod, param in correct_param_values.items():
+                for name, target_value in param.items():
+                    actual = sim.modules[mod].parameters[name]
+                    if isinstance(target_value, pd.Series):
+                        pd.testing.assert_series_equal(target_value, actual)
+                    elif isinstance(target_value, pd.DataFrame):
+                        pd.testing.assert_frame_equal(target_value, actual)
+                    elif isinstance(target_value, list):
+                        assert all([t == v for t, v in zip(target_value, actual)])
+                    else:
+                        assert target_value == actual
+                    print('Parameters all look good.')
+
+            # Check for health care seeking being forced to occur for all symptoms
+            hcs = sim.modules["HealthSeekingBehaviour"].force_any_symptom_to_lead_to_healthcareseeking
+            assert isinstance(hcs, bool) and (hcs is max_healthcare_seeking[phase_of_simulation])
+
+
+    sim = Simulation(start_date=Date(2010, 1, 1), seed=seed)
+    sim.register(
+        *(
+            fullmodel(resourcefilepath=resourcefilepath)
+            + [
+                ImprovedHealthSystemAndCareSeekingScenarioSwitcher(
+                    resourcefilepath=resourcefilepath
+                ),
+                DummyModule(),
+            ]
+        )
+    )
+
+    # Check that the `ImprovedHealthSystemAndCareSeekingScenarioSwitcher` is the first registered module.
+    assert (
+        "ImprovedHealthSystemAndCareSeekingScenarioSwitcher"
+        == list(sim.modules.keys())[0]
+    )
+    module = sim.modules["ImprovedHealthSystemAndCareSeekingScenarioSwitcher"]
+
+    # Set the changes for the ScenarioSwitcher by manipulating its parameters (mimicking what `Scenario` class does).
+    module.parameters["year_of_switch"] = year_of_change
+    module.parameters["max_healthsystem_function"] = max_healthsystem_function
+    module.parameters["max_healthcare_seeking"] = max_healthcare_seeking
 
     # Initialise the population
     sim.make_initial_population(n=100)
 
-    def check_parameters(sim, phase_of_simulation) -> None:
-        """Check that the paramter values in the simulation currently match expectation of that phase of the
-        simulation (0=first phase before the change, 1=second phase after the change)."""
+    # Run the simulation until well after the date of parameter change. (The checking will be occurring every month,
+    # and if any errors an `AssertionError` would be raised.)
+    sim.simulate(end_date=Date(year_of_change + 2, 1, 1))
 
-        updated_values = get_parameters_for_improved_healthsystem_and_healthcare_seeking(
-            resourcefilepath=resourcefilepath,
-            max_healthsystem_function=max_healthsystem_function[phase_of_simulation],
-            max_healthcare_seeking=max_healthcare_seeking[phase_of_simulation]
-        )
-
-        for module, param in updated_values.items():
-            for name, target_value in param.items():
-
-                actual = sim.modules[module].parameters[name]
-
-                if isinstance(target_value, pd.Series):
-                    pd.testing.assert_series_equal(target_value, actual)
-                elif isinstance(target_value, pd.DataFrame):
-                    pd.testing.assert_frame_equal(target_value, actual)
-                elif isinstance(target_value, list):
-                    assert all([t == v for t, v in zip(target_value, actual)])
-                else:
-                    assert target_value == actual
-
-        # Spot check for health care seeking being forced to occur for all symptoms
-        hcs = sim.modules["HealthSeekingBehaviour"].force_any_symptom_to_lead_to_healthcareseeking
-        assert isinstance(hcs, bool) and (hcs is max_healthcare_seeking[phase_of_simulation])
-
-    # Check that all the parameter values in the simulation are updated to be the value expected at the beginning of
-    # the simulation.
-    check_parameters(sim, 0)
-
-    # Run the simulation until after the date of the change and then check the values have been updated.
-    sim.simulate(end_date=Date(year_of_change, 2, 1))
-    check_parameters(sim, 1)
 
 def test_summarize():
     """Check that the summarize utility function works as expected."""
 
     results_multiple_draws = pd.DataFrame(
-        columns=pd.MultiIndex.from_tuples([
-            ('DrawA', 'DrawA_Run1'),
-            ('DrawA', 'DrawA_Run2'),
-            ('DrawB', 'DrawB_Run1'),
-            ('DrawB', 'DrawB_Run2')],
-            names=('draw', 'run')),
-        index=['TimePoint0', 'TimePoint1'],
-        data=np.array([
-            [0, 20, 1000, 2000],
-            [0, 20, 1000, 2000],
-            ])
+        columns=pd.MultiIndex.from_tuples(
+            [
+                ("DrawA", "DrawA_Run1"),
+                ("DrawA", "DrawA_Run2"),
+                ("DrawB", "DrawB_Run1"),
+                ("DrawB", "DrawB_Run2"),
+            ],
+            names=("draw", "run"),
+        ),
+        index=["TimePoint0", "TimePoint1"],
+        data=np.array([[0, 20, 1000, 2000], [0, 20, 1000, 2000],]),
     )
 
     results_one_draw = pd.DataFrame(
-        columns=pd.MultiIndex.from_tuples([
-            ('DrawA', 'DrawA_Run1'),
-            ('DrawA', 'DrawA_Run2')],
-            names=('draw', 'run')),
-        index=['TimePoint0', 'TimePoint1'],
-        data=np.array([
-            [0, 20],
-            [0, 20]
-        ]),
+        columns=pd.MultiIndex.from_tuples(
+            [("DrawA", "DrawA_Run1"), ("DrawA", "DrawA_Run2")], names=("draw", "run")
+        ),
+        index=["TimePoint0", "TimePoint1"],
+        data=np.array([[0, 20], [0, 20]]),
     )
 
     # Without collapsing and all stats provided
     pd.testing.assert_frame_equal(
         pd.DataFrame(
-            columns=pd.MultiIndex.from_tuples([
-                ('DrawA', 'lower'),
-                ('DrawA', 'mean'),
-                ('DrawA', 'upper'),
-                ("DrawB", "lower"),
-                ("DrawB", "mean"),
-                ("DrawB", "upper")],
-                names=('draw', 'stat')),
-            index=['TimePoint0', 'TimePoint1'],
-            data=np.array([
-                [0.5, 10.0, 19.5, 1025.0, 1500.0, 1975.0],
-                [0.5, 10.0, 19.5, 1025.0, 1500.0, 1975.0],
-            ])
+            columns=pd.MultiIndex.from_tuples(
+                [
+                    ("DrawA", "lower"),
+                    ("DrawA", "mean"),
+                    ("DrawA", "upper"),
+                    ("DrawB", "lower"),
+                    ("DrawB", "mean"),
+                    ("DrawB", "upper"),
+                ],
+                names=("draw", "stat"),
+            ),
+            index=["TimePoint0", "TimePoint1"],
+            data=np.array(
+                [
+                    [0.5, 10.0, 19.5, 1025.0, 1500.0, 1975.0],
+                    [0.5, 10.0, 19.5, 1025.0, 1500.0, 1975.0],
+                ]
+            ),
         ),
-        summarize(results_multiple_draws)
+        summarize(results_multiple_draws),
     )
 
     # Without collapsing and only mean
     pd.testing.assert_frame_equal(
         pd.DataFrame(
-            columns=pd.Index([
-                'DrawA',
-                'DrawB'],
-                name='draw'),
-            index=['TimePoint0', 'TimePoint1'],
-            data=np.array([
-                [10.0, 1500.0],
-                [10.0, 1500.0]
-                ])
+            columns=pd.Index(["DrawA", "DrawB"], name="draw"),
+            index=["TimePoint0", "TimePoint1"],
+            data=np.array([[10.0, 1500.0], [10.0, 1500.0]]),
         ),
-        summarize(results_multiple_draws, only_mean=True)
+        summarize(results_multiple_draws, only_mean=True),
     )
 
     # With collapsing (as only one draw)
     pd.testing.assert_frame_equal(
         pd.DataFrame(
-            columns=pd.Index(
-                ['lower',
-                 'mean',
-                 'upper'],
-                name='stat'
-            ),
-            index=['TimePoint0', 'TimePoint1'],
-            data=np.array([
-                [0.5, 10.0, 19.5],
-                [0.5, 10.0, 19.5],
-            ])
+            columns=pd.Index(["lower", "mean", "upper"], name="stat"),
+            index=["TimePoint0", "TimePoint1"],
+            data=np.array([[0.5, 10.0, 19.5], [0.5, 10.0, 19.5],]),
         ),
-        summarize(results_one_draw, collapse_columns=True)
+        summarize(results_one_draw, collapse_columns=True),
     )

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -28,7 +28,7 @@ from tlo.analysis.utils import (
 from tlo.events import PopulationScopeEventMixin, RegularEvent
 from tlo.methods import demography
 from tlo.methods.fullmodel import fullmodel
-from tlo.methods.scenario_switcher import ScenarioSwitcher
+from tlo.methods.scenario_switcher import ImprovedHealthSystemAndCareSeekingScenarioSwitcher
 
 resourcefilepath = Path(os.path.dirname(__file__)) / '../resources'
 
@@ -420,50 +420,68 @@ def test_mix_scenarios():
     }
 
 
-def test_scenario_switcher(seed):
+def test_improved_healthsystem_and_care_seeking_scenario_switcher(seed):
     """Check the `ScenarioSwitcher` module can update parameter values in a manner similar to them being changed
-    directly after registration in the simulation (as would be done by the Scenario class)."""
+    directly after registration in the simulation (as would be done by the Scenario class).
+    And check that these parameters can be changed mid-way through the simulation."""
 
     sim = Simulation(start_date=Date(2010, 1, 1), seed=seed)
     sim.register(*(
-        fullmodel(resourcefilepath=resourcefilepath) + [ScenarioSwitcher(resourcefilepath=resourcefilepath)]
+        fullmodel(resourcefilepath=resourcefilepath) +
+        [ImprovedHealthSystemAndCareSeekingScenarioSwitcher(resourcefilepath=resourcefilepath)]
     ))
 
-    # Check that the 'ScenarioSwitcher` is the first registered module.
-    assert 'ScenarioSwitcher' == list(sim.modules.keys())[0]
+    # Check that the 'ImprovedHealthSystemAndCareSeekingScenarioSwitcher` is the first registered module.
+    assert 'ImprovedHealthSystemAndCareSeekingScenarioSwitcher' == list(sim.modules.keys())[0]
+    module = sim.modules['ImprovedHealthSystemAndCareSeekingScenarioSwitcher']
 
     # Change the parameters for max_healthsystem_function and max_healthcare_seeking via the ScenarioSwitcher
-    sim.modules['ScenarioSwitcher'].parameters['max_healthsystem_function'] = True
-    sim.modules['ScenarioSwitcher'].parameters['max_healthcare_seeking'] = True
+    max_healthsystem_function = [False, True]
+    max_healthcare_seeking = [False, True]
+    year_of_change = sim.date.year + 1
+
+    module.parameters['year_of_switch'] = year_of_change
+    module.parameters['max_healthsystem_function'] = max_healthsystem_function
+    module.parameters['max_healthcare_seeking'] = max_healthcare_seeking
 
     # Initialise the population
     sim.make_initial_population(n=100)
 
-    # Check that all the parameter values in the simulation are updated to be the value expected.
-    updated_values = get_parameters_for_improved_healthsystem_and_healthcare_seeking(
-        resourcefilepath=resourcefilepath,
-        max_healthsystem_function=True,
-        max_healthcare_seeking=True
-    )
+    def check_parameters(sim, phase_of_simulation) -> None:
+        """Check that the paramter values in the simulation currently match expectation of that phase of the
+        simulation (0=first phase before the change, 1=second phase after the change)."""
 
-    for module, param in updated_values.items():
-        for name, target_value in param.items():
+        updated_values = get_parameters_for_improved_healthsystem_and_healthcare_seeking(
+            resourcefilepath=resourcefilepath,
+            max_healthsystem_function=max_healthsystem_function[phase_of_simulation],
+            max_healthcare_seeking=max_healthcare_seeking[phase_of_simulation]
+        )
 
-            actual = sim.modules[module].parameters[name]
+        for module, param in updated_values.items():
+            for name, target_value in param.items():
 
-            if isinstance(target_value, pd.Series):
-                pd.testing.assert_series_equal(target_value, actual)
-            elif isinstance(target_value, pd.DataFrame):
-                pd.testing.assert_frame_equal(target_value, actual)
-            elif isinstance(target_value, list):
-                assert all([t == v for t, v in zip(target_value, actual)])
-            else:
-                assert target_value == actual
+                actual = sim.modules[module].parameters[name]
 
-    # Spot check for health care seeking being forced to occur for all symptoms
-    hcs = sim.modules['HealthSeekingBehaviour'].force_any_symptom_to_lead_to_healthcareseeking
-    assert isinstance(hcs, bool) and hcs
+                if isinstance(target_value, pd.Series):
+                    pd.testing.assert_series_equal(target_value, actual)
+                elif isinstance(target_value, pd.DataFrame):
+                    pd.testing.assert_frame_equal(target_value, actual)
+                elif isinstance(target_value, list):
+                    assert all([t == v for t, v in zip(target_value, actual)])
+                else:
+                    assert target_value == actual
 
+        # Spot check for health care seeking being forced to occur for all symptoms
+        hcs = sim.modules["HealthSeekingBehaviour"].force_any_symptom_to_lead_to_healthcareseeking
+        assert isinstance(hcs, bool) and (hcs is max_healthcare_seeking[phase_of_simulation])
+
+    # Check that all the parameter values in the simulation are updated to be the value expected at the beginning of
+    # the simulation.
+    check_parameters(sim, 0)
+
+    # Run the simulation until after the date of the change and then check the values have been updated.
+    sim.simulate(end_date=Date(year_of_change, 2, 1))
+    check_parameters(sim, 1)
 
 def test_summarize():
     """Check that the summarize utility function works as expected."""


### PR DESCRIPTION
(Cherry-picked from `hallett/analysis_for_vertical_and_horizontal_progs`)

This change allows the ScenarioSwitcher to cause a change at any point in the simulation, rather than only at the beginning of the simulation.