### PR TITLE
Fix running_total_footprint in mode 2

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -2010,7 +2010,7 @@ class HealthSystem(Module):
                         original_call = footprints_of_all_individual_level_hsi_event[ev_num]
                         footprints_of_all_individual_level_hsi_event[ev_num] = updated_call
                         self.running_total_footprint -= original_call
-                        self.running_total_footprint.update(updated_call)
+                        self.running_total_footprint += updated_call
 
                         # Don't recompute for mode=0
                         if self.mode_appt_constraints != 0:

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -2010,7 +2010,7 @@ class HealthSystem(Module):
                         original_call = footprints_of_all_individual_level_hsi_event[ev_num]
                         footprints_of_all_individual_level_hsi_event[ev_num] = updated_call
                         self.running_total_footprint -= original_call
-                        self.running_total_footprint += updated_call
+                        self.running_total_footprint.update(updated_call)
 
                         # Don't recompute for mode=0
                         if self.mode_appt_constraints != 0:
@@ -2425,8 +2425,7 @@ class HealthSystemScheduler(RegularEvent, PopulationScopeEventMixin):
                                         )
 
                             # Update today's footprint based on actual call and squeeze factor
-                            self.module.running_total_footprint -= original_call
-                            self.module.running_total_footprint += updated_call
+                            self.module.running_total_footprint.update(updated_call)
 
                             # Write to the log
                             self.module.record_hsi_event(


### PR DESCRIPTION
The running_total_footprint is not properly updated in mode 2. This variable is not relevant for the functioning of this mode (it is used in mode 1 to compute the daily squeeze factor), so this wouldn't have created any problems in previous runs*. However, since it is still logged, this commit ensures that the value logged is meaningful even in mode 2. 

*Note: it is not a problem even in the rescaling of mode 2 to effective capabilities because the former is based on the running_total_footprint computed in mode 1, prior to switching to mode 2. 


