### PR TITLE
Fix non-determinism in equipment ever used log entry

### DIFF
--- a/src/tlo/methods/equipment.py
+++ b/src/tlo/methods/equipment.py
@@ -221,16 +221,16 @@ class Equipment:
 
         mfl = self.master_facilities_list
 
-        def set_of_keys_or_empty_set(x: Union[set, dict]):
-            if isinstance(x, set):
-                return x
-            elif isinstance(x, dict):
-                return set(x.keys())
+        def sorted_keys_or_empty_list(x: Union[dict, None]) -> list:
+            if isinstance(x, dict):
+                return sorted(x.keys())
             else:
-                return set()
+                return []
 
         set_of_equipment_ever_used_at_each_facility_id = pd.Series({
-            fac_id: set_of_keys_or_empty_set(self._record_of_equipment_used_by_facility_id.get(fac_id, set()))
+            fac_id: sorted_keys_or_empty_list(
+                self._record_of_equipment_used_by_facility_id.get(fac_id)
+            )
             for fac_id in mfl['Facility_ID']
         }, name='EquipmentEverUsed').astype(str)
 

--- a/tests/test_equipment.py
+++ b/tests/test_equipment.py
@@ -1,5 +1,6 @@
 """This file contains all the tests to do with Equipment."""
 import os
+from ast import literal_eval
 from pathlib import Path
 from typing import Dict
 
@@ -259,7 +260,7 @@ def test_equipment_use_is_logged(seed, tmpdir):
         (at any facility)."""
         s = set()
         for i in log["EquipmentEverUsed_ByFacilityID"]['EquipmentEverUsed']:
-            s.update(eval(i))
+            s.update(literal_eval(i))
         return s
 
     # * An HSI that declares no use of any equipment (logs should be empty).
@@ -474,7 +475,7 @@ def test_logging_of_equipment_from_multiple_hsi(seed, tmpdir):
     # Read log to find what equipment used
     df = parse_log_file(sim.log_filepath)["tlo.methods.healthsystem.summary"]['EquipmentEverUsed_ByFacilityID']
     df = df.drop(index=df.index[~df['Facility_Level'].isin(item_code_needed_at_each_level.keys())])
-    df['EquipmentEverUsed'] = df['EquipmentEverUsed'].apply(eval).apply(list)
+    df['EquipmentEverUsed'] = df['EquipmentEverUsed'].apply(literal_eval)
 
     # Check that equipment used at each level matches expectations
     assert item_code_needed_at_each_level == df.groupby('Facility_Level')['EquipmentEverUsed'].sum().apply(set).to_dict()


### PR DESCRIPTION
Fixes #1435 

Changes log entry to use sorted lists of item codes rather than sets where ordering in string representation can change across different Python processes