### PR TITLE
Globally disable Pylint E0606 possibly-used-before-assignment rule + fix one case

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ disable = [
     "R",
     "C",
     "W",
+    "E0606",  # possibly-used-before-assignment - gives a lot of false positives
 ]
 
 

--- a/src/tlo/analysis/hsi_events.py
+++ b/src/tlo/analysis/hsi_events.py
@@ -465,6 +465,9 @@ def main():
     """Entry point to do the inspection of HSI events when running as script."""
     args = _parse_command_line_args()
     warnings.simplefilter('ignore')
+    if args.json_file is None and args.merge_json_details:
+        msg = "Cannot merge details if JSON file not specified"
+        raise ValueError(msg)
     if args.json_file is not None:
         with open(args.json_file, 'r') as f:
             hsi_event_details = json.load(f)


### PR DESCRIPTION
As noted in https://github.com/UCL/TLOmodel/pull/1098#issuecomment-2112085188, the [latest v3.2.0 Pylint release](https://github.com/pylint-dev/pylint/releases/tag/v3.2.0) adds [a new check `possibly-used-before-assignment / E0606`](https://pylint.pycqa.org/en/latest/user_guide/messages/error/possibly-used-before-assignment.html) which checks for possible usages of variables before they are assigned to. This however currently seems to be throwing up a lot of false positives when [running checks on main](https://github.com/UCL/TLOmodel/actions/runs/9087784671/job/24976165364):

```
check: commands[5]> pylint src tests
 ************* Module src.tlo.analysis.hsi_events
src/tlo/analysis/hsi_events.py:498:12: E0606: Possibly using variable 'inspect_hsi_event_details' before assignment (possibly-used-before-assignment)
src/tlo/analysis/hsi_events.py:498:39: E0606: Possibly using variable 'json_hsi_event_details' before assignment (possibly-used-before-assignment)
************* Module src.tlo.methods.pregnancy_helper_functions
src/tlo/methods/pregnancy_helper_functions.py:430:16: E0606: Possibly using variable 'risk' before assignment (possibly-used-before-assignment)
************* Module src.tlo.methods.postnatal_supervisor
src/tlo/methods/postnatal_supervisor.py:864:46: E0606: Possibly using variable 'risk_of_death' before assignment (possibly-used-before-assignment)
************* Module src.tlo.methods.pregnancy_supervisor
src/tlo/methods/pregnancy_supervisor.py:913:60: E0606: Possibly using variable 'first_anc_appt' before assignment (possibly-used-before-assignment)
************* Module src.tlo.methods.contraception
src/tlo/methods/contraception.py:698:78: E0606: Possibly using variable 'due_appt' before assignment (possibly-used-before-assignment
```

Of these the only one I think is potentially valid is `src/tlo/analysis/hsi_events.py:498:39: E0606: Possibly using variable 'json_hsi_event_details' before assignment (possibly-used-before-assignment)` as in 

https://github.com/UCL/TLOmodel/blob/b844efeb1b949d998e5d9de51fdae36690909a1b/src/tlo/analysis/hsi_events.py#L468-L499

if `args.json_file is None` and `args.merge_json_details` is `True` then line 498 will be run and `json_hsi_event_details` will not be defined (this set of arguments would not in itself make sense but we should probably still have a more informative error message triggered if these arguments are encountered).

The other cases I think are all false positives, corresponding to variants of the following minimum working examples

```Python
def case_a(condition_1: bool, condition_2: bool):
    if not condition_1 and condition_2:
        condition_3 = True
    return condition_2 and (condition_1 or condition_3)


def case_b(condition: bool, key: str):

    def inner_function(key):
        a_dict[key] = 2

    if condition:
        a_dict = {key: 1}
        inner_function(key)


def case_c(condition_1: bool, condition_2: bool, number: float):
    if condition_1:
        a_variable = 1
    elif condition_2:
        a_variable = 2
    if condition_1 or condition_2:
        if number < a_variable:
            ...
    ...


def case_d(condition_1: bool, condition_2: bool):
    if condition_1 or condition_2:
        variable = ...
    if condition_2:
        print(variable)
```

with Pylint flagging E0606 failures on all four `case_*` functions even though I think in all cases it is not possible for code path with an undefined variable to be reached. There are already a couple of open issues on Pylint repository pylint-dev/pylint/issues/9628 and pylint-dev/pylint/issues/9627 with regards to false positives with E0606, and I think some of above cases may suggest there are further things needing fixing to make this check robust.

This PR therefore globally disables the Pylint E0606 rule by adding to the `tool.pylint.main.disable` list. It also adds logic to raise an exception with a more informative error message for the true positive identified in `hsi_events.py` with regards to `json_hsi_event_details` potentially not being defined when used for some (invalid) argument values, though because of I think pylint-dev/pylint/issues/9627 a false positive E0606 violation is still registered after this fix.