### PR TITLE
Editing units of consumable required: Contraception module

### DIFF
--- a/src/tlo/methods/contraception.py
+++ b/src/tlo/methods/contraception.py
@@ -675,9 +675,8 @@ class Contraception(Module):
         _cons_codes = dict()
         _cons_alternatives_probs = dict()
         # # items for each method that requires an HSI to switch to
-        # TODO: to find from Emi - What are the numbers of pills in monthly packets for both following items?
         _cons_codes['pill'] =\
-            {get_item_code("Levonorgestrel 0.0375 mg, cycle"): 28*3.75,
+            {get_item_code("Levonorgestrel 0.0375 mg, cycle"): 21*3.75,
              # (alternative) progesterone-only pills used in other 20% cases (see _cons_alternatives_probs)
              get_item_code("Levonorgestrel 0.15 mg + Ethinyl estradiol 30 mcg (Microgynon), cycle"): 21*3.75
              # combined pills used in 80% cases (see _cons_alternatives_probs)

--- a/src/tlo/methods/contraception.py
+++ b/src/tlo/methods/contraception.py
@@ -692,16 +692,12 @@ class Contraception(Module):
         _cons_codes['IUD'] =\
             {get_item_code("Glove disposable powdered latex medium_100_CMST"): 2,
              get_item_code("IUD, Copper T-380A"): 1}
-        # TODO: originally used "Medroxyprogesterone acetate injection 150mg/mL, 1mL vial with 2ml syringe with 22g 0.7
-        #  X 25mm needle_each_CMST", which is not within the RF_Costing anymore, does it mean we need to add a syringe
-        #  and a needle?
         _cons_codes['injections'] = \
             {get_item_code("Depot-Medroxyprogesterone Acetate 150 mg - 3 monthly"): 1,
              get_item_code("Glove disposable powdered latex medium_100_CMST"): 1,
              get_item_code("Water for injection, 10ml_Each_CMST"): 1,
              get_item_code("Povidone iodine, solution, 10 %, 5 ml per injection"): 5,
              get_item_code("Gauze, swabs 8-ply 10cm x 10cm_100_CMST"): 1}
-        # TODO: @Sakshi - update the unit to 1 use
         _cons_codes['implant'] =\
             {get_item_code("Glove disposable powdered latex medium_100_CMST"): 3,
              get_item_code("Lidocaine HCl (in dextrose 7.5%), ampoule 2 ml"): 2,

--- a/src/tlo/methods/contraception.py
+++ b/src/tlo/methods/contraception.py
@@ -701,9 +701,7 @@ class Contraception(Module):
              get_item_code("Water for injection, 10ml_Each_CMST"): 1,
              get_item_code("Povidone iodine, solution, 10 %, 5 ml per injection"): 5,
              get_item_code("Gauze, swabs 8-ply 10cm x 10cm_100_CMST"): 1}
-        # TODO: trocar may be reusable (we used 0.1 units, indicating 10 uses on average) - need to find out for what
-        #  kind of trocar (reusable or not) we have the cost
-        # TODO: @Sakshi The chosen unit for Jadelle is '1 implant', does it cover both rods?
+        # TODO: @Sakshi - update the unit to 1 use
         _cons_codes['implant'] =\
             {get_item_code("Glove disposable powdered latex medium_100_CMST"): 3,
              get_item_code("Lidocaine HCl (in dextrose 7.5%), ampoule 2 ml"): 2,


### PR DESCRIPTION
units per case updated to relate to the chosen units in #1298 for consumables in contraception module
(and item codes get from item names instead of pkg name, hence numbers of units per case defined within the code)