### PR TITLE
allocate population equally across districts at initialisation

### DIFF
--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -87,6 +87,7 @@ class Demography(Module):
         self.districts = None  # will store all the districts in a list
 
     OPTIONAL_INIT_DEPENDENCIES = {'ImprovedHealthSystemAndCareSeekingScenarioSwitcher'}
+    # <-- this forces that module to be the first registered module, if it's registered.
 
     AGE_RANGE_CATEGORIES, AGE_RANGE_LOOKUP = create_age_range_lookup(
         min_age=MIN_AGE_FOR_RANGE,

--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -33,7 +33,6 @@ from tlo.methods.causes import (
     get_gbd_causes_not_represented_in_disease_modules,
 )
 from tlo.util import DEFAULT_MOTHER_ID, create_age_range_lookup, get_person_id_to_inherit_from
-from tlo.simulation import Simulation
 
 # Standard logger
 logger = logging.getLogger(__name__)

--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -73,9 +73,10 @@ class Demography(Module):
     The core demography module.
     """
 
-    def __init__(self, name=None, resourcefilepath=None):
+    def __init__(self, name=None, resourcefilepath=None, equal_allocation_by_district: bool = False):
         super().__init__(name)
         self.resourcefilepath = resourcefilepath
+        self.equal_allocation_by_district = equal_allocation_by_district
         self.initial_model_to_data_popsize_ratio = None  # will store scaling factor
         self.popsize_by_year = dict()  # will store total population size each year
         self.causes_of_death = dict()  # will store all the causes of death that are possible in the simulation

--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -85,8 +85,7 @@ class Demography(Module):
         self.other_death_poll = None    # will hold pointer to the OtherDeathPoll object
         self.districts = None  # will store all the districts in a list
 
-    OPTIONAL_INIT_DEPENDENCIES = {'ScenarioSwitcher'}  # <-- Forces the 'ScenarioSwitcher' to be the first registered
-    #                                                        module, if it's registered.
+    OPTIONAL_INIT_DEPENDENCIES = {'ImprovedHealthSystemAndCareSeekingScenarioSwitcher'}
 
     AGE_RANGE_CATEGORIES, AGE_RANGE_LOOKUP = create_age_range_lookup(
         min_age=MIN_AGE_FOR_RANGE,

--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -33,6 +33,7 @@ from tlo.methods.causes import (
     get_gbd_causes_not_represented_in_disease_modules,
 )
 from tlo.util import DEFAULT_MOTHER_ID, create_age_range_lookup, get_person_id_to_inherit_from
+from tlo.simulation import Simulation
 
 # Standard logger
 logger = logging.getLogger(__name__)
@@ -85,8 +86,8 @@ class Demography(Module):
         self.other_death_poll = None    # will hold pointer to the OtherDeathPoll object
         self.districts = None  # will store all the districts in a list
 
-    OPTIONAL_INIT_DEPENDENCIES = {'ImprovedHealthSystemAndCareSeekingScenarioSwitcher'}
-    # <-- this forces that module to be the first registered module, if it's registered.
+    OPTIONAL_INIT_DEPENDENCIES = {'ScenarioSwitcher'}  # <-- Forces the 'ScenarioSwitcher' to be the first registered
+    #                                                        module, if it's registered.
 
     AGE_RANGE_CATEGORIES, AGE_RANGE_LOOKUP = create_age_range_lookup(
         min_age=MIN_AGE_FOR_RANGE,
@@ -230,29 +231,77 @@ class Demography(Module):
             categories=self.parameters['pop_2010']['Region'].unique().tolist()
         )
 
+    def access_simulation_attribute(self):
+        # Access the equal_allocation_by_district attribute from the Simulation instance
+        return getattr(self.sim, 'equal_allocation_by_district', False)
+
     def initialise_population(self, population):
         """Set properties for this module and compute the initial population scaling factor"""
+
         df = population.props
 
         # Compute the initial population scaling factor
+        # todo this should change if equal_allocation_by_district=True
         self.initial_model_to_data_popsize_ratio = \
             self.compute_initial_model_to_data_popsize_ratio(population.initial_size)
 
+        # get the initial population by age in every district in 2010
         init_pop = self.parameters['pop_2010']
-        init_pop['prob'] = init_pop['Count'] / init_pop['Count'].sum()
 
-        init_pop = self._edit_init_pop_to_prevent_persons_greater_than_max_age(
-            init_pop,
-            max_age=self.parameters['max_age_initial']
-        )
+        # get argument from class Simulation whether to distribute population equally amongst districts
+        equal_allocation = self.access_simulation_attribute()
 
-        # randomly pick from the init_pop sheet, to allocate characteristic to each person in the df
-        demog_char_to_assign = init_pop.iloc[self.rng.choice(init_pop.index.values,
-                                                             size=len(df),
-                                                             replace=True,
-                                                             p=init_pop.prob)][
-            ['District', 'District_Num', 'Region', 'Sex', 'Age']] \
-            .reset_index(drop=True)
+        if equal_allocation:
+            # distribute equal population sizes within districts
+
+            grouped = init_pop.groupby(['District', 'Age', 'Sex']).agg({
+                'Count': 'sum',  # Aggregate Count column by sum
+                'District_Num': 'first',  # Keep the first value of Region within each group
+                'Region': 'first'  # Keep the first value of prob within each group
+            }).reset_index()
+
+            # Step 4: Calculate the total count for each district and transform back to each row within group
+            district_totals = grouped.groupby('District')['Count'].transform('sum')
+
+            # Step 5: Calculate proportion (prob) for each age-group in each district
+            grouped['prob'] = grouped['Count'] / district_totals
+
+            # randomly pick from the init_pop sheet, to allocate characteristic to each person in the df
+            district_groups = init_pop.groupby('District')
+            rows_per_district = int(len(df) / len(district_groups))
+
+            sampled_dfs = []
+            # Iterate over each district and perform random sampling
+            for district, group in district_groups:
+                # Randomly sample from 'init_pop' based on probabilities ('prob') for this district
+                district_population = grouped[grouped['District'] == district]
+                sampled_indices = np.random.choice(district_population.index, size=rows_per_district, replace=True,
+                                                   p=district_population['prob'])
+                sampled_data = district_population.loc[
+                    sampled_indices, ['District', 'District_Num', 'Region', 'Sex', 'Age']].copy()
+
+                # Append the sampled dataframe to the list
+                sampled_dfs.append(sampled_data)
+
+            # Concatenate all sampled dataframes into the final dataframe
+            demog_char_to_assign = pd.concat(sampled_dfs, ignore_index=True)
+
+        else:
+            # randomly distribute population across all districts
+            init_pop['prob'] = init_pop['Count'] / init_pop['Count'].sum()
+
+            # remove anyone older than 120 and rescale probabilities
+            init_pop = self._edit_init_pop_to_prevent_persons_greater_than_max_age(
+                init_pop,
+                max_age=self.parameters['max_age_initial']
+            )
+
+            demog_char_to_assign = init_pop.iloc[self.rng.choice(init_pop.index.values,
+                                                                 size=len(df),
+                                                                 replace=True,
+                                                                 p=init_pop.prob)][
+                ['District', 'District_Num', 'Region', 'Sex', 'Age']] \
+                .reset_index(drop=True)
 
         # make a date of birth that is consistent with the allocated age of each person
         demog_char_to_assign['days_since_last_birthday'] = self.rng.randint(0, 365, len(demog_char_to_assign))
@@ -528,13 +577,13 @@ class Demography(Module):
         df_py.loc[condition, 'age_exact_start'] = 0
 
         # collected all time spent in age at start of period
-        df1 = df_py[['sex', 'years_in_age_start', 'age_years_start']].groupby(by=['sex', 'age_years_start']).sum()
+        df1 = df_py[['sex', 'years_in_age_start', 'age_years_start']].groupby(by=['sex', 'age_years_start'], observed=False).sum()
         df1 = df1.unstack('sex')
         df1.columns = df1.columns.droplevel(0)
         df1.index.rename('age_years', inplace=True)
 
         # collect all time spent in age at end of period
-        df2 = df_py[['sex', 'years_in_age_end', 'age_years_end']].groupby(by=['sex', 'age_years_end']).sum()
+        df2 = df_py[['sex', 'years_in_age_end', 'age_years_end']].groupby(by=['sex', 'age_years_end'], observed=False).sum()
         df2 = df2.unstack('sex')
         df2.columns = df2.columns.droplevel(0)
         df2.index.rename('age_years', inplace=True)
@@ -723,7 +772,7 @@ class DemographyLoggingEvent(RegularEvent, PopulationScopeEventMixin):
         self.module.popsize_by_year[self.sim.date.year] = df.is_alive.sum()
 
         # 2) Compute Statistics for the log
-        sex_count = df[df.is_alive].groupby('sex').size()
+        sex_count = df[df.is_alive].groupby('sex', observed=False).size()
 
         logger.info(
             key='population',
@@ -734,8 +783,8 @@ class DemographyLoggingEvent(RegularEvent, PopulationScopeEventMixin):
 
         # (nb. if you groupby both sex and age_range, you weirdly lose categories where size==0, so
         # get the counts separately.)
-        m_age_counts = df[df.is_alive & (df.sex == 'M')].groupby('age_range').size()
-        f_age_counts = df[df.is_alive & (df.sex == 'F')].groupby('age_range').size()
+        m_age_counts = df[df.is_alive & (df.sex == 'M')].groupby('age_range', observed=False).size()
+        f_age_counts = df[df.is_alive & (df.sex == 'F')].groupby('age_range', observed=False).size()
 
         logger.info(key='age_range_m', data=m_age_counts.to_dict())
 

--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -776,7 +776,7 @@ class DemographyLoggingEvent(RegularEvent, PopulationScopeEventMixin):
         self.module.popsize_by_year[self.sim.date.year] = df.is_alive.sum()
 
         # 2) Compute Statistics for the log
-        sex_count = df[df.is_alive].groupby('sex', observed=False).size()
+        sex_count = df[df.is_alive].groupby('sex').size()
 
         logger.info(
             key='population',
@@ -787,8 +787,8 @@ class DemographyLoggingEvent(RegularEvent, PopulationScopeEventMixin):
 
         # (nb. if you groupby both sex and age_range, you weirdly lose categories where size==0, so
         # get the counts separately.)
-        m_age_counts = df[df.is_alive & (df.sex == 'M')].groupby('age_range', observed=False).size()
-        f_age_counts = df[df.is_alive & (df.sex == 'F')].groupby('age_range', observed=False).size()
+        m_age_counts = df[df.is_alive & (df.sex == 'M')].groupby('age_range').size()
+        f_age_counts = df[df.is_alive & (df.sex == 'F')].groupby('age_range').size()
 
         logger.info(key='age_range_m', data=m_age_counts.to_dict())
 

--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -384,7 +384,8 @@ class Demography(Module):
         _df.prob = _df.prob / _df.prob.sum()  # Rescale `prob` so that it sums to 1.0
         return _df.reset_index(drop=True)
 
-    def _edit_init_pop_so_that_equal_number_in_each_district(self, df) -> pd.DataFrame:
+    @staticmethod
+    def _edit_init_pop_so_that_equal_number_in_each_district(df) -> pd.DataFrame:
         """Return an edited version of the `pd.DataFrame` describing the probability of persons in the population being
         created with certain characteristics to reflect the constraint of there being an equal number of persons
         in each district."""

--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -580,13 +580,13 @@ class Demography(Module):
         df_py.loc[condition, 'age_exact_start'] = 0
 
         # collected all time spent in age at start of period
-        df1 = df_py[['sex', 'years_in_age_start', 'age_years_start']].groupby(by=['sex', 'age_years_start'], observed=False).sum()
+        df1 = df_py[['sex', 'years_in_age_start', 'age_years_start']].groupby(by=['sex', 'age_years_start']).sum()
         df1 = df1.unstack('sex')
         df1.columns = df1.columns.droplevel(0)
         df1.index.rename('age_years', inplace=True)
 
         # collect all time spent in age at end of period
-        df2 = df_py[['sex', 'years_in_age_end', 'age_years_end']].groupby(by=['sex', 'age_years_end'], observed=False).sum()
+        df2 = df_py[['sex', 'years_in_age_end', 'age_years_end']].groupby(by=['sex', 'age_years_end']).sum()
         df2 = df2.unstack('sex')
         df2.columns = df2.columns.droplevel(0)
         df2.index.rename('age_years', inplace=True)

--- a/src/tlo/simulation.py
+++ b/src/tlo/simulation.py
@@ -42,8 +42,9 @@ class Simulation:
         Note that individual modules also have their own random number generator
         with independent state.
     """
+
     def __init__(self, *, start_date: Date, seed: int = None, log_config: dict = None,
-                 show_progress_bar=False, equal_allocation_by_district: bool = False):
+                 show_progress_bar=False):
         """Create a new simulation.
 
         :param start_date: the date the simulation begins; must be given as
@@ -60,11 +61,6 @@ class Simulation:
         self.end_date = None
         self.output_file = None
         self.population: Optional[Population] = None
-
-        if equal_allocation_by_district is None:
-            self.equal_allocation_by_district = False
-        else:
-            self.equal_allocation_by_district = equal_allocation_by_district
 
         self.show_progress_bar = show_progress_bar
 
@@ -187,10 +183,6 @@ class Simulation:
             module.pre_initialise_population()
 
         # Make the initial population
-        # if equal_allocation_by_district=True, then n=number of people in each district
-        if self.equal_allocation_by_district:
-            n = n * 32
-
         self.population = Population(self, n)
         for module in self.modules.values():
             start1 = time.time()

--- a/src/tlo/simulation.py
+++ b/src/tlo/simulation.py
@@ -42,9 +42,8 @@ class Simulation:
         Note that individual modules also have their own random number generator
         with independent state.
     """
-
     def __init__(self, *, start_date: Date, seed: int = None, log_config: dict = None,
-                 show_progress_bar=False):
+                 show_progress_bar=False, equal_allocation_by_district: bool = False):
         """Create a new simulation.
 
         :param start_date: the date the simulation begins; must be given as
@@ -61,6 +60,11 @@ class Simulation:
         self.end_date = None
         self.output_file = None
         self.population: Optional[Population] = None
+
+        if equal_allocation_by_district is None:
+            self.equal_allocation_by_district = False
+        else:
+            self.equal_allocation_by_district = equal_allocation_by_district
 
         self.show_progress_bar = show_progress_bar
 
@@ -183,6 +187,10 @@ class Simulation:
             module.pre_initialise_population()
 
         # Make the initial population
+        # if equal_allocation_by_district=True, then n=number of people in each district
+        if self.equal_allocation_by_district:
+            n = n * 32
+
         self.population = Population(self, n)
         for module in self.modules.values():
             start1 = time.time()

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -374,3 +374,29 @@ def test_ageing_of_old_people_up_to_max_age(simulation):
     # All persons should have died, with a cause of 'Other'
     assert not df.loc[ever_alive].is_alive.any()
     assert (df.loc[ever_alive, 'cause_of_death'] == 'Other').all()
+
+
+def test_equal_allocation_by_district(seed):
+    """
+    check when argument equal_allocation_by_district=True in class Simulation
+    that pop_size refers to the population within each district
+    and each district has idential population size
+    """
+
+    resourcefilepath = Path(os.path.dirname(__file__)) / '../resources'
+    popsize = 10
+    sim = Simulation(start_date=start_date, seed=seed, equal_allocation_by_district=True)
+    core_module = demography.Demography(resourcefilepath=resourcefilepath)
+    sim.register(core_module)
+    sim.make_initial_population(n=popsize)
+    sim.simulate(end_date=sim.start_date)
+
+    # check final population size
+    df = sim.population.props
+    assert len(df) == popsize * 32  # 32 districts
+
+    # check total within each district is identical and equals popsize
+    district_counts = df.groupby('district_of_residence').size()
+    assert (district_counts == popsize).all()
+
+

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -400,5 +400,5 @@ def test_equal_allocation_by_district(seed):
     assert sum(df.is_alive) == popsize
 
     # check total within each district is (close to being) identical and matches the target population of each district
-    pop_size_by_district = df.groupby('district_of_residence').size()
+    pop_size_by_district = df.loc[df.is_alive].groupby('district_of_residence').size()
     assert np.allclose(pop_size_by_district.values, pop_size_by_district, rtol=0.05)

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -378,25 +378,27 @@ def test_ageing_of_old_people_up_to_max_age(simulation):
 
 def test_equal_allocation_by_district(seed):
     """
-    check when argument equal_allocation_by_district=True in class Simulation
-    that pop_size refers to the population within each district
-    and each district has idential population size
+    Check when key-word argument `equal_allocation_by_district=True` that each district has an identical population size
     """
 
     resourcefilepath = Path(os.path.dirname(__file__)) / '../resources'
-    popsize = 10
-    sim = Simulation(start_date=start_date, seed=seed, equal_allocation_by_district=True)
-    core_module = demography.Demography(resourcefilepath=resourcefilepath)
-    sim.register(core_module)
+    sim = Simulation(start_date=start_date, seed=seed)
+    sim.register(
+        demography.Demography(
+            resourcefilepath=resourcefilepath,
+            equal_allocation_by_district=True,
+        )
+    )
+    population_per_district = 10_000
+    number_of_districts = len(sim.modules['Demography'].districts)
+    popsize = number_of_districts * population_per_district
     sim.make_initial_population(n=popsize)
-    sim.simulate(end_date=sim.start_date)
+    sim.simulate(end_date=sim.start_date)  # Simulate for zero days
 
-    # check final population size
+    # check population size
     df = sim.population.props
-    assert len(df) == popsize * 32  # 32 districts
+    assert sum(df.is_alive) == popsize
 
-    # check total within each district is identical and equals popsize
-    district_counts = df.groupby('district_of_residence').size()
-    assert (district_counts == popsize).all()
-
-
+    # check total within each district is (close to being) identical and matches the target population of each district
+    pop_size_by_district = df.groupby('district_of_residence').size()
+    assert np.allclose(pop_size_by_district.values, pop_size_by_district, rtol=0.05)


### PR DESCRIPTION
This PR uses the initial specified population size (n) and produces a population dataframe which creates n entries within each district. 

The rationale is that for highly heterogeneous diseases which occur in sparsely populated districts, this offers a way to create large enough populations in each district to reach endemic equilibria without requiring huge total population sizes. 

The argument equal_allocation_by_district is added to the Simulation class which is called during make_initial_population to create the correct sized dataframe.

Demography then uses this argument to allocate the population equally across the districts, retaining the age structure from the initial population data. 

A test is created in test_demography to ensure population size is correctly allocated. 

TO DO:
One issue is that the scaling factor now needs to be calculated per district. This will be needed to scale the outputs to full population size and to scale HCW capabilities in the case that mode 2 runs are required. 