### PR TITLE
Use isinstance instead of equality comparison on type in `tlo.analysis.utils`

### DIFF
--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -290,7 +290,7 @@ def extract_results(results_folder: Path,
             try:
                 df: pd.DataFrame = load_pickled_dataframes(results_folder, draw, run, module)[module][key]
                 output_from_eval: pd.Series = generate_series(df)
-                assert pd.Series == type(output_from_eval), 'Custom command does not generate a pd.Series'
+                assert isinstance(output_from_eval, pd.Series), 'Custom command does not generate a pd.Series'
                 if do_scaling:
                     res[draw_run] = output_from_eval * get_multiplier(draw, run)
                 else:


### PR DESCRIPTION
The checks workflow [is failing](https://github.com/UCL/TLOmodel/actions/runs/10200400312/job/28219769117?pr=1164) on a couple of PRs (#1164, #1310) I've updated on a file not touched by those PRs due a `ruff` complaining about a type comparison in `tlo.analysis.utils`

```
src/tlo/analysis/utils.py:293:24: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
291 |                 df: pd.DataFrame = load_pickled_dataframes(results_folder, draw, run, module)[module][key]
292 |                 output_from_eval: pd.Series = generate_series(df)
293 |                 assert pd.Series == type(output_from_eval), 'Custom command does not generate a pd.Series'
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
294 |                 if do_scaling:
295 |                     res[draw_run] = output_from_eval * get_multiplier(draw, run)
    |
```

This PR is a one line fix for the above by changing the equality `==` comparison to instead use `isinstance`.