### PR TITLE
Use `IndividualDetails` context for `SymptomManager.has_what`

### DIFF
--- a/src/tlo/methods/alri.py
+++ b/src/tlo/methods/alri.py
@@ -1253,7 +1253,7 @@ class Alri(Module, GenericFirstAppointmentsMixin):
 
         # Gather underlying properties that will affect success of treatment
         SpO2_level = person.ri_SpO2_level
-        symptoms = self.sim.modules['SymptomManager'].has_what(person_id)
+        symptoms = self.sim.modules['SymptomManager'].has_what(person_id=person_id)
         imci_symptom_based_classification = self.get_imci_classification_based_on_symptoms(
             child_is_younger_than_2_months=person.age_exact_years < (2.0 / 12.0),
             symptoms=symptoms,
@@ -2726,7 +2726,7 @@ class HSI_Alri_Treatment(HSI_Event, IndividualScopeEventMixin):
                 return
 
             # Do nothing if the persons does not have indicating symptoms
-            symptoms = self.sim.modules['SymptomManager'].has_what(person_id)
+            symptoms = self.sim.modules['SymptomManager'].has_what(person_id=person_id)
             if not {'cough', 'difficult_breathing'}.intersection(symptoms):
                 return self.make_appt_footprint({})
 
@@ -3009,7 +3009,7 @@ class AlriIncidentCase_Lethal_DangerSigns_Pneumonia(AlriIncidentCase):
 
         assert 'danger_signs_pneumonia' == self.module.get_imci_classification_based_on_symptoms(
             child_is_younger_than_2_months=df.at[person_id, 'age_exact_years'] < (2.0 / 12.0),
-            symptoms=self.sim.modules['SymptomManager'].has_what(person_id)
+            symptoms=self.sim.modules['SymptomManager'].has_what(person_id=person_id)
         )
 
 
@@ -3040,7 +3040,7 @@ class AlriIncidentCase_NonLethal_Fast_Breathing_Pneumonia(AlriIncidentCase):
 
         assert 'fast_breathing_pneumonia' == \
                self.module.get_imci_classification_based_on_symptoms(
-                   child_is_younger_than_2_months=False, symptoms=self.sim.modules['SymptomManager'].has_what(person_id)
+                   child_is_younger_than_2_months=False, symptoms=self.sim.modules['SymptomManager'].has_what(person_id=person_id)
                )
 
 

--- a/src/tlo/methods/bladder_cancer.py
+++ b/src/tlo/methods/bladder_cancer.py
@@ -718,7 +718,7 @@ class HSI_BladderCancer_Investigation_Following_Blood_Urine(HSI_Event, Individua
             return hs.get_blank_appt_footprint()
 
         # Check that this event has been called for someone with the symptom blood_urine
-        assert 'blood_urine' in self.sim.modules['SymptomManager'].has_what(person_id)
+        assert 'blood_urine' in self.sim.modules['SymptomManager'].has_what(person_id=person_id)
 
         # If the person is already diagnosed, then take no action:
         if not pd.isnull(df.at[person_id, "bc_date_diagnosis"]):
@@ -791,7 +791,7 @@ class HSI_BladderCancer_Investigation_Following_pelvic_pain(HSI_Event, Individua
             return hs.get_blank_appt_footprint()
 
         # Check that this event has been called for someone with the symptom pelvic_pain
-        assert 'pelvic_pain' in self.sim.modules['SymptomManager'].has_what(person_id)
+        assert 'pelvic_pain' in self.sim.modules['SymptomManager'].has_what(person_id=person_id)
 
         # If the person is already diagnosed, then take no action:
         if not pd.isnull(df.at[person_id, "bc_date_diagnosis"]):

--- a/src/tlo/methods/breast_cancer.py
+++ b/src/tlo/methods/breast_cancer.py
@@ -685,7 +685,7 @@ class HSI_BreastCancer_Investigation_Following_breast_lump_discernible(HSI_Event
             return hs.get_blank_appt_footprint()
 
         # Check that this event has been called for someone with the symptom breast_lump_discernible
-        assert 'breast_lump_discernible' in self.sim.modules['SymptomManager'].has_what(person_id)
+        assert 'breast_lump_discernible' in self.sim.modules['SymptomManager'].has_what(person_id=person_id)
 
         # If the person is already diagnosed, then take no action:
         if not pd.isnull(df.at[person_id, "brc_date_diagnosis"]):

--- a/src/tlo/methods/depression.py
+++ b/src/tlo/methods/depression.py
@@ -593,7 +593,7 @@ class Depression(Module, GenericFirstAppointmentsMixin):
         and there may need to be screening for depression.
         """
         if self._check_for_suspected_depression(
-            self.sim.modules["SymptomManager"].has_what(person_id),
+            self.sim.modules["SymptomManager"].has_what(person_id=person_id),
             hsi_event.TREATMENT_ID,
             self.sim.population.props.at[person_id, "de_ever_diagnosed_depression"],
         ):

--- a/src/tlo/methods/hsi_generic_first_appts.py
+++ b/src/tlo/methods/hsi_generic_first_appts.py
@@ -184,8 +184,10 @@ class _BaseHSIGenericFirstAppt(HSI_Event, IndividualScopeEventMixin):
             if not individual_properties["is_alive"]:
                 return
             # Pre-evaluate symptoms for individual to avoid repeat accesses
-            # TODO: Use individual_properties to populate symptoms
-            symptoms = self.sim.modules["SymptomManager"].has_what(self.target)
+            # Use the individual_properties context here to save independent DF lookups
+            symptoms = self.sim.modules["SymptomManager"].has_what(
+                person_id=person_id, individual_details=individual_properties
+            )
             schedule_hsi_event = self.sim.modules["HealthSystem"].schedule_hsi_event
             for module in self.sim.modules.values():
                 if isinstance(module, GenericFirstAppointmentsMixin):

--- a/src/tlo/methods/malaria.py
+++ b/src/tlo/methods/malaria.py
@@ -1060,7 +1060,7 @@ class HSI_Malaria_rdt(HSI_Event, IndividualScopeEventMixin):
         )
 
         # Log the test: line-list of summary information about each test
-        fever_present = 'fever' in self.sim.modules["SymptomManager"].has_what(person_id)
+        fever_present = 'fever' in self.sim.modules["SymptomManager"].has_what(person_id=person_id)
         person_details_for_test = {
             'person_id': person_id,
             'age': df.at[person_id, 'age_years'],
@@ -1152,7 +1152,7 @@ class HSI_Malaria_rdt_community(HSI_Event, IndividualScopeEventMixin):
         )
 
         # Log the test: line-list of summary information about each test
-        fever_present = 'fever' in self.sim.modules["SymptomManager"].has_what(person_id)
+        fever_present = 'fever' in self.sim.modules["SymptomManager"].has_what(person_id=person_id)
         person_details_for_test = {
             'person_id': person_id,
             'age': df.at[person_id, 'age_years'],
@@ -1214,7 +1214,7 @@ class HSI_Malaria_Treatment(HSI_Event, IndividualScopeEventMixin):
 
                 # rdt is offered as part of the treatment package
                 # Log the test: line-list of summary information about each test
-                fever_present = 'fever' in self.sim.modules["SymptomManager"].has_what(person_id)
+                fever_present = 'fever' in self.sim.modules["SymptomManager"].has_what(person_id=person_id)
                 person_details_for_test = {
                     'person_id': person_id,
                     'age': df.at[person_id, 'age_years'],
@@ -1311,7 +1311,7 @@ class HSI_Malaria_Treatment_Complicated(HSI_Event, IndividualScopeEventMixin):
 
                 # rdt is offered as part of the treatment package
                 # Log the test: line-list of summary information about each test
-                fever_present = 'fever' in self.sim.modules["SymptomManager"].has_what(person_id)
+                fever_present = 'fever' in self.sim.modules["SymptomManager"].has_what(person_id=person_id)
                 person_details_for_test = {
                     'person_id': person_id,
                     'age': df.at[person_id, 'age_years'],

--- a/src/tlo/methods/measles.py
+++ b/src/tlo/methods/measles.py
@@ -442,7 +442,7 @@ class HSI_Measles_Treatment(HSI_Event, IndividualScopeEventMixin):
                      data=f"HSI_Measles_Treatment: treat person {person_id} for measles")
 
         df = self.sim.population.props
-        symptoms = self.sim.modules["SymptomManager"].has_what(person_id)
+        symptoms = self.sim.modules["SymptomManager"].has_what(person_id=person_id)
 
         # for non-complicated measles
         item_codes = [self.module.consumables['vit_A']]

--- a/src/tlo/methods/oesophagealcancer.py
+++ b/src/tlo/methods/oesophagealcancer.py
@@ -681,7 +681,7 @@ class HSI_OesophagealCancer_Investigation_Following_Dysphagia(HSI_Event, Individ
             return hs.get_blank_appt_footprint()
 
         # Check that this event has been called for someone with the symptom dysphagia
-        assert 'dysphagia' in self.sim.modules['SymptomManager'].has_what(person_id)
+        assert 'dysphagia' in self.sim.modules['SymptomManager'].has_what(person_id=person_id)
 
         # If the person is already diagnosed, then take no action:
         if not pd.isnull(df.at[person_id, "oc_date_diagnosis"]):

--- a/src/tlo/methods/other_adult_cancers.py
+++ b/src/tlo/methods/other_adult_cancers.py
@@ -685,7 +685,7 @@ class HSI_OtherAdultCancer_Investigation_Following_early_other_adult_ca_symptom(
             return hs.get_blank_appt_footprint()
 
         # Check that this event has been called for someone with the symptom other_adult_ca_symptom
-        assert 'early_other_adult_ca_symptom' in self.sim.modules['SymptomManager'].has_what(person_id)
+        assert 'early_other_adult_ca_symptom' in self.sim.modules['SymptomManager'].has_what(person_id=person_id)
 
         # If the person is already diagnosed, then take no action:
         if not pd.isnull(df.at[person_id, "oac_date_diagnosis"]):

--- a/src/tlo/methods/prostate_cancer.py
+++ b/src/tlo/methods/prostate_cancer.py
@@ -719,7 +719,7 @@ class HSI_ProstateCancer_Investigation_Following_Urinary_Symptoms(HSI_Event, Ind
             return hs.get_blank_appt_footprint()
 
         # Check that this event has been called for someone with the urinary symptoms
-        assert 'urinary' in self.sim.modules['SymptomManager'].has_what(person_id)
+        assert 'urinary' in self.sim.modules['SymptomManager'].has_what(person_id=person_id)
 
         # If the person is already diagnosed, then take no action:
         if not pd.isnull(df.at[person_id, "pc_date_diagnosis"]):
@@ -767,7 +767,7 @@ class HSI_ProstateCancer_Investigation_Following_Pelvic_Pain(HSI_Event, Individu
             return hs.get_blank_appt_footprint()
 
         # Check that this event has been called for someone with the pelvic pain
-        assert 'pelvic_pain' in self.sim.modules['SymptomManager'].has_what(person_id)
+        assert 'pelvic_pain' in self.sim.modules['SymptomManager'].has_what(person_id=person_id)
 
         # If the person is already diagnosed, then take no action:
         if not pd.isnull(df.at[person_id, "pc_date_diagnosis"]):

--- a/src/tlo/methods/tb.py
+++ b/src/tlo/methods/tb.py
@@ -1698,7 +1698,7 @@ class HSI_Tb_ScreeningAndRefer(HSI_Event, IndividualScopeEventMixin):
 
         # check if patient has: cough, fever, night sweat, weight loss
         # if none of the above conditions are present, no further action
-        persons_symptoms = self.sim.modules["SymptomManager"].has_what(person_id)
+        persons_symptoms = self.sim.modules["SymptomManager"].has_what(person_id=person_id)
         if not any(x in self.module.symptom_list for x in persons_symptoms):
             return self.make_appt_footprint({})
 
@@ -1961,7 +1961,7 @@ class HSI_Tb_ClinicalDiagnosis(HSI_Event, IndividualScopeEventMixin):
 
         # check if patient has: cough, fever, night sweat, weight loss
         set_of_symptoms_that_indicate_tb = set(self.module.symptom_list)
-        persons_symptoms = self.sim.modules["SymptomManager"].has_what(person_id)
+        persons_symptoms = self.sim.modules["SymptomManager"].has_what(person_id=person_id)
 
         if not set_of_symptoms_that_indicate_tb.intersection(persons_symptoms):
             # if none of the above conditions are present, no further action
@@ -2465,7 +2465,7 @@ class HSI_Tb_Start_or_Continue_Ipt(HSI_Event, IndividualScopeEventMixin):
             return
 
         # if currently have symptoms of TB, refer for screening/testing
-        persons_symptoms = self.sim.modules["SymptomManager"].has_what(person_id)
+        persons_symptoms = self.sim.modules["SymptomManager"].has_what(person_id=person_id)
         if any(x in self.module.symptom_list for x in persons_symptoms):
 
             self.sim.modules["HealthSystem"].schedule_hsi_event(

--- a/tests/test_cardiometabolicdisorders.py
+++ b/tests/test_cardiometabolicdisorders.py
@@ -770,7 +770,7 @@ def test_hsi_emergency_events(seed):
         assert pd.isnull(df.at[person_id, f'nc_{event}_scheduled_date_death'])
         assert isinstance(sim.modules['HealthSystem'].HSI_EVENT_QUEUE[0].hsi_event,
                           HSI_CardioMetabolicDisorders_StartWeightLossAndMedication)
-        assert f"{event}_damage" not in sim.modules['SymptomManager'].has_what(person_id)
+        assert f"{event}_damage" not in sim.modules['SymptomManager'].has_what(person_id=person_id)
 
 
 def test_no_availability_of_consumables_for_conditions(seed):

--- a/tests/test_copd.py
+++ b/tests/test_copd.py
@@ -211,12 +211,12 @@ def test_moderate_exacerbation():
     df.at[person_id, 'ch_has_inhaler'] = False
 
     # check individuals do not have symptoms before an event is run
-    assert 'breathless_moderate' not in sim.modules['SymptomManager'].has_what(person_id)
+    assert 'breathless_moderate' not in sim.modules['SymptomManager'].has_what(person_id=person_id)
 
     # run Copd Exacerbation event on an individual and confirm they now have a
     # non-emergency symptom(breathless moderate)
     copd.CopdExacerbationEvent(copd_module, person_id, severe=False).run()
-    assert 'breathless_moderate' in sim.modules['SymptomManager'].has_what(person_id)
+    assert 'breathless_moderate' in sim.modules['SymptomManager'].has_what(person_id=person_id)
 
     # Run health seeking behavior event and check non-emergency care is sought
     hsp = HealthSeekingBehaviourPoll(sim.modules['HealthSeekingBehaviour'])
@@ -259,7 +259,7 @@ def test_severe_exacerbation():
     df.at[person_id, 'ch_has_inhaler'] = False
 
     # check an individual do not have emergency symptoms before an event is run
-    assert 'breathless_severe' not in sim.modules['SymptomManager'].has_what(person_id)
+    assert 'breathless_severe' not in sim.modules['SymptomManager'].has_what(person_id=person_id)
 
     # schedule exacerbations event setting severe to True. This will ensure the individual has severe exacerbation
     copd.CopdExacerbationEvent(copd_module, person_id, severe=True).run()
@@ -420,7 +420,7 @@ def test_referral_logic():
     df.at[person_id, 'ch_has_inhaler'] = False
 
     # check an individual do not have emergency symptoms before an event is run
-    assert 'breathless_severe' not in sim.modules['SymptomManager'].has_what(person_id)
+    assert 'breathless_severe' not in sim.modules['SymptomManager'].has_what(person_id=person_id)
 
     # schedule exacerbations event setting severe to True. This will ensure the individual has severe exacerbation
     copd.CopdExacerbationEvent(copd_module, person_id, severe=True).run()

--- a/tests/test_hiv.py
+++ b/tests/test_hiv.py
@@ -224,7 +224,7 @@ def test_generation_of_natural_history_process_no_art(seed):
 
     # run the AIDS onset event for this person:
     aids_event.apply(person_id)
-    assert "aids_symptoms" in sim.modules['SymptomManager'].has_what(person_id)
+    assert "aids_symptoms" in sim.modules['SymptomManager'].has_what(person_id=person_id)
 
     # find the AIDS death event for this person
     date_aids_death_event, aids_death_event = \
@@ -274,7 +274,7 @@ def test_generation_of_natural_history_process_with_art_before_aids(seed):
     assert [] == [ev for ev in sim.find_events_for_person(person_id) if isinstance(ev[1], hiv.HivAidsDeathEvent)]
 
     # check no AIDS symptoms for this person
-    assert "aids_symptoms" not in sim.modules['SymptomManager'].has_what(person_id)
+    assert "aids_symptoms" not in sim.modules['SymptomManager'].has_what(person_id=person_id)
 
 
 def test_generation_of_natural_history_process_with_art_after_aids(seed):
@@ -312,7 +312,7 @@ def test_generation_of_natural_history_process_with_art_after_aids(seed):
     date_aids_death_event, aids_death_event = \
         [ev for ev in sim.find_events_for_person(person_id) if isinstance(ev[1], hiv.HivAidsDeathEvent)][0]
     assert date_aids_death_event > sim.date
-    assert "aids_symptoms" in sim.modules['SymptomManager'].has_what(person_id)
+    assert "aids_symptoms" in sim.modules['SymptomManager'].has_what(person_id=person_id)
 
     # Put the person on ART with VL suppression prior to the AIDS death (but following AIDS onset)
     df.at[person_id, 'hv_art'] = "on_VL_suppressed"
@@ -516,7 +516,7 @@ def test_aids_symptoms_lead_to_treatment_being_initiated(seed):
     aids_event.apply(person_id)
 
     # Confirm that they have aids symptoms and an AIDS death schedule
-    assert 'aids_symptoms' in sim.modules['SymptomManager'].has_what(person_id)
+    assert 'aids_symptoms' in sim.modules['SymptomManager'].has_what(person_id=person_id)
     assert 1 == len(
         [ev[0] for ev in sim.find_events_for_person(person_id) if isinstance(ev[1], hiv.HivAidsTbDeathEvent)])
 

--- a/tests/test_malaria.py
+++ b/tests/test_malaria.py
@@ -268,7 +268,7 @@ def test_dx_algorithm_for_malaria_outcomes_clinical(
             add_or_remove='+'
         )
 
-    assert "fever" in sim.modules["SymptomManager"].has_what(person_id)
+    assert "fever" in sim.modules["SymptomManager"].has_what(person_id=person_id)
 
     def diagnosis_function(tests, use_dict: bool = False, report_tried: bool = False):
         return hsi_event.healthcare_system.dx_manager.run_dx_test(
@@ -346,7 +346,7 @@ def test_dx_algorithm_for_non_malaria_outcomes(seed):
         add_or_remove='+'
     )
 
-    assert "fever" in sim.modules["SymptomManager"].has_what(person_id)
+    assert "fever" in sim.modules["SymptomManager"].has_what(person_id=person_id)
 
     def diagnosis_function(tests, use_dict: bool = False, report_tried: bool = False):
         return hsi_event.healthcare_system.dx_manager.run_dx_test(
@@ -517,7 +517,7 @@ def test_individual_testing_and_treatment(sim):
     pollevent.run()
 
     assert not pd.isnull(df.at[person_id, "ma_date_symptoms"])
-    assert set(sim.modules['SymptomManager'].has_what(person_id)) == {"fever", "headache", "vomiting", "stomachache"}
+    assert set(sim.modules['SymptomManager'].has_what(person_id=person_id)) == {"fever", "headache", "vomiting", "stomachache"}
 
     # check rdt is scheduled
     date_event, event = [
@@ -560,7 +560,7 @@ def test_individual_testing_and_treatment(sim):
     pollevent = malaria.MalariaUpdateEvent(module=sim.modules['Malaria'])
     pollevent.apply(sim.population)
 
-    assert sim.modules['SymptomManager'].has_what(person_id) == []
+    assert sim.modules['SymptomManager'].has_what(person_id=person_id) == []
 
     # check no rdt is scheduled
     assert "malaria.HSI_Malaria_rdt" not in sim.modules['HealthSystem'].find_events_for_person(person_id)

--- a/tests/test_symptommanager.py
+++ b/tests/test_symptommanager.py
@@ -227,7 +227,7 @@ def test_baby_born_has_no_symptoms(seed):
     person_id = sim.do_birth(mother_id)
 
     # check that the new person does not have symptoms:
-    assert [] == sim.modules['SymptomManager'].has_what(person_id)
+    assert [] == sim.modules['SymptomManager'].has_what(person_id=person_id)
 
 
 def test_auto_onset_symptom(seed):
@@ -250,7 +250,7 @@ def test_auto_onset_symptom(seed):
     sim.population.props.loc[person_id, 'is_alive'] = True
     for symptom in sm.symptom_names:
         sim.population.props.loc[person_id, sm.get_column_name_for_symptom(symptom)] = 0
-    assert 0 == len(sm.has_what(person_id))
+    assert 0 == len(sm.has_what(person_id=person_id))
 
     def get_events_in_sim():
         return [ev for ev in sim.event_queue.queue if (person_id in ev[3].person_id)]
@@ -273,7 +273,7 @@ def test_auto_onset_symptom(seed):
     )
 
     # check that the symptom is not imposed
-    assert 0 == len(sm.has_what(person_id))
+    assert 0 == len(sm.has_what(person_id=person_id))
 
     # get the future events for this person (should be just the auto-onset event)
     assert 1 == len(get_events_in_sim())
@@ -285,7 +285,7 @@ def test_auto_onset_symptom(seed):
     # run the events and check for the changing of symptoms
     sim.date = date_of_onset
     onset[3].apply(sim.population)
-    assert symptom_string in sm.has_what(person_id)
+    assert symptom_string in sm.has_what(person_id=person_id)
 
     # get the future events for this person (should now include the auto-resolve event)
     assert 2 == len(get_events_in_sim())
@@ -295,7 +295,7 @@ def test_auto_onset_symptom(seed):
     assert isinstance(resolve[3], SymptomManager_AutoResolveEvent)
 
     resolve[3].apply(sim.population)
-    assert 0 == len(sm.has_what(person_id))
+    assert 0 == len(sm.has_what(person_id=person_id))
 
 
 def test_nonemergency_spurious_symptoms_during_simulation(seed):

--- a/tests/test_symptommanager.py
+++ b/tests/test_symptommanager.py
@@ -511,6 +511,19 @@ def test_has_what(
         ][0]
         assert symptom not in symptom_manager.has_what(person_without_symptom)
 
+        # Do the same checks but using an IndividualDetails context
+        with simulation.population.individual_properties(
+            person_with_symptom, read_only=True
+        ) as with_symptom_properties:
+            assert symptom in symptom_manager.has_what(
+                individual_details=with_symptom_properties
+            )
+        with simulation.population.individual_properties(
+            person_without_symptom, read_only=True
+        ) as without_symptom_properties:
+            assert symptom not in symptom_manager.has_what(
+                individual_details=without_symptom_properties
+            )
 
 def test_has_what_disease_module(
     symptom_manager, disease_module, disease_module_symptoms, simulation

--- a/tests/test_tb.py
+++ b/tests/test_tb.py
@@ -576,7 +576,7 @@ def test_children_referrals(seed):
         duration_in_days=None,
     )
 
-    assert set(sim.modules['SymptomManager'].has_what(person_id)) == symptom_list
+    assert set(sim.modules['SymptomManager'].has_what(person_id=person_id)) == symptom_list
 
     # run HSI_Tb_ScreeningAndRefer and check outcomes
     sim.modules['HealthSystem'].schedule_hsi_event(
@@ -1036,7 +1036,7 @@ def test_hsi_scheduling(seed):
         duration_in_days=None,
     )
 
-    assert set(sim.modules['SymptomManager'].has_what(person_id)) == symptom_list
+    assert set(sim.modules['SymptomManager'].has_what(person_id=person_id)) == symptom_list
 
     hsi_event = tb.HSI_Tb_ScreeningAndRefer(person_id=person_id, module=sim.modules['Tb'])
     hsi_event.run(squeeze_factor=0)
@@ -1080,7 +1080,7 @@ def test_hsi_scheduling(seed):
         duration_in_days=None,
     )
 
-    assert set(sim.modules['SymptomManager'].has_what(person_id)) == symptom_list
+    assert set(sim.modules['SymptomManager'].has_what(person_id=person_id)) == symptom_list
 
     hsi_event = tb.HSI_Tb_ScreeningAndRefer(person_id=person_id, module=sim.modules['Tb'])
     hsi_event.run(squeeze_factor=0)
@@ -1125,7 +1125,7 @@ def test_hsi_scheduling(seed):
         duration_in_days=None,
     )
 
-    assert set(sim.modules['SymptomManager'].has_what(person_id)) == symptom_list
+    assert set(sim.modules['SymptomManager'].has_what(person_id=person_id)) == symptom_list
 
     hsi_event = tb.HSI_Tb_ScreeningAndRefer(person_id=person_id, module=sim.modules['Tb'])
     hsi_event.run(squeeze_factor=0)


### PR DESCRIPTION
We are currently spending a lot of time within the `SymptomManager.has_what` method (called inside the `do_at_generic_first_appt` methods) - approx 8% of simulation time according to the [most recent profiling](http://github-pages.ucl.ac.uk/TLOmodel-profiling/_static/profiling_html/schedule_1009_a83f624e56817fe0c37d7b0e1db55cf593ccb63e.html) result.

SnakeViz places the blame for this on calls to pandas methods within `SymptomManager`, because it does not make use of the `IndividualDetails` context that is setup during the `generic_first_appt` method.

![master_snakeviz](https://github.com/user-attachments/assets/c46a6711-6586-4e73-9795-3994457a6b5a)

This PR introduces the following changes:

- `SymptomManager.has_what` can now be passed an `IndividualProperties` instance, which it will use instead of looking up values directly from the population DataFrame.
- This same method now only takes keyword arguments, and must be supplied either the `person_id` or `individual_details` inputs. The `individual_details` argument takes priority over the `person_id` method if both are supplied (since it is at worst the same speed as looking up from the DF each time).
- All calls to `SymptomManager.has_what` in the codebase now respect the keyword arguments the function takes.
- `test_has_what` has been updated to check that the new method of retrieving symptoms via the `individual_details` keyword performs as expected.

With these changes, the time spent within `has_what` has almost halved:

![exp_snakeviz](https://github.com/user-attachments/assets/d15255cf-89a1-4d18-b17b-cee531675b05)

with us now spending 174s inside `has_what` and all subfunctions, rather than `331s` that we were spending before. Experiments were run using the `scale_run` simulation over 2 years and using a relatively small initial population of 10,000, so have triggered a profiling run here to get some more accurate figures.