### PR TITLE
Fix logging of unrecognised consumables item codes

### DIFF
--- a/src/tlo/methods/consumables.py
+++ b/src/tlo/methods/consumables.py
@@ -54,7 +54,7 @@ class Consumables:
         self._prob_item_codes_available = None  # Data on the probability of each item_code being available
         self._is_available = None  # Dict of sets giving the set of item_codes available, by facility_id
         self._is_unknown_item_available = None  # Whether an unknown item is available, by facility_id
-        self._not_recognised_item_codes = set()  # The item codes requested but which are not recognised.
+        self._not_recognised_item_codes = defaultdict(set)  # The item codes requested but which are not recognised.
 
         # Save designations
         self._item_code_designations = item_code_designations
@@ -214,8 +214,9 @@ class Consumables:
         """
 
         # Issue warning if any item_code is not recognised.
-        if not self.item_codes.issuperset(item_codes.keys()):
-            self._not_recognised_item_codes.add((treatment_id, tuple(set(item_codes.keys()) - self.item_codes)))
+        not_recognised_item_codes = item_codes.keys() - self.item_codes
+        if len(not_recognised_item_codes) > 0:
+            self._not_recognised_item_codes[treatment_id] |= not_recognised_item_codes
 
         # Look-up whether each of these items is available in this facility currently:
         available = self._lookup_availability_of_consumables(item_codes=item_codes, facility_info=facility_info)
@@ -269,21 +270,19 @@ class Consumables:
          
         Raise warnings and enter to log about item_codes not recognised.
         """
-        if self._not_recognised_item_codes:
+        if len(self._not_recognised_item_codes) > 0:
+            not_recognised_item_codes = {
+                treatment_id if treatment_id is not None else "": sorted(codes) 
+                for treatment_id, codes in self._not_recognised_item_codes.items()
+            }
             warnings.warn(
                 UserWarning(
-                    f"Item_Codes were not recognised./n"
-                    f"{self._not_recognised_item_codes}"
+                    f"Item_Codes were not recognised.\n{not_recognised_item_codes}"
                 )
             )
             logger.info(
                 key="item_codes_not_recognised",
-                data={
-                    _treatment_id if _treatment_id is not None else "": list(
-                        _item_codes
-                    )
-                    for _treatment_id, _item_codes in self._not_recognised_item_codes
-                },
+                data=not_recognised_item_codes,
             )
 
     def on_end_of_year(self):

--- a/tests/test_consumables.py
+++ b/tests/test_consumables.py
@@ -66,7 +66,7 @@ def test_using_recognised_item_codes(seed):
     )
 
     assert {0: False, 1: True} == rtn
-    assert not cons._not_recognised_item_codes  # No item_codes recorded as not recognised.
+    assert len(cons._not_recognised_item_codes) == 0  # No item_codes recorded as not recognised.
 
 
 def test_unrecognised_item_code_is_recorded(seed):
@@ -93,7 +93,7 @@ def test_unrecognised_item_code_is_recorded(seed):
     )
 
     assert isinstance(rtn[99], bool)
-    assert cons._not_recognised_item_codes  # Some item_codes recorded as not recognised.
+    assert len(cons._not_recognised_item_codes) > 0  # Some item_codes recorded as not recognised.
 
     # Check warning is issued at end of simulation
     with pytest.warns(UserWarning) as recorded_warnings:
@@ -321,7 +321,7 @@ def get_sim_with_dummy_module_registered(tmpdir=None, run=True, data=None):
     return sim
 
 
-def get_dummy_hsi_event_instance(module, facility_id=None):
+def get_dummy_hsi_event_instance(module, facility_id=None, to_log=False):
     """Make an HSI Event that runs for person_id=0 in a particular facility_id and requests consumables,
     and for which its parent is the identified module."""
 
@@ -340,7 +340,7 @@ def get_dummy_hsi_event_instance(module, facility_id=None):
             """Requests all recognised consumables."""
             self.get_consumables(
                 item_codes=list(self.sim.modules['HealthSystem'].consumables.item_codes),
-                to_log=True,
+                to_log=to_log,
                 return_individual_results=False
             )
 
@@ -446,7 +446,7 @@ def test_outputs_to_log(tmpdir):
 
         # Schedule the HSI event for person_id=0
         sim.modules['HealthSystem'].schedule_hsi_event(
-            hsi_event=get_dummy_hsi_event_instance(module=sim.modules['DummyModule'], facility_id=0),
+            hsi_event=get_dummy_hsi_event_instance(module=sim.modules['DummyModule'], facility_id=0, to_log=True),
             topen=sim.start_date,
             tclose=None,
             priority=0
@@ -500,12 +500,12 @@ def test_every_declared_consumable_for_every_possible_hsi_using_actual_data(recw
                     facility_id=_facility_id
                 )
                 for _item_code in item_codes:
-                    hsi_event.get_consumables(item_codes=_item_code)
+                    hsi_event.get_consumables(item_codes=_item_code, to_log=False)
 
     sim.modules['HealthSystem'].on_simulation_end()
 
-    # Check that no warnings raised or item_codes recorded as being not recogised.
-    assert not sim.modules['HealthSystem'].consumables._not_recognised_item_codes
+    # Check that no warnings raised or item_codes recorded as being not recognised.
+    assert len(sim.modules['HealthSystem'].consumables._not_recognised_item_codes) == 0
     assert not any_warnings_about_item_code(recwarn)
 
 


### PR DESCRIPTION
Resolves #1434 

Follows suggestion in #1434 of refactoring `self._not_recognised_item_codes` attribute which was previously a set of tuples of treatment IDs and tuples of item codes, to a `defaultdict` with set values, with keys corresponding to treatment IDs and values sets of item codes. The log entry is now directly constructed from this dictionary with some processing of the keys to convert from `None` treatment ID to empty string (as done previously) and converting the sets of item codes to sorted lists to ensure reproducibility over multiple runs.

I've also done some minor updates to tests to disable logging in `HSI_Event.get_consumables` calls when not needed for the checks performed by the tests as I noticed when running the tests the `test_every_declared_consumable_for_every_possible_hsi_using_actual_data` in particular was generating an enormous amount of log output (four levels of nested loop with a total of 9833472 iterations!) which was slowing down the test considerably. Disabling log output seems to have increased speed of test by about a factor of 10.