### PR TITLE
Fixes for diarrhoea generic first appointment logic and updating of individual properties across modules

### DIFF
--- a/src/tlo/methods/diarrhoea.py
+++ b/src/tlo/methods/diarrhoea.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 import numpy as np
 import pandas as pd
@@ -944,13 +944,14 @@ class Diarrhoea(Module):
         self,
         patient_id: int,
         patient_details: PatientDetails,
+        symptoms: List[str],
         diagnosis_function: DiagnosisFunction,
         **kwargs,
     ) -> IndividualPropertyUpdates:
         # This routine is called when Diarrhoea is a symptom for a child
         # attending a Generic HSI Appointment. It checks for danger signs
         # and schedules HSI Events appropriately.
-        if patient_details.age_years > 5:
+        if patient_details.age_years > 5  or "diarrhoea" not in symptoms:
             return {}
 
         # 1) Assessment of danger signs

--- a/tests/test_diarrhoea.py
+++ b/tests/test_diarrhoea.py
@@ -404,6 +404,7 @@ def test_do_when_presentation_with_diarrhoea_severe_dehydration(seed):
         module=sim.modules["HealthSeekingBehaviour"], person_id=person_id
     )
     patient_details = sim.population.row_in_readonly_form(person_id)
+    symptoms = {"diarrhoea"}
 
     def diagnosis_fn(tests, use_dict: bool = False, report_tried: bool = False):
         return generic_hsi.healthcare_system.dx_manager.run_dx_test(
@@ -419,6 +420,7 @@ def test_do_when_presentation_with_diarrhoea_severe_dehydration(seed):
         patient_id=person_id,
         patient_details=patient_details,
         diagnosis_function=diagnosis_fn,
+        symptoms=symptoms,
     )
     evs = sim.modules['HealthSystem'].find_events_for_person(person_id)
 
@@ -432,6 +434,7 @@ def test_do_when_presentation_with_diarrhoea_severe_dehydration(seed):
         patient_id=person_id,
         patient_details=patient_details,
         diagnosis_function=diagnosis_fn,
+        symptoms=symptoms,
     )
     evs = sim.modules['HealthSystem'].find_events_for_person(person_id)
     assert 1 == len(evs)
@@ -493,6 +496,7 @@ def test_do_when_presentation_with_diarrhoea_severe_dehydration_dxtest_notfuncti
     generic_hsi = HSI_GenericNonEmergencyFirstAppt(
         module=sim.modules['HealthSeekingBehaviour'], person_id=person_id)
     patient_details = sim.population.row_in_readonly_form(person_id)
+    symptoms = {"diarrhoea"}
 
     def diagnosis_fn(tests, use_dict: bool = False, report_tried: bool = False):
         return generic_hsi.healthcare_system.dx_manager.run_dx_test(
@@ -509,6 +513,7 @@ def test_do_when_presentation_with_diarrhoea_severe_dehydration_dxtest_notfuncti
         patient_id=person_id,
         patient_details=patient_details,
         diagnosis_function=diagnosis_fn,
+        symptoms=symptoms,
     )
     evs = sim.modules['HealthSystem'].find_events_for_person(person_id)
     assert 1 == len(evs)
@@ -569,6 +574,7 @@ def test_do_when_presentation_with_diarrhoea_non_severe_dehydration(seed):
     generic_hsi = HSI_GenericNonEmergencyFirstAppt(
         module=sim.modules['HealthSeekingBehaviour'], person_id=person_id)
     patient_details = sim.population.row_in_readonly_form(person_id)
+    symptoms = {"diarrhoea"}
 
     def diagnosis_fn(tests, use_dict: bool = False, report_tried: bool = False):
         return generic_hsi.healthcare_system.dx_manager.run_dx_test(
@@ -580,7 +586,10 @@ def test_do_when_presentation_with_diarrhoea_non_severe_dehydration(seed):
     # 1) Outpatient HSI should be created
     sim.modules["HealthSystem"].reset_queue()
     sim.modules["Diarrhoea"].do_at_generic_first_appt(
-        patient_id=person_id, patient_details=patient_details, diagnosis_function=diagnosis_fn
+        patient_id=person_id,
+        patient_details=patient_details,
+        diagnosis_function=diagnosis_fn,
+        symptoms=symptoms,
     )
     evs = sim.modules["HealthSystem"].find_events_for_person(person_id)
 


### PR DESCRIPTION
Related to #1348  and #1366.

As discussed in software engineering meeting today, this PR addresses two known issues with current refactored generic first appointments logic:

1. A change in the conditions on which the diarrhoea module does or does not perform an action on a generic first appointment introduced accidentally by the refactoring in #1292 is fixed to return to the previous behaviour (not performing any further action if the individual is over the age of 5 _or_ does not have any diarrhoea symptoms).
2. The issue identified by @marghe-molaro in https://github.com/UCL/TLOmodel/issues/1348#issuecomment-2134959827, that is that in 
  https://github.com/UCL/TLOmodel/blob/df25c764e6d6fc99f224a65d18a030c67630c5a4/src/tlo/methods/hsi_generic_first_appts.py#L80-L103
  updates to an individual properties by previous modules in the loop are not reflected necessarily in the `patient_details` structure passed to the `do_at_generic_first_appt` method of the current module in the loop as the updates are only made to the dataframe after the loop has completed. Due the subsequent changes to the `PatientDetails` type made in #1315, this will actually only be an issue if an update is made to a property by a module that has previously been read (and cached) by that or another module and then a subsequent module reads the same property again (as it will get the initial cached value). I'm not sure there are cases where that chain actually happens currently given only very few modules actually output updates to the individual properties and they are for properties usually specific to the module, so this possibly explains why @willGraham01 was able to get consistent dataframe checksums when working on #1366 even without this fix.

The fix for (2) here uses the simple approach I mentioned in https://github.com/UCL/TLOmodel/issues/1348#issuecomment-2139374633 which will loose some of the performance benefits we currently have by doing updates to the dataframe whenever a module returns properties to update (rather than doing all updates at once). In the longer term #1387 should fix the same issue in a more performant manner.