### PR TITLE
Enforce order in which modules are dealt with in _do_on_generic_first_appt

### DIFF
--- a/src/scripts/healthsystem/impact_of_module_order/scenario_impact_of_module_order.py
+++ b/src/scripts/healthsystem/impact_of_module_order/scenario_impact_of_module_order.py
@@ -1,0 +1,123 @@
+"""This Scenario file run the model under different assumptions for HR capabilities expansion in order to estimate the
+impact that is achieved under each.
+
+Run on the batch system using:
+```
+tlo batch-submit src/scripts/healthsystem/impact_of_policy/scenario_impact_of_module_order.py
+```
+
+or locally using:
+```
+tlo scenario-run src/scripts/healthsystem/impact_of_policy/scenario_impact_of_module_order.py
+```
+
+"""
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+
+from tlo import Date, logging
+from tlo.analysis.utils import get_parameters_for_status_quo, mix_scenarios
+from tlo.methods.fullmodel import fullmodel
+from tlo.methods.scenario_switcher import ImprovedHealthSystemAndCareSeekingScenarioSwitcher
+from tlo.scenario import BaseScenario
+
+
+class ImpactOfHealthSystemMode(BaseScenario):
+    def __init__(self):
+        super().__init__()
+        self.seed = 0
+        self.start_date = Date(2010, 1, 1)
+        self.end_date = self.start_date + pd.DateOffset(years=6)
+        self.pop_size = 100_000
+        self._scenarios = self._get_scenarios()
+        self.number_of_draws = len(self._scenarios)
+        self.runs_per_draw = 3
+
+    def log_configuration(self):
+        return {
+            'filename': 'effect_of_module_order',
+            'directory': Path('./outputs'),  # <- (specified only for local running)
+            'custom_levels': {
+                '*': logging.WARNING,
+                'tlo.methods.demography': logging.INFO,
+                'tlo.methods.demography.detail': logging.WARNING,
+                'tlo.methods.healthburden': logging.INFO,
+                'tlo.methods.healthsystem.summary': logging.INFO,
+            }
+        }
+
+    def modules(self):
+        return (
+            fullmodel(resourcefilepath=self.resources)
+            + [ImprovedHealthSystemAndCareSeekingScenarioSwitcher(resourcefilepath=self.resources)]
+        )
+
+    def draw_parameters(self, draw_number, rng):
+        if draw_number < self.number_of_draws:
+            return list(self._scenarios.values())[draw_number]
+        else:
+            return
+
+    def _get_scenarios(self) -> Dict[str, Dict]:
+        """Return the Dict with values for the parameters that are changed, keyed by a name for the scenario.
+        """
+        
+        self.YEAR_OF_CHANGE = 2011
+
+        return {
+   
+            "Original order":
+                mix_scenarios(
+                    self._baseline(),
+                ),
+                
+            #"Invert HIV and CMD":
+            #    mix_scenarios(
+            #        self._baseline(),
+            #    ),
+
+            #"RTI first and HTM last":
+            #    mix_scenarios(
+            #        self._baseline(),
+            #    ),
+                
+            #"Random shuffle 1":
+            #    mix_scenarios(
+            #        self._baseline(),
+            #    ),
+                
+            #"Random shuffle 2":
+            #    mix_scenarios(
+            #       self._baseline(),
+            #    ),
+
+            #"Random shuffle 3":
+            #    mix_scenarios(
+            #        self._baseline(),
+            #    ),
+        }
+        
+    def _baseline(self) -> Dict:
+        """Return the Dict with values for the parameter changes that define the baseline scenario. """
+        return mix_scenarios(
+            get_parameters_for_status_quo(),
+            {
+                "HealthSystem": {
+                    "mode_appt_constraints": 1,                 # <-- Mode 1 prior to change to preserve calibration
+                    "mode_appt_constraints_postSwitch": 2,      # <-- Mode 2 post-change to show effects of HRH
+                    "year_mode_switch": self.YEAR_OF_CHANGE,
+                    "policy_name": "Naive",
+                    "tclose_overwrite": 1,
+                    "tclose_days_offset_overwrite": 7,
+                    "use_funded_or_actual_staffing": "actual",
+                    "cons_availability": "default",
+                }
+            },
+        )
+
+if __name__ == '__main__':
+    from tlo.cli import scenario_run
+
+    scenario_run([__file__])

--- a/src/tlo/methods/hsi_generic_first_appts.py
+++ b/src/tlo/methods/hsi_generic_first_appts.py
@@ -68,6 +68,9 @@ class HSI_BaseGenericFirstAppt(HSI_Event, IndividualScopeEventMixin):
         """
         # Make top-level reads of information, to avoid repeat accesses.
         modules: OrderedDict[str, "Module"] = self.sim.modules
+        print(modules)
+        print(modules.values())
+        exit(-1)
         symptoms = modules["SymptomManager"].has_what(self.target)
 
         # Dynamically create immutable container with the target's details stored.

--- a/src/tlo/methods/hsi_generic_first_appts.py
+++ b/src/tlo/methods/hsi_generic_first_appts.py
@@ -21,42 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-fixed_modules_order = [
-    'ImprovedHealthSystemAndCareSeekingScenarioSwitcher',
-    'Demography',
-    'Lifestyle',
-    'HealthBurden',
-    'HealthSystem',
-    'SymptomManager',
-    'HealthSeekingBehaviour',
-    'Epi',
-    'Contraception',
-    'CardioMetabolicDisorders',
-    'Hiv',
-    'Malaria',
-    'PregnancySupervisor',
-    'CareOfWomenDuringPregnancy',
-    'NewbornOutcomes',
-    'Wasting',
-    'Diarrhoea',
-    'Stunting',
-    'Labour',
-    'PostnatalSupervisor',
-    'Alri',
-    'Measles',
-    'Schisto',
-    'Tb',
-    'BladderCancer',
-    'BreastCancer',
-    'OesophagealCancer',
-    'OtherAdultCancer',
-    'ProstateCancer',
-    'RTI',
-    'Copd',
-    'Depression',
-    'Epilepsy',
-    'SimplifiedBirths',
-    'Mockitis']
+fixed_modules_order = ['ImprovedHealthSystemAndCareSeekingScenarioSwitcher', 'Demography', 'Lifestyle', 'HealthBurden', 'HealthSystem', 'SymptomManager', 'HealthSeekingBehaviour', 'Epi', 'Contraception', 'CardioMetabolicDisorders', 'Hiv', 'Malaria', 'PregnancySupervisor', 'CareOfWomenDuringPregnancy', 'NewbornOutcomes', 'Wasting', 'Diarrhoea', 'Stunting', 'Labour', 'PostnatalSupervisor', 'Alri', 'Measles', 'Schisto', 'Tb', 'BladderCancer', 'BreastCancer', 'OesophagealCancer', 'OtherAdultCancer', 'ProstateCancer', 'RTI', 'Copd', 'Depression', 'Epilepsy', 'SimplifiedBirths', 'Mockitis']
 
 class HSI_BaseGenericFirstAppt(HSI_Event, IndividualScopeEventMixin):
     """
@@ -105,30 +70,31 @@ class HSI_BaseGenericFirstAppt(HSI_Event, IndividualScopeEventMixin):
         """
         # Make top-level reads of information, to avoid repeat accesses.
         modules: OrderedDict[str, "Module"] = fixed_modules_order #self.sim.modules
+        filtered_modules = [item for item in modules if item in self.sim.modules]
+
         symptoms = self.sim.modules["SymptomManager"].has_what(self.target)
 
         # Dynamically create immutable container with the target's details stored.
         # This will avoid repeat DataFrame reads when we call the module-level functions.
         patient_details = self.sim.population.row_in_readonly_form(self.target)
-        for name in modules:
-            if name in self.sim.modules.keys():
-                module = self.sim.modules[name]
-                module_patient_updates = getattr(module, self.MODULE_METHOD_ON_APPLY)(
-                    patient_id=self.target,
-                    patient_details=patient_details,
-                    symptoms=symptoms,
-                    diagnosis_function=self._diagnosis_function,
-                    consumables_checker=self.get_consumables,
-                    facility_level=self.ACCEPTED_FACILITY_LEVEL,
-                    treatment_id=self.TREATMENT_ID,
-                    random_state=self.module.rng,
-                )
-                # Record any requested DataFrame updates
-                if module_patient_updates:
-                    for key, value in module_patient_updates.items():
-                        self.sim.population.props.at[self.target, key] = value
-                    # Also need to recreate  patient_details to reflect updated properties
-                    patient_details = self.sim.population.row_in_readonly_form(self.target)
+        for name in filtered_modules:
+            module = self.sim.modules[name]
+            module_patient_updates = getattr(module, self.MODULE_METHOD_ON_APPLY)(
+                patient_id=self.target,
+                patient_details=patient_details,
+                symptoms=symptoms,
+                diagnosis_function=self._diagnosis_function,
+                consumables_checker=self.get_consumables,
+                facility_level=self.ACCEPTED_FACILITY_LEVEL,
+                treatment_id=self.TREATMENT_ID,
+                random_state=self.module.rng,
+            )
+            # Record any requested DataFrame updates
+            if module_patient_updates:
+                for key, value in module_patient_updates.items():
+                    self.sim.population.props.at[self.target, key] = value
+                # Also need to recreate  patient_details to reflect updated properties
+                patient_details = self.sim.population.row_in_readonly_form(self.target)
 
     def apply(self, person_id, squeeze_factor=0.) -> None:
         """


### PR DESCRIPTION
Quick PR to ensure we can specify in which order modules are dealt with in _do_on_generic_first_appt. This will have to be changed manually, and will only be used for testing (will not be merged in master).
@matt-graham could you just double check this looks all right to you? 

