### PR TITLE
Change logging level of message about footprint not being possible.

### DIFF
--- a/src/tlo/methods/hsi_event.py
+++ b/src/tlo/methods/hsi_event.py
@@ -358,7 +358,7 @@ class HSI_Event:
             ):
                 return True
             else:
-                logger.warning(
+                logger.debug(
                     key="message",
                     data=(
                         f"The expected footprint of {self.TREATMENT_ID} is not possible with the configuration of "


### PR DESCRIPTION
This should prevent this message being included in logs many, many times.