### PR TITLE
Guard `psutil` import

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,8 @@ on:
       - requirements/**
       - resources/**
       - src/tlo/**
+      - src/scripts/profiling/scale_run.py
+      - src/scripts/profiling/shared.py
       - tests/**
       - pyproject.toml
       - tox.ini

--- a/src/scripts/profiling/shared.py
+++ b/src/scripts/profiling/shared.py
@@ -23,16 +23,12 @@ def memory_statistics() -> dict[str, float]:
         Resident set size in mebibytes. The non-swapped physical memory the process has used.
     memory_vms_MiB: float
         Virtual memory size in mebibytes. The total amount of virtual memory used by the process.
-    memory_uss_MiB: float
-        Unique set size in mebibytes. The memory which is unique to a process and which would be freed if the process
-        was terminated right now
     """
     process = psutil.Process()
-    memory_info = process.memory_full_info()
+    memory_info = process.memory_info()
     return {
         "memory_rss_MiB": memory_info.rss / 2**20,
         "memory_vms_MiB": memory_info.vms / 2**20,
-        "memory_uss_MiB": memory_info.uss / 2**20,
     }
 
 

--- a/src/scripts/profiling/shared.py
+++ b/src/scripts/profiling/shared.py
@@ -23,12 +23,16 @@ def memory_statistics() -> dict[str, float]:
         Resident set size in mebibytes. The non-swapped physical memory the process has used.
     memory_vms_MiB: float
         Virtual memory size in mebibytes. The total amount of virtual memory used by the process.
+    memory_uss_MiB: float
+        Unique set size in mebibytes. The memory which is unique to a process and which would be freed if the process
+        was terminated right now
     """
     process = psutil.Process()
-    memory_info = process.memory_info()
+    memory_info = process.memory_full_info()
     return {
         "memory_rss_MiB": memory_info.rss / 2**20,
         "memory_vms_MiB": memory_info.vms / 2**20,
+        "memory_uss_MiB": memory_info.uss / 2**20,
     }
 
 

--- a/src/scripts/profiling/shared.py
+++ b/src/scripts/profiling/shared.py
@@ -3,7 +3,11 @@ import random
 import time
 
 import pandas as pd
-import psutil
+
+try:
+    import psutil
+except ImportError:
+    psutil = None
 
 from tlo import DateOffset, Simulation, logging
 from tlo.events import PopulationScopeEventMixin, RegularEvent
@@ -15,8 +19,8 @@ logger.setLevel(logging.INFO)
 
 def memory_statistics() -> dict[str, float]:
     """
-    Extract memory usage statistics in current process using `psutil`.
-    Statistics are returned as a dictionary.
+    Extract memory usage statistics in current process using `psutil` if available.
+    Statistics are returned as a dictionary. If `psutil` not installed an empty dict is returned.
     
     Key / value pairs are:
     memory_rss_MiB: float
@@ -27,6 +31,8 @@ def memory_statistics() -> dict[str, float]:
         Unique set size in mebibytes. The memory which is unique to a process and which would be freed if the process
         was terminated right now
     """
+    if psutil is None:
+        return {}
     process = psutil.Process()
     memory_info = process.memory_full_info()
     return {


### PR DESCRIPTION
Potentially resolves #1472 

EDIT: Looks from experiments in #1474 issue was not `psutil` method requiring elevated privileges but just that I forgot it isn't part of core dependencies so doesn't get installed on runners for tests 🤦.