### PR TITLE
Log memory usage during profiling runs

### DIFF
--- a/src/scripts/profiling/scale_run.py
+++ b/src/scripts/profiling/scale_run.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
 from shared import print_checksum, schedule_profile_log
 
 from tlo import Date, Simulation, logging
-from tlo.analysis.utils import parse_log_file as parse_log_file_fn, LogsDict
+from tlo.analysis.utils import LogsDict
+from tlo.analysis.utils import parse_log_file as parse_log_file_fn
 from tlo.methods.fullmodel import fullmodel
 
 _TLO_ROOT: Path = Path(__file__).parents[3].resolve()

--- a/src/scripts/profiling/scale_run.py
+++ b/src/scripts/profiling/scale_run.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 from shared import print_checksum, schedule_profile_log
 
 from tlo import Date, Simulation, logging
-from tlo.analysis.utils import parse_log_file as parse_log_file_fn
+from tlo.analysis.utils import parse_log_file as parse_log_file_fn, LogsDict
 from tlo.methods.fullmodel import fullmodel
 
 _TLO_ROOT: Path = Path(__file__).parents[3].resolve()
@@ -55,13 +55,9 @@ def scale_run(
     ignore_warnings: bool = False,
     log_final_population_checksum: bool = True,
     profiler: Optional["Profiler"] = None,
-) -> Simulation:
+) -> Simulation | tuple[Simulation, LogsDict]:
     if ignore_warnings:
         warnings.filterwarnings("ignore")
-
-    # Start profiler if one has been passed
-    if profiler is not None:
-        profiler.start()
 
     # Simulation period
     start_date = Date(2010, 1, 1)
@@ -70,9 +66,14 @@ def scale_run(
     log_config = {
         "filename": log_filename,
         "directory": output_dir,
-        "custom_levels": {"*": getattr(logging, log_level)},
+        # Ensure tlo.profiling log records always recorded
+        "custom_levels": {"*": getattr(logging, log_level), "tlo.profiling": logging.INFO},
         "suppress_stdout": disable_log_output_to_stdout,
     }
+    
+    # Start profiler if one has been passed
+    if profiler is not None:
+        profiler.start()
 
     sim = Simulation(
         start_date=start_date,
@@ -102,16 +103,18 @@ def scale_run(
 
     # Run the simulation
     sim.make_initial_population(n=initial_population)
-    schedule_profile_log(sim)
+    schedule_profile_log(sim, frequency_months=1)
     sim.simulate(end_date=end_date)
+    
+    # Stop profiling session
+    if profiler is not None:
+        profiler.stop()
+
     if log_final_population_checksum:
         print_checksum(sim)
 
     if save_final_population:
         sim.population.props.to_pickle(output_dir / "final_population.pkl")
-
-    if parse_log_file:
-        parse_log_file_fn(sim.log_filepath)
 
     if record_hsi_event_details:
         with open(output_dir / "hsi_event_details.json", "w") as json_file:
@@ -124,10 +127,11 @@ def scale_run(
                 ],
                 json_file,
             )
+            
+    if parse_log_file:
+        logs_dict = parse_log_file_fn(sim.log_filepath)
+        return sim, logs_dict
 
-    # Stop profiling session
-    if profiler is not None:
-        profiler.stop()
     return sim
 
 

--- a/src/scripts/profiling/shared.py
+++ b/src/scripts/profiling/shared.py
@@ -3,6 +3,7 @@ import random
 import time
 
 import pandas as pd
+import psutil
 
 from tlo import DateOffset, Simulation, logging
 from tlo.events import PopulationScopeEventMixin, RegularEvent
@@ -12,9 +13,32 @@ logger = logging.getLogger("tlo.profiling")
 logger.setLevel(logging.INFO)
 
 
+def memory_statistics() -> dict[str, float]:
+    """
+    Extract memory usage statistics in current process using `psutil`.
+    Statistics are returned as a dictionary.
+    
+    Key / value pairs are:
+    memory_rss_MiB: float
+        Resident set size in mebibytes. The non-swapped physical memory the process has used.
+    memory_vms_MiB: float
+        Virtual memory size in mebibytes. The total amount of virtual memory used by the process.
+    memory_uss_MiB: float
+        Unique set size in mebibytes. The memory which is unique to a process and which would be freed if the process
+        was terminated right now
+    """
+    process = psutil.Process()
+    memory_info = process.memory_full_info()
+    return {
+        "memory_rss_MiB": memory_info.rss / 2**20,
+        "memory_vms_MiB": memory_info.vms / 2**20,
+        "memory_uss_MiB": memory_info.uss / 2**20,
+    }
+
+
 class LogProgress(RegularEvent, PopulationScopeEventMixin):
-    def __init__(self, module):
-        super().__init__(module, frequency=DateOffset(months=3))
+    def __init__(self, module, frequency_months=3):
+        super().__init__(module, frequency=DateOffset(months=frequency_months))
         self.time = time.time()
 
     def apply(self, population):
@@ -26,16 +50,18 @@ class LogProgress(RegularEvent, PopulationScopeEventMixin):
             key="stats",
             data={
                 "time": datetime.datetime.now().isoformat(),
-                "duration": duration,
-                "alive": df.is_alive.sum(),
-                "total": len(df),
+                "duration_minutes": duration,
+                "pop_df_number_alive": df.is_alive.sum(),
+                "pop_df_rows": len(df),
+                "pop_df_mem_MiB": df.memory_usage(index=True, deep=True).sum() / 2**20,
+                **memory_statistics(),
             },
         )
 
 
-def schedule_profile_log(sim: Simulation) -> None:
+def schedule_profile_log(sim: Simulation, frequency_months: int = 3) -> None:
     """Schedules the log progress event, used only for profiling"""
-    sim.schedule_event(LogProgress(sim.modules["Demography"]), sim.start_date)
+    sim.schedule_event(LogProgress(sim.modules["Demography"], frequency_months), sim.start_date)
 
 
 def print_checksum(sim: Simulation) -> None:


### PR DESCRIPTION
Uses [`psutil.Process.memory_full_info` method](https://psutil.readthedocs.io/en/latest/index.html#psutil.Process.memory_full_info) to get memory usage statistics for current process and log this regularly (one month frequency by default) during profiling runs. Currently the resident set size (RSS), virtual memory size (VMS) and unique set size (USS) statistics are all logged (these should be available across Linux, MacOS and Windows). The `run_profiling.py` script has been updated to extract these logged statistics and save to a CSV alongside the other results also logged, and to also log these same memory statistics at the end of the profiling session.