### PR TITLE
Use `isinstance` instead of checking type equality

### DIFF
--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -290,7 +290,9 @@ def extract_results(results_folder: Path,
             try:
                 df: pd.DataFrame = load_pickled_dataframes(results_folder, draw, run, module)[module][key]
                 output_from_eval: pd.Series = generate_series(df)
-                assert pd.Series == type(output_from_eval), 'Custom command does not generate a pd.Series'
+                assert isinstance(output_from_eval, pd.Series), (
+                    'Custom command does not generate a pd.Series'
+                )
                 if do_scaling:
                     res[draw_run] = output_from_eval * get_multiplier(draw, run)
                 else:


### PR DESCRIPTION
[Scheduled checks run failed on `master`](https://github.com/UCL/TLOmodel/actions/runs/10764131778/job/29846489383) due to an explicit comparison between `type` evaluated on an object an a type rather than using `isinstance` (or `is` with type). 