### PR TITLE
Revert "[CI] Change label of runners for profiling workflows"

### DIFF
--- a/.github/workflows/run-profiling.yaml
+++ b/.github/workflows/run-profiling.yaml
@@ -82,7 +82,7 @@ jobs:
     needs: set-variables
     uses: ./.github/workflows/run-on-comment.yml
     with:
-      runs-on: '["self-hosted", "profiling"]'
+      runs-on: '["self-hosted", "test"]'
       keyword: profiling
       commands: |
         tox -vv -e profile -- \
@@ -108,7 +108,7 @@ jobs:
     name: Scheduled / dispatch triggered profiling
     if: ${{ github.event_name != 'issue_comment' }}
     needs: set-variables
-    runs-on: [self-hosted, profiling]
+    runs-on: [self-hosted, test]
     timeout-minutes: 8640
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Reverts UCL/TLOmodel#1358.  The Azure Kubernetes cluster is up and running, but it's not able to create new runners.  I need to investigate what's going on.

***Edit***: wait, maybe I found the issue.