### PR TITLE
Trial using threading to run events simultaneously

### DIFF
--- a/src/scripts/profiling/scale_run.py
+++ b/src/scripts/profiling/scale_run.py
@@ -13,9 +13,9 @@ if TYPE_CHECKING:
 from shared import print_checksum, schedule_profile_log
 
 from tlo import Date, Simulation, logging
-from tlo.threaded_simulation import ThreadedSimulation
 from tlo.analysis.utils import parse_log_file as parse_log_file_fn
 from tlo.methods.fullmodel import fullmodel
+from tlo.threaded_simulation import ThreadedSimulation
 
 _TLO_ROOT: Path = Path(__file__).parents[3].resolve()
 _TLO_OUTPUT_DIR: Path = (_TLO_ROOT / "outputs").resolve()

--- a/src/tlo/simulation.py
+++ b/src/tlo/simulation.py
@@ -51,6 +51,7 @@ class _BaseSimulation:
     fired.
     """
 
+    __name__: str = "_BaseSimulation"
     modules: OrderedDict[str, Module]
 
     def __init__(self, *, start_date: Date, seed: int = None, log_config: dict = None,

--- a/src/tlo/threaded_simulation.py
+++ b/src/tlo/threaded_simulation.py
@@ -1,11 +1,11 @@
+from queue import Queue
 from threading import Thread
 from time import sleep
 from typing import Callable, List
-from queue import Queue
 from warnings import warn
 
-from tlo.simulation import _BaseSimulation
 from tlo.events import Event, IndividualScopeEventMixin
+from tlo.simulation import _BaseSimulation
 
 MAX_THREADS = 4 # make more elegant, probably examine the OS
 


### PR DESCRIPTION
# Proof of Concept

At present, the simulation runs by working through the event queue in serial, and the simulation is deemed complete when the date of the next event in the queue exceeds the end date of the simulation.

We should be able to use threading to run multiple events simultaneously in different threads; so long as the events that run are not going to interfere with each other (target the same patient, advance time before events the previous day finish, etc).

## This PR implements

- `ThreadedSimulation` class. Essentially identical to the existing `Simulation` class, but utilises a pool of threads to execute events in the simulation event queue simultaneously when possible. When an event is deemed unsafe to be run in parallel to others, the "threads" are allowed to finish working on the events they have already been given, then the unsafe event is run in the main thread, and then delegation of work is resumed.
- `ThreadController` class. For handling the multiple threads that we'll need when running events simultaneously.
- Refactors the majority of the `Simulation` class into the `_BaseSimulation` class, from which `Simulation` now inherits. This is to avoid a large amount of code repetition (as now `Simulation` and `ThreadedSimulation` can inherit rather than redefine).
- Adds a CLI to the `scale_run` profiling script to allow for the option of using a `ThreadedSimulation`.

## TODO

- This only speeds up the execution of simulation events, but the most recent profiling results indicate that the `HealthCareSystem` population-level event is really what is slowing the simulation down. This population-level event also has a HSI-event-queue that it works through in serial, so we might be able to apply the same threading logic here to provide further speedup.