### PR TITLE
`HSI_Event` uses separate private member function (`_run_after_hsi_event`) instead of `post_apply_hook`

### DIFF
--- a/src/tlo/methods/hsi_event.py
+++ b/src/tlo/methods/hsi_event.py
@@ -171,7 +171,7 @@ class HSI_Event:
         """Called when this event is was entered to the HSI Event Queue, but was never run."""
         logger.debug(key="message", data=f"{self.__class__.__name__}: was never run.")
 
-    def post_apply_hook(self) -> None:
+    def _run_after_hsi_event(self) -> None:
         """
         Do things following the event's `apply` function running.
          * Impose the bed-days footprint (if target of the HSI is a person_id)
@@ -193,6 +193,7 @@ class HSI_Event:
         """Make the event happen."""
         updated_appt_footprint = self.apply(self.target, squeeze_factor)
         self.post_apply_hook()
+        self._run_after_hsi_event()
         return updated_appt_footprint
 
     def get_consumables(
@@ -283,7 +284,7 @@ class HSI_Event:
     def add_equipment(self, item_codes: Union[int, str, Iterable[int], Iterable[str]]) -> None:
         """Declare that piece(s) of equipment are used in this HSI_Event. Equipment items can be identified by their
         item_codes (int) or descriptors (str); a singular item or an iterable of items (either codes or descriptors but
-        not a mix of both) can be defined at once. Checks are done on the validity of the item_codes/item 
+        not a mix of both) can be defined at once. Checks are done on the validity of the item_codes/item
         descriptions and a warning issued if any are not recognised."""
         self._EQUIPMENT.update(self.healthcare_system.equipment.parse_items(item_codes))
 

--- a/src/tlo/methods/hsi_event.py
+++ b/src/tlo/methods/hsi_event.py
@@ -173,7 +173,6 @@ class HSI_Event:
 
     def post_apply_hook(self) -> None:
         """Do any required processing after apply() completes."""
-        pass
 
     def _run_after_hsi_event(self) -> None:
         """

--- a/src/tlo/methods/hsi_event.py
+++ b/src/tlo/methods/hsi_event.py
@@ -173,7 +173,7 @@ class HSI_Event:
 
     def _run_after_hsi_event(self) -> None:
         """
-        Do things following the event's `apply` function running.
+        Do things following the event's `apply` and `post_apply_hook` functions running.
          * Impose the bed-days footprint (if target of the HSI is a person_id)
          * Record the equipment that has been added before and during the course of the HSI Event.
         """

--- a/src/tlo/methods/hsi_event.py
+++ b/src/tlo/methods/hsi_event.py
@@ -284,7 +284,7 @@ class HSI_Event:
     def add_equipment(self, item_codes: Union[int, str, Iterable[int], Iterable[str]]) -> None:
         """Declare that piece(s) of equipment are used in this HSI_Event. Equipment items can be identified by their
         item_codes (int) or descriptors (str); a singular item or an iterable of items (either codes or descriptors but
-        not a mix of both) can be defined at once. Checks are done on the validity of the item_codes/item
+        not a mix of both) can be defined at once. Checks are done on the validity of the item_codes/item 
         descriptions and a warning issued if any are not recognised."""
         self._EQUIPMENT.update(self.healthcare_system.equipment.parse_items(item_codes))
 

--- a/src/tlo/methods/hsi_event.py
+++ b/src/tlo/methods/hsi_event.py
@@ -171,6 +171,10 @@ class HSI_Event:
         """Called when this event is was entered to the HSI Event Queue, but was never run."""
         logger.debug(key="message", data=f"{self.__class__.__name__}: was never run.")
 
+    def post_apply_hook(self):
+        """Do any required processing after apply() completes."""
+        pass
+
     def _run_after_hsi_event(self) -> None:
         """
         Do things following the event's `apply` and `post_apply_hook` functions running.
@@ -284,7 +288,7 @@ class HSI_Event:
     def add_equipment(self, item_codes: Union[int, str, Iterable[int], Iterable[str]]) -> None:
         """Declare that piece(s) of equipment are used in this HSI_Event. Equipment items can be identified by their
         item_codes (int) or descriptors (str); a singular item or an iterable of items (either codes or descriptors but
-        not a mix of both) can be defined at once. Checks are done on the validity of the item_codes/item 
+        not a mix of both) can be defined at once. Checks are done on the validity of the item_codes/item
         descriptions and a warning issued if any are not recognised."""
         self._EQUIPMENT.update(self.healthcare_system.equipment.parse_items(item_codes))
 

--- a/src/tlo/methods/hsi_event.py
+++ b/src/tlo/methods/hsi_event.py
@@ -171,7 +171,7 @@ class HSI_Event:
         """Called when this event is was entered to the HSI Event Queue, but was never run."""
         logger.debug(key="message", data=f"{self.__class__.__name__}: was never run.")
 
-    def post_apply_hook(self):
+    def post_apply_hook(self) -> None:
         """Do any required processing after apply() completes."""
         pass
 

--- a/tests/test_beddays.py
+++ b/tests/test_beddays.py
@@ -211,7 +211,7 @@ def test_bed_days_basics(tmpdir, seed):
     assert not df.at[person_id, 'hs_is_inpatient']
 
     # impose the footprint:
-    hsi_bd.post_apply_hook()
+    hsi_bd._run_after_hsi_event()
 
     # check that person is an in-patient now
     assert df.at[person_id, 'hs_is_inpatient']


### PR DESCRIPTION
Fixes #1360 

Here `HSI_Event` uses a separate private member function (`_run_after_hsi_event`) rather than `post_apply_hook` to do the jobs expected after the `HSI_Event` has run.

This prevents disease modules using `HSI_Events` that over-write the `post_apply_hook` member function and so inadvertently removing the expected behaviour of the `HSI_Event`.

