### PR TITLE
Remove generation of coverage report in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,4 +75,4 @@ jobs:
           tox --version
       - name: Test with tox
         run: |
-          tox -v -e py311,report -- pytest --cov --cov-report=term-missing -vv "${{ matrix.file }}"
+          tox -v -e py311 -- pytest --show-capture=no -vv "${{ matrix.file }}"


### PR DESCRIPTION
Removes step to generate HTML coverage report (and command line coverage report) in tests workflow as we don't use former at all as far as I'm aware, and the latter is not very helpful as it's generated per test file due to use of matrix job. Also prevents captured log / `stdout` output being shown on failing tests as this leads to very verbose logs and is rarely helpful in my opinion (tracebacks will still be shown). Aim with both these is to decrease size of artefacts being produced by test workflows to try to address issue of runners running out of disk space.