### PR TITLE
Update minimum Python version to 3.11 in project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,6 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
 ]
@@ -41,7 +38,7 @@ description = "Thanzi la Onse Epidemiology Model"
 dynamic = ["version"]
 license = {file = "LICENSE.txt"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 
 [project.optional-dependencies]
 dev = [
@@ -120,7 +117,7 @@ addopts = "-ra --strict-markers --doctest-modules --doctest-glob=*.rst --tb=shor
 markers = ["group2", "slow"]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py311"
 line-length = 120
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
While our set up instructions currently state to install Python 3.11 and we test only on this Python version, the `pyproject.toml` file still lists the minimum Python version as 3.8. We have started using some Python 3.9+ features in code so the code no longer I think runs without errors on Python 3.8. 

I'm not sure if we are currently using anything Python 3.11 specific rather than Python 3.10 specific, but as we're only testing on Python 3.11 I would say it makes sense to specify that as the minimum supported version as we won't be able to tell if / when we break this. 