### PR TITLE
Add option to specify image tag when submitting batch tasks

### DIFF
--- a/src/tlo/cli.py
+++ b/src/tlo/cli.py
@@ -88,9 +88,10 @@ def scenario_run(scenario_file, draw_only, draw: tuple, output_dir=None):
 @click.option("--asserts-on", type=bool, default=False, is_flag=True, help="Enable assertions in simulation run.")
 @click.option("--more-memory", type=bool, default=False, is_flag=True,
               help="Request machine wth more memory (for larger population sizes).")
+@click.option("--image-tag", type=str, help="Tag of the Docker image to use.")
 @click.option("--keep-pool-alive", type=bool, default=False, is_flag=True, hidden=True)
 @click.pass_context
-def batch_submit(ctx, scenario_file, asserts_on, more_memory, keep_pool_alive):
+def batch_submit(ctx, scenario_file, asserts_on, more_memory, keep_pool_alive, image_tag=None):
     """Submit a scenario to the batch system.
 
     SCENARIO_FILE is path to file containing scenario class.
@@ -180,8 +181,14 @@ def batch_submit(ctx, scenario_file, asserts_on, more_memory, keep_pool_alive):
         password=config["REGISTRY"]["KEY"],
     )
 
-    # Name of the image in the registry
-    image_name = config["REGISTRY"]["SERVER"] + "/" + config["REGISTRY"]["IMAGE_NAME"]
+    # url of the docker image to run the tasks
+    image_name = f"{config['REGISTRY']['SERVER']}/{config['REGISTRY']['IMAGE']}"
+
+    # use the supplied image tag if provided, otherwise use the default
+    if image_tag is None:
+        image_name = f"{image_name}:{config['REGISTRY']['DEFAULT_TAG']}"
+    else:
+        image_name = f"{image_name}:{image_tag}"
 
     # Create container configuration, prefetching Docker images from the container registry
     container_conf = batch_models.ContainerConfiguration(


### PR DESCRIPTION
- overrides default image tag, which is set in batch configuration
- allows user to run tasks on an older image (e.g. with python 3.8 support)

Fixes #1328 