### PR TITLE
`extract_results()`: adapt use of `do_scaling` option to behave as user expects.

### DIFF
--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -254,13 +254,11 @@ def extract_results(results_folder: Path,
     """
 
     def get_multiplier(_draw, _run):
-        """Helper function to get the multiplier from the simulation, if do_scaling=True.
+        """Helper function to get the multiplier from the simulation.
         Note that if the scaling factor cannot be found a `KeyError` is thrown."""
-        if not do_scaling:
-            return 1.0
-        else:
-            return load_pickled_dataframes(results_folder, _draw, _run, 'tlo.methods.population'
-                                           )['tlo.methods.population']['scaling_factor']['scaling_factor'].values[0]
+        return load_pickled_dataframes(
+            results_folder, _draw, _run, 'tlo.methods.population'
+        )['tlo.methods.population']['scaling_factor']['scaling_factor'].values[0]
 
     if custom_generate_series is None:
         # If there is no `custom_generate_series` provided, it implies that function required selects the specified
@@ -293,7 +291,10 @@ def extract_results(results_folder: Path,
                 df: pd.DataFrame = load_pickled_dataframes(results_folder, draw, run, module)[module][key]
                 output_from_eval: pd.Series = generate_series(df)
                 assert pd.Series == type(output_from_eval), 'Custom command does not generate a pd.Series'
-                res[draw_run] = output_from_eval * get_multiplier(draw, run)
+                if do_scaling:
+                    res[draw_run] = output_from_eval * get_multiplier(draw, run)
+                else:
+                    res[draw_run] = output_from_eval
 
             except KeyError:
                 # Some logs could not be found - probably because this run failed.


### PR DESCRIPTION
Currently, even when the user specifies `do_scaling=False` in `extract_results`, there is an attempt to scale results (by 1.0). This causes unexpected errrors in the case of non-numeric data.

This update means that when `do_scaling=False` there is no attemt to any scaling and so the function can be used safely with non-numeric data.
