### PR TITLE
[CI] Run nightly calibration with new healthsystem mode

### DIFF
--- a/.github/workflows/calibrations.yaml
+++ b/.github/workflows/calibrations.yaml
@@ -5,14 +5,14 @@ on:
     - cron: 31 2 * * *
 
 jobs:
-  name: "Calibration for model ${{ matrix.model }}"
   version-matrix:
+    name: "Calibration for mode ${{ matrix.hs_mode }}"
     strategy:
       fail-fast: false
       matrix:
-        model: [mode1, mode2]
+        hs_mode: [1, 2]
     uses: ./.github/workflows/calibrations_common.yaml
     with:
-      model: ${{ matrix.model }}
+      hs_mode: ${{ matrix.hs_mode }}
       commit: ${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/calibrations.yaml
+++ b/.github/workflows/calibrations.yaml
@@ -3,6 +3,8 @@ name: "Calibrations (nightly)"
 on:
   schedule:
     - cron: 31 2 * * *
+  pull_request:
+    branches: "master"
 
 jobs:
   version-matrix:

--- a/.github/workflows/calibrations.yaml
+++ b/.github/workflows/calibrations.yaml
@@ -1,0 +1,18 @@
+name: "Calibrations (nightly)"
+
+on:
+  schedule:
+    - cron: 31 2 * * *
+
+jobs:
+  name: "Calibration for model ${{ matrix.model }}"
+  version-matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        model: [mode1, mode2]
+    uses: ./.github/workflows/calibrations_common.yaml
+    with:
+      model: ${{ matrix.model }}
+      commit: ${{ github.sha }}
+    secrets: inherit

--- a/.github/workflows/calibrations_common.yaml
+++ b/.github/workflows/calibrations_common.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Generate environment variables
         id: vars
         run: |
-          SHA=${{ inputs.commit }}
+          SHA="mg/calibration-mod2"
           ENV="/mnt/tlo/env-healthsystem-mode${{ inputs.hs_mode }}-${SHA}"
           if [[ -d "${ENV}" ]]; then
               echo "Virtual environment directory ${ENV} already exists, leaving..."
@@ -85,7 +85,7 @@ jobs:
         run: |
           # If the repository doesn't exist on disk, clone it.
           if [[ ! -d "${REPO_PATH}" ]]; then
-              git clone --depth=1 --branch="${{ github.ref_name }}" "https://github.com/${{ github.repository }}.git" "${REPO_PATH}"
+              git clone "https://github.com/giordano/TLOmodel.git" "${REPO_PATH}"
           fi
           # In any case, fetch the requested commit.
           git -C "${REPO_PATH}" fetch --depth=1 origin "${SHA}"
@@ -167,7 +167,7 @@ jobs:
           task_output_dir="${{ needs.setup.outputs.output_dir }}/${RUN_NAME}/${draw}/${{ matrix.index }}"
           mkdir -p "${task_output_dir}"
 
-          tlo scenario-run --output-dir "${task_output_dir}" --draw "${draw}" ${{ matrix.index }} "${{ needs.setup.outputs.worktree_path }}/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py" --healthsystem-mode ${{ inputs.hs_mode }}
+          tlo scenario-run --output-dir "${task_output_dir}" --draw "${draw}" ${{ matrix.index }} "${{ needs.setup.outputs.worktree_path }}/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py" --healthsystem-mode ${{ inputs.hs_mode }} --end-date '2011-01-01'
         working-directory: "${{ needs.setup.outputs.worktree_path }}"
 
   # Do the postprocessing

--- a/.github/workflows/calibrations_common.yaml
+++ b/.github/workflows/calibrations_common.yaml
@@ -1,23 +1,41 @@
-name: Calibration
+name: "Calibration (reusable)"
 
 on:
+  workflow_call:
+    inputs:
+      commit:
+        description: '40-character commit hash'
+        required: true
+        default: ''
+        type: string
+      model:
+        description: 'Model'
+        required: true
+        default: ''
+        type: string
   workflow_dispatch:
     inputs:
       commit:
         description: '40-character commit hash'
         required: true
-        default: ""
+        default: ''
         type: string
-  schedule:
-    - cron: 31 2 * * *
+      model:
+        description: 'Model'
+        required: true
+        default: ''
+        type: choice
+        options:
+        - 'mode1'
+        - 'mode2'
 
 env:
   REPO_PATH:       /mnt/tlo/TLOmodel
   OUTPUT_ROOT:     /mnt/tlodev2stg/tlo-dev-fs-2/task-runner/output
   RUNS_NUMBER:     10
   PYTHON_VER:      3.11
-  RUN_NAME:        021_long_run_all_diseases_run
-  PROCESS_NAME:    022_long_run_all_diseases_process
+  RUN_NAME:        021_long_run_all_diseases_${{ inputs.model }}_run
+  PROCESS_NAME:    022_long_run_all_diseases_${{ inputs.model }}_process
 
 jobs:
 
@@ -27,7 +45,7 @@ jobs:
   # `actions/checkout` workflow.
   setup:
     name: Setup
-    runs-on: [tlo-dev-vm-1]
+    runs-on: [tlo-dev-vm-3]
     strategy:
       fail-fast: false
     outputs:
@@ -43,17 +61,13 @@ jobs:
       - name: Generate environment variables
         id: vars
         run: |
-          if [[ ${{ github.event_name }} == 'workflow_dispatch' ]] && [[ -n "${{ inputs.commit }}" ]]; then
-              SHA=${{ inputs.commit }}
-          else
-              SHA=${{ github.sha }}
-          fi
-          ENV="/mnt/tlo/env-${SHA}"
+          SHA=${{ inputs.commit }}
+          ENV="/mnt/tlo/env-${{ inputs.model }}-${SHA}"
           if [[ -d "${ENV}" ]]; then
               echo "Virtual environment directory ${ENV} already exists, leaving..."
               exit 1
           fi
-          WORKTREE_PATH="/mnt/tlo/${SHA}"
+          WORKTREE_PATH="/mnt/tlo/${{ inputs.model }}-${SHA}"
           if [[ -d "${WORKTREE_PATH}" ]]; then
               echo "Worktree directory ${WORKTREE_PATH} already exists, leaving..."
               exit 1
@@ -134,7 +148,7 @@ jobs:
   tasks:
     needs: setup
     name: Run task ${{ matrix.index }}
-    runs-on: [tlo-dev-vm-1, tasks] # Use only runners dedicated to running the tasks.
+    runs-on: [tlo-dev-vm-3, tasks, ${{ inputs.model }}] # Use only runners dedicated to running the tasks.
     timeout-minutes: 5760 # = 4 * 24 * 60 minutes = 4 days
     strategy:
       fail-fast: false
@@ -159,7 +173,7 @@ jobs:
   postprocess:
     name: Post processing
     needs: [setup, tasks]
-    runs-on: [tlo-dev-vm-1, postprocess] # Use only the runners dedicated to postprocessing
+    runs-on: [tlo-dev-vm-3, postprocess] # Use only the runners dedicated to postprocessing
     strategy:
       fail-fast: false
     steps:
@@ -190,7 +204,7 @@ jobs:
     # `setup` was successful, to avoid cleaning up existing worktrees and
     # environments used by other builds.
     if: ${{ always() && needs.setup.result == 'success' }}
-    runs-on: [tlo-dev-vm-1]
+    runs-on: [tlo-dev-vm-3]
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/calibrations_common.yaml
+++ b/.github/workflows/calibrations_common.yaml
@@ -8,8 +8,8 @@ on:
         required: true
         default: ''
         type: string
-      model:
-        description: 'Model'
+      hs_mode:
+        description: 'Healthsystem mode'
         required: true
         default: ''
         type: string
@@ -20,22 +20,22 @@ on:
         required: true
         default: ''
         type: string
-      model:
-        description: 'Model'
+      hs_mode:
+        description: 'Healthsystem mode'
         required: true
         default: ''
         type: choice
         options:
-        - 'mode1'
-        - 'mode2'
+        - '1'
+        - '2'
 
 env:
-  REPO_PATH:       /mnt/tlo/TLOmodel
+  REPO_PATH:       /mnt/tlo/TLOmodel-mode${{ inputs.hs_mode }}
   OUTPUT_ROOT:     /mnt/tlodev2stg/tlo-dev-fs-2/task-runner/output
   RUNS_NUMBER:     10
   PYTHON_VER:      3.11
-  RUN_NAME:        021_long_run_all_diseases_${{ inputs.model }}_run
-  PROCESS_NAME:    022_long_run_all_diseases_${{ inputs.model }}_process
+  RUN_NAME:        021_long_run_all_diseases_mode${{ inputs.hs_mode }}_run
+  PROCESS_NAME:    022_long_run_all_diseases_mode${{ inputs.hs_mode }}_process
 
 jobs:
 
@@ -62,12 +62,12 @@ jobs:
         id: vars
         run: |
           SHA=${{ inputs.commit }}
-          ENV="/mnt/tlo/env-${{ inputs.model }}-${SHA}"
+          ENV="/mnt/tlo/env-healthsystem-mode${{ inputs.hs_mode }}-${SHA}"
           if [[ -d "${ENV}" ]]; then
               echo "Virtual environment directory ${ENV} already exists, leaving..."
               exit 1
           fi
-          WORKTREE_PATH="/mnt/tlo/${{ inputs.model }}-${SHA}"
+          WORKTREE_PATH="/mnt/tlo/healthsystem-mode${{ inputs.hs_mode }}-${SHA}"
           if [[ -d "${WORKTREE_PATH}" ]]; then
               echo "Worktree directory ${WORKTREE_PATH} already exists, leaving..."
               exit 1
@@ -116,8 +116,9 @@ jobs:
         id: tasks
         run: |
           SKIP_TASKS="false"
-          if [[ -d "${output_dir}" ]]; then
-              echo "Output directory ${output_dir} already exists, setting RUNS_NUMBER to 1 and skipping further task runs"
+          output_dir_run_name="${output_dir}/${RUN_NAME}"
+          if [[ -d "${output_dir_run_name}" ]]; then
+              echo "Output directory ${output_dir_run_name} already exists, setting RUNS_NUMBER to 1 and skipping further task runs"
               RUNS_NUMBER=1
               # Set variable to make task job run, but exit immediately, so that
               # the build doesn't fail.
@@ -148,7 +149,7 @@ jobs:
   tasks:
     needs: setup
     name: Run task ${{ matrix.index }}
-    runs-on: [tlo-dev-vm-3, tasks, ${{ inputs.model }}] # Use only runners dedicated to running the tasks.
+    runs-on: [tlo-dev-vm-3, tasks, 'healthsystem-mode-${{ inputs.hs_mode }}'] # Use only runners dedicated to running the tasks.
     timeout-minutes: 5760 # = 4 * 24 * 60 minutes = 4 days
     strategy:
       fail-fast: false
@@ -166,7 +167,7 @@ jobs:
           task_output_dir="${{ needs.setup.outputs.output_dir }}/${RUN_NAME}/${draw}/${{ matrix.index }}"
           mkdir -p "${task_output_dir}"
 
-          tlo scenario-run --output-dir "${task_output_dir}" --draw "${draw}" ${{ matrix.index }} "${{ needs.setup.outputs.worktree_path }}/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py"
+          tlo scenario-run --output-dir "${task_output_dir}" --draw "${draw}" ${{ matrix.index }} "${{ needs.setup.outputs.worktree_path }}/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py" --healthsystem-mode ${{ inputs.hs_mode }}
         working-directory: "${{ needs.setup.outputs.worktree_path }}"
 
   # Do the postprocessing

--- a/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
+++ b/src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py
@@ -14,6 +14,7 @@ from tlo import Date, logging
 from tlo.analysis.utils import get_parameters_for_status_quo
 from tlo.methods.fullmodel import fullmodel
 from tlo.scenario import BaseScenario
+from tlo.util import str_to_pandas_date
 
 
 class LongRun(BaseScenario):
@@ -25,6 +26,7 @@ class LongRun(BaseScenario):
         self.pop_size = 20_000
         self.number_of_draws = 1
         self.runs_per_draw = 10
+        self.healthsystem_mode = 1
 
     def log_configuration(self):
         return {
@@ -45,8 +47,13 @@ class LongRun(BaseScenario):
         return fullmodel(resourcefilepath=self.resources)
 
     def draw_parameters(self, draw_number, rng):
-        return get_parameters_for_status_quo()
+        params = get_parameters_for_status_quo()
+        params['HealthSystem']['mode_appt_constraints'] = self.healthsystem_mode
+        return params
 
+    def add_arguments(self, parser):
+        parser.add_argument('--healthsystem-mode', type=int)
+        parser.add_argument('--end-date', type=str_to_pandas_date)
 
 if __name__ == '__main__':
     from tlo.cli import scenario_run


### PR DESCRIPTION
This turn the old calibration workflow into a reusable workflow, which can be used by multiple healthsystem modes runs.

This will eventually fix #1335.

As discussed in the meeting this morning we will probably go with a single larger machine ([`Standard_F32s_v2`](https://learn.microsoft.com/en-us/azure/virtual-machines/fsv2-series)?), to answer the question at https://github.com/UCL/TLOmodel/issues/1335#issuecomment-2117248807.

TODO:

*   [x] reference mode name in `WORKTREE_PATH` and `ENV`, so that the different calibration runs don't step on each other (especially the cleanup stage)
*   [x] the run script should actually do something different for the two different modes (right now I don't know exactly where this should happen)
*   [x] set up and provision the new virtual machine. Remember to change the labels of the runners, some (10?) runners will be only for `mode1`, other only for `mode2` (but both for `tasks`), and one for `postprocess`
*   [x] change the `runs-on` to use the new machine name
*   [ ] the postprocessing script will have to be adapted
*   [ ] the html generating script will have to be adapted
*   [ ] drop the test commit before merging
*   [ ] ...