### PR TITLE
`BedDays` availability switch now correctly updates capacities

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -2776,7 +2776,11 @@ class HealthSystemChangeParameters(Event, PopulationScopeEventMixin):
             self.module.consumables.on_start_of_day(self.module.sim.date)
 
         if 'beds_availability' in self._parameters:
-            self.module.bed_days.availability = self._parameters['beds_availability']
+            self.module.bed_days.switch_beddays_availability(
+                new_availability=self._parameters["beds_availability"],
+                effective_on_and_from=self.sim.date,
+                model_to_data_popsize_ratio=self.sim.modules["Demography"].initial_model_to_data_popsize_ratio
+            )
 
         if 'equip_availability' in self._parameters:
             self.module.equipment.availability = self._parameters['equip_availability']


### PR DESCRIPTION
Fixes #1346

- A new method, `switch_beddays_availability` has been created to handle all steps necessary when switching the availability of beds.
- An appropriate test for this method has been added. There is scope to parametrise this test to check other possible inputs for `availability`, but this in itself should be covered if we are already testing the `set_scaled_capacity` method which the new method depends on.