### PR TITLE
Allow for use_funded_or_actual_staffing to be changed mid-simulation

### DIFF
--- a/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
+++ b/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5df67165565fc88987f848e43363616e2ea4135de7c74d131e785ddc0178f123
-size 706
+oid sha256:f1cb38ba76c5673855e2e17e28ad1d36b5cec07d5d7872a7d6bc8aafde0f7009
+size 828

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -1347,6 +1347,7 @@ def test_HealthSystemChangeParameters(seed, tmpdir):
         'cons_availability': 'all',
         'beds_availability': 'default',
         'equip_availability': 'default',
+        'use_funded_or_actual_staffing': 'funded_plus',
     }
     new_parameters = {
         'mode_appt_constraints': 2,
@@ -1355,6 +1356,7 @@ def test_HealthSystemChangeParameters(seed, tmpdir):
         'cons_availability': 'none',
         'beds_availability': 'none',
         'equip_availability': 'all',
+        'use_funded_or_actual_staffing': 'actual',
     }
 
     class CheckHealthSystemParameters(RegularEvent, PopulationScopeEventMixin):
@@ -1371,6 +1373,7 @@ def test_HealthSystemChangeParameters(seed, tmpdir):
             _params['cons_availability'] = hs.consumables.availability
             _params['beds_availability'] = hs.bed_days.availability
             _params['equip_availability'] = hs.equipment.availability
+            _params['use_funded_or_actual_staffing'] = hs.use_funded_or_actual_staffing
 
             logger = logging.getLogger('tlo.methods.healthsystem')
             logger.info(key='CheckHealthSystemParameters', data=_params)


### PR DESCRIPTION
This PR allows to switch from one mode of use_funded_or_actual_staffing to another (use_funded_or_actual_staffing_postSwitch) on the first day of the year year_use_funded_or_actual_staffing_switch.

There however appears to be a problem with it being included in the test_HealthSystemChangeParameters, namely the test fails with the following error
<img width="1009" alt="Screenshot 2024-05-31 at 11 36 02" src="https://github.com/UCL/TLOmodel/assets/48129834/56dded8a-7fbf-4891-a0aa-ca03d088c205">

I'm really struggling to understand why, since it _is_ included in the health system. @tbhallett maybe you can spot it more easily.