### PR TITLE
[CI] Change label of runners for profiling workflows

### DIFF
--- a/.github/workflows/run-profiling.yaml
+++ b/.github/workflows/run-profiling.yaml
@@ -82,7 +82,7 @@ jobs:
     needs: set-variables
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: '["self-hosted", "test"]'
+      runs-on: '["self-hosted", "profiling"]'
       keyword: profiling
       commands: |
         tox -vv -e profile -- \
@@ -108,7 +108,7 @@ jobs:
     name: Scheduled / dispatch triggered profiling
     if: ${{ github.event_name != 'issue_comment' }}
     needs: set-variables
-    runs-on: [self-hosted, test]
+    runs-on: [self-hosted, profiling]
     timeout-minutes: 8640
     steps:
       - name: Checkout repository


### PR DESCRIPTION
I set up a new Kubernetes cluster on Azure, the runners have labels [`profiling`](https://github.com/TLOmodel/autoscaling-github-actions-runners/blob/52c13eb11bf80a9f5a0447631f45d53bbdaeb434/infra/manifest.tmpl.yaml#L14).

Ref: #1356.