### PR TITLE
Wgraham/prevent recomputing of equipment values

### DIFF
--- a/src/tlo/methods/equipment.py
+++ b/src/tlo/methods/equipment.py
@@ -116,7 +116,7 @@ class Equipment:
         assert availability in ["all", "none", "default"], f"New availability parameter {availability} not recognised."
         self.availability = availability
 
-    def _calculate_equipment_availability_probabilities(self) -> pd.DataFrame:
+    def _calculate_equipment_availability_probabilities(self) -> pd.Series:
         """
         Compute the probabilities that each equipment item is available (at a given
         facility), for use when the equipment availability is set to "default".
@@ -153,18 +153,7 @@ class Equipment:
         # Check no missing values
         assert not df.isnull().any()
 
-        # # Over-write these data if `availability` argument specifies that `none` or `all` items should be available
-        # if availability == "default":
-        #     pass
-        # elif availability == "all":
-        #     df = (df + 1).clip(upper=1.0)  # All probabilities -> 1.0
-        # elif availability == "none":
-        #     df = df.mul(0.0)  # All probabilities -> 0.0
-        # else:
-        #     raise KeyError(f"Unknown equipment availability specified: {availability=}")
-
-        # Save
-        self._probabilities_of_items_available = df
+        return df
 
     def parse_items(self, items: Union[int, str, Iterable[int | str]]) -> Set[int]:
         """Parse equipment items specified as an item_code (integer), an item descriptor (string), or an iterable of


### PR DESCRIPTION
Suggested changes for https://github.com/UCL/TLOmodel/pull/1098/files#r1598295772 - feel free to push changes to this branch. Likewise, what I write below is based off my current understanding of what we want the Equipment class to do, so please point out if I have misunderstood anything!

It looks like every time the equipment availability is updated, we are going to rebuild the `_probabilities_of_items_available` dataframe from scratch, which would likely slow us down a bit.

In two of the cases ("all" and "none") we actually just want all the probabilities to be 1/0 respectively, and in the third case we can get away with computing the probabilities once (say at the start of the simulation) and then storing them rather than overwriting them with 1s and 0s.

So I think it might be better for us to store the "availability" (that gets passed on `__init__`) and slightly rework the probability method to check against this variable before trying to lookup equipment:

```python

def __init__(self, ...):
  # ...
  self.availabilty = "all"/"none"/"default"
  self._equip_probabilities_by_default = _set_equipment_items_available()
  # ...

def probability_all_equipment_available(self, ...):
  if self.availability = "all":
    return 1
  elif self.availability = "none":
    return 0
  else:
    return p # the value we currently compute, from looking up all availability probabilities and multiplying, etc.
```

The changes in this PR perform these changes:

- The `_probabilities_of_items_available` attribute is computed in the `Equipment.__init__` method.
- The `availability` of equipment is stored by the `Equipment` instance.
- The `update_availability` method now just updates the `Equipment.availability` attribute.
- The `probability_all_equipment_available` method now checks against the `availability` value when returning probabilities, and flat returns 0 or 1 when necessary without needing to examine `_probabilities_of_items_available`.