### PR TITLE
Fix numpy array data type error on windows machine - Equipment class

### DIFF
--- a/src/tlo/methods/equipment.py
+++ b/src/tlo/methods/equipment.py
@@ -115,7 +115,7 @@ class Equipment:
         calculation if the equipment availability change event occurs during the simulation.
         """
         dat = self.data_availability.set_index(
-            [self.data_availability["Facility_ID"].astype(int), self.data_availability["Item_Code"].astype(int)]
+            [self.data_availability["Facility_ID"].astype(np.int64), self.data_availability["Item_Code"].astype(np.int64)]
         )["Pr_Available"]
 
         # Confirm that there is an estimate for every item_code at every facility_id


### PR DESCRIPTION
This PR aims at fixing the weird windows machines behavior(in equipment class)  of storing NumPy arrays in 32 bit format even on a 64 bit architecture. Successfully merging this PR will close issue #1390 