### PR TITLE
Allow users to pass command-line arguments to scenarios

### DIFF
--- a/src/tlo/cli.py
+++ b/src/tlo/cli.py
@@ -44,17 +44,23 @@ def cli(ctx, config_file, verbose):
     ctx.obj["verbose"] = verbose
 
 
-@cli.command()
+@cli.command(context_settings=dict(ignore_unknown_options=True))
 @click.argument("scenario_file", type=click.Path(exists=True))
 @click.option("--draw-only", is_flag=True, help="Only generate draws; do not run the simulation")
 @click.option("--draw", "-d", nargs=2, type=int)
 @click.option("--output-dir", type=str)
-def scenario_run(scenario_file, draw_only, draw: tuple, output_dir=None):
+@click.argument('scenario_args', nargs=-1, type=click.UNPROCESSED)
+def scenario_run(scenario_file, draw_only, draw: tuple, output_dir=None, scenario_args=None):
     """Run the specified scenario locally.
 
     SCENARIO_FILE is path to file containing a scenario class
     """
     scenario = load_scenario(scenario_file)
+
+    # if we have other scenario arguments, parse them
+    if scenario_args is not None:
+        scenario.parse_arguments(scenario_args)
+
     config = scenario.save_draws(return_config=True)
     json_string = json.dumps(config, indent=2)
 

--- a/src/tlo/scenario.py
+++ b/src/tlo/scenario.py
@@ -66,7 +66,7 @@ import json
 import pickle
 from itertools import product
 from pathlib import Path, PurePosixPath
-from typing import Optional, List
+from typing import List, Optional
 
 import numpy as np
 

--- a/src/tlo/scenario.py
+++ b/src/tlo/scenario.py
@@ -136,8 +136,6 @@ class BaseScenario(abc.ABC):
         self.arguments = extra_arguments
 
         parser = argparse.ArgumentParser()
-        parser.add_argument("--resume-simulation", type=str, help="Resume simulation from directory")
-        parser.add_argument("--suspend-date", type=str_to_pandas_date, help="Suspend the simulation")
 
         # add arguments from the subclass
         self.add_arguments(parser)

--- a/src/tlo/scenario.py
+++ b/src/tlo/scenario.py
@@ -153,7 +153,8 @@ class BaseScenario(abc.ABC):
         """Add scenario-specific arguments that can be passed to scenario from the command line.
 
         This method is called to add scenario-specific arguments to the command line parser. The method should add
-        arguments to the parser using the `add_argument` method.
+        arguments to the parser using the `add_argument` method. Arguments that have a value of None are not set or
+        overridden.
 
         :param parser: An instance of `argparse.ArgumentParser` to which arguments should be added.
 

--- a/src/tlo/scenario.py
+++ b/src/tlo/scenario.py
@@ -66,7 +66,7 @@ import json
 import pickle
 from itertools import product
 from pathlib import Path, PurePosixPath
-from typing import Optional
+from typing import Optional, List
 
 import numpy as np
 
@@ -129,7 +129,7 @@ class BaseScenario(abc.ABC):
         self.scenario_path = None
         self.arguments = None
 
-    def parse_arguments(self, extra_arguments):
+    def parse_arguments(self, extra_arguments: List[str]) -> None:
         """Base class command line arguments handling for scenarios. This should not be overridden by subclasses.
         Subclasses can add argument handling to their classes by implementing the `add_arguments` method."""
 
@@ -151,12 +151,13 @@ class BaseScenario(abc.ABC):
                     logger.info(key="message", data=f"Overriding attribute: {key}: {getattr(self, key)} -> {value}")
                 setattr(self, key, value)
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         """Add scenario-specific arguments that can be passed to scenario from the command line.
 
-        This method is called to add scenario-specific arguments to the command line parser. The parser is an
-        instance of argparse.ArgumentParser. The method should add arguments to the parser using the
-        add_argument method.
+        This method is called to add scenario-specific arguments to the command line parser. The method should add
+        arguments to the parser using the `add_argument` method.
+
+        :param parser: An instance of `argparse.ArgumentParser` to which arguments should be added.
 
         Example::
 

--- a/src/tlo/scenario.py
+++ b/src/tlo/scenario.py
@@ -72,7 +72,6 @@ import numpy as np
 
 from tlo import Date, Simulation, logging
 from tlo.analysis.utils import parse_log_file
-from tlo.util import str_to_pandas_date
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/src/tlo/scenario.py
+++ b/src/tlo/scenario.py
@@ -130,16 +130,9 @@ class BaseScenario(abc.ABC):
         self.arguments = None
 
     def parse_arguments(self, extra_arguments):
-        """Add scenario-specific arguments to the command line parser.
+        """Base class command line arguments handling for scenarios. This should not be overridden by subclasses.
+        Subclasses can add argument handling to their classes by implementing the `add_arguments` method."""
 
-        This method is called by the CLI to add scenario-specific arguments to the
-        command line parser. The parser is an instance of argparse.ArgumentParser. The
-        method should add arguments to the parser using the add_argument method.
-
-        Example::
-
-            parser.add_argument('--pop-size', type=int, default=20_000, help='Population size')
-        """
         self.arguments = extra_arguments
 
         parser = argparse.ArgumentParser()
@@ -159,7 +152,16 @@ class BaseScenario(abc.ABC):
                 setattr(self, key, value)
 
     def add_arguments(self, parser):
-        """Called to add scenario-specific arguments to the argparse parser. Can be overridden in subclasses."""
+        """Add scenario-specific arguments that can be passed to scenario from the command line.
+
+        This method is called to add scenario-specific arguments to the command line parser. The parser is an
+        instance of argparse.ArgumentParser. The method should add arguments to the parser using the
+        add_argument method.
+
+        Example::
+
+            parser.add_argument('--pop-size', type=int, default=20_000, help='Population size')
+        """
         pass
 
     @abc.abstractmethod

--- a/src/tlo/util.py
+++ b/src/tlo/util.py
@@ -407,6 +407,11 @@ def random_date(start, end, rng):
     return start + DateOffset(days=rng.randint(0, (end - start).days))
 
 
+def str_to_pandas_date(date_string):
+    """Convert a string with the format YYYY-MM-DD to a pandas Timestamp (aka TLO Date) object."""
+    return pd.to_datetime(date_string, format="%Y-%m-%d")
+
+
 def hash_dataframe(dataframe: pd.DataFrame):
     def coerce_lists_to_tuples(df: pd.DataFrame) -> pd.DataFrame:
         """Coerce columns in a pd.DataFrame that are lists to tuples. This step is needed before hashing a pd.DataFrame

--- a/tests/resources/scenario.py
+++ b/tests/resources/scenario.py
@@ -1,0 +1,35 @@
+from tlo import Date, logging
+from tlo.scenario import BaseScenario
+
+
+class TestScenario(BaseScenario):
+    def __init__(self):
+        super().__init__()
+        self.seed = 655123742
+        self.start_date = Date(2010, 1, 1)
+        self.end_date = Date(2011, 1, 1)
+        self.pop_size = 2000
+        self.number_of_draws = 5
+        self.runs_per_draw = 1
+
+    def log_configuration(self):
+        return {
+            'directory': None,
+            'custom_levels': {
+                '*': logging.INFO,
+            }
+        }
+
+    def modules(self):
+        return []
+
+    def add_arguments(self, parser):
+        parser.add_argument('--pop-size', type=int)
+
+    def draw_parameters(self, draw_number, rng):
+        return {
+            'Lifestyle': {
+                'init_p_urban': rng.randint(10, 20) / 100.0,
+                'init_p_high_sugar': 0.52,
+            },
+        }

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -30,12 +30,13 @@ def loaded_scenario(scenario_path):
 
 @pytest.fixture
 def arguments(pop_size, suspend_date):
-    return ['--pop-size', str(pop_size), '--suspend-date', suspend_date.strftime('%Y-%m-%d')]
+    return ['--pop-size', str(pop_size)]
 
 
 @pytest.fixture
 def loaded_scenario_with_parsed_arguments(loaded_scenario, arguments):
     loaded_scenario.parse_arguments(arguments)
+    return loaded_scenario
 
 
 def test_load(loaded_scenario, scenario_path):
@@ -45,15 +46,14 @@ def test_load(loaded_scenario, scenario_path):
     assert hasattr(loaded_scenario, "pop_size")  # Default value set in initialiser
 
 
-def test_parse_arguments(loaded_scenario_with_parsed_arguments, pop_size, suspend_date):
+def test_parse_arguments(loaded_scenario_with_parsed_arguments, pop_size):
     """Check we can parse arguments related to the scenario. pop-size is used by our scenario,
     suspend-date is used in base class"""
     assert loaded_scenario_with_parsed_arguments.pop_size == pop_size
-    assert loaded_scenario_with_parsed_arguments.suspend_date == suspend_date
     assert not hasattr(loaded_scenario_with_parsed_arguments, 'resume_simulation')
 
 
-def test_config(tmp_path, loaded_scenario_with_parsed_arguments):
+def test_config(tmp_path, loaded_scenario_with_parsed_arguments, arguments):
     """Create the run configuration and check we've got the right values in there."""
     config = loaded_scenario_with_parsed_arguments.save_draws(return_config=True)
     assert config['scenario_seed'] == loaded_scenario_with_parsed_arguments.seed
@@ -72,5 +72,4 @@ def test_runner(tmp_path, loaded_scenario_with_parsed_arguments, pop_size, suspe
     assert isinstance(scenario, BaseScenario)
     assert scenario.__class__.__name__ == 'TestScenario'
     assert scenario.pop_size == pop_size
-    assert scenario.suspend_date == suspend_date
     assert runner.number_of_draws == loaded_scenario_with_parsed_arguments.number_of_draws

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 from tlo import Date
-from tlo.scenario import ScenarioLoader, BaseScenario, SampleRunner
+from tlo.scenario import BaseScenario, SampleRunner, ScenarioLoader
 
 
 class TestScenarioStore:

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -24,7 +24,7 @@ def loaded_scenario(scenario_path):
 
 
 @pytest.fixture
-def arguments(pop_size, suspend_date):
+def arguments(pop_size):
     return ['--pop-size', str(pop_size)]
 
 

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -14,11 +14,6 @@ def scenario_path():
 
 
 @pytest.fixture
-def suspend_date():
-    return Date(2012, 3, 4)
-
-
-@pytest.fixture
 def pop_size():
     return 100
 

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 
-from tlo import Date
 from tlo.scenario import BaseScenario, SampleRunner, ScenarioLoader
 
 

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -1,0 +1,56 @@
+import json
+import os
+from pathlib import Path
+
+from tlo import Date
+from tlo.scenario import ScenarioLoader, BaseScenario, SampleRunner
+
+
+class TestScenarioStore:
+    scenario = None
+    config_path = None
+
+
+def test_load():
+    """Check we can load the scenario class from a file"""
+    path = Path(f'{os.path.dirname(__file__)}/resources/scenario.py')
+    scenario = ScenarioLoader(path).get_scenario()
+    assert isinstance(scenario, BaseScenario)
+    assert scenario.scenario_path == path
+    TestScenarioStore.scenario = scenario
+
+
+def test_arguments():
+    """Check we can parse arguments related to the scenario. pop-size is used by our scenario,
+    suspend-date is used in base class"""
+    scenario = TestScenarioStore.scenario
+    assert scenario.pop_size == 2000  # this is the default pop size set in the scenario class
+    scenario.parse_arguments(['--pop-size', '100', '--suspend-date', '2012-03-04'])
+    assert scenario.pop_size == 100  # this is the value we passed in
+    assert scenario.suspend_date == Date(year=2012, month=3, day=4)
+    assert not hasattr(scenario, 'resume_simulation')
+
+
+def test_config(tmp_path):
+    """Create the run configuration and check we've got the right values in there."""
+    scenario = TestScenarioStore.scenario
+    config = scenario.save_draws(return_config=True)
+    assert config['scenario_seed'] == 655123742
+    assert config['arguments'] == ['--pop-size', '100', '--suspend-date', '2012-03-04']
+    assert len(config['draws']) == 5
+
+    config_path = tmp_path / 'scenario.json'
+    TestScenarioStore.config_path = config_path
+    with open(config_path, 'w') as f:
+        f.write(json.dumps(config, indent=2))
+
+
+def test_runner():
+    """Check we can load the scenario from the configuration file."""
+    runner = SampleRunner(TestScenarioStore.config_path)
+    scenario = runner.scenario
+    assert isinstance(scenario, BaseScenario)
+    assert scenario.__class__.__name__ == 'TestScenario'
+    assert scenario.pop_size == 100
+    assert scenario.suspend_date == Date(year=2012, month=3, day=4)
+    assert runner.number_of_draws == 5

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -55,7 +55,7 @@ def test_config(tmp_path, loaded_scenario_with_parsed_arguments, arguments):
     assert len(config['draws']) == loaded_scenario_with_parsed_arguments.number_of_draws
 
 
-def test_runner(tmp_path, loaded_scenario_with_parsed_arguments, pop_size, suspend_date):
+def test_runner(tmp_path, loaded_scenario_with_parsed_arguments, pop_size):
     """Check we can load the scenario from a configuration file."""
     config = loaded_scenario_with_parsed_arguments.save_draws(return_config=True)
     config_path = tmp_path / 'scenario.json'

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -45,7 +45,6 @@ def test_parse_arguments(loaded_scenario_with_parsed_arguments, pop_size):
     """Check we can parse arguments related to the scenario. pop-size is used by our scenario,
     suspend-date is used in base class"""
     assert loaded_scenario_with_parsed_arguments.pop_size == pop_size
-    assert not hasattr(loaded_scenario_with_parsed_arguments, 'resume_simulation')
 
 
 def test_config(tmp_path, loaded_scenario_with_parsed_arguments, arguments):


### PR DESCRIPTION
For #1363 and #1335


- allow users to add their own arguments to scenarios, which will override attributes in the subclass
- add `--resume-simulation` and `--suspend-date` arguments, in anticipation of suspend/resume functionality, which is handled by BaseScenario.

I could not figure out a nice way to use the [Click](https://click.palletsprojects.com/en/8.1.x/) argument handling for partial handling of arguments inside of subclasses, so have implemented using argparse. Click will pass on any unhandled arguments to the scenario for handling upstream.

*Example*

`tlo scenario-run --draw-only src/scripts/dev/scenarios/playing_22.py --pop-size 200`

Here, only `--draw-only` is known and handled by the click decorators in `cli.py`. `--pop-size` is passed to a new scenario `parse_arguments()` method. In order for it to work, the scenario writer should have added the following to their scenario class:

```
    def add_arguments(self, parser):
        parser.add_argument('--pop-size', type=int)
```

This allows the scenario to accept the `--pop-size` argument which, in turn, sets `self.pop_size` (overriding any existing value).
