### PR TITLE
Remove hardcoded reference to simulation years preventing simulations being ran with a start date after 2010

### DIFF
--- a/src/tlo/methods/epi.py
+++ b/src/tlo/methods/epi.py
@@ -182,7 +182,10 @@ class Epi(Module):
         sim.schedule_event(EpiLoggingEvent(self), sim.date + DateOffset(years=1))
 
         # HPV vaccine given from 2018 onwards
-        sim.schedule_event(HpvScheduleEvent(self), Date(2018, 1, 1))
+        if self.sim.date.year < 2018:
+            sim.schedule_event(HpvScheduleEvent(self), Date(2018, 1, 1))
+        else:
+            sim.schedule_event(HpvScheduleEvent(self), Date(self.sim.date.year, 1, 1))
 
         # Look up item codes for consumables
         self.get_item_codes()

--- a/src/tlo/methods/hiv.py
+++ b/src/tlo/methods/hiv.py
@@ -1503,20 +1503,20 @@ class Hiv(Module, GenericFirstAppointmentsMixin):
 
         df = self.sim.population.props
 
-        # get number of tests performed in last time period
-        if self.sim.date.year == (self.sim.start_date.year + 1):
-            number_tests_new = df.hv_number_tests.sum()
+        if not self.stored_test_numbers:
+            # If it's the first year, set previous_test_numbers to 0
             previous_test_numbers = 0
-
         else:
+            # For subsequent years, retrieve the last stored number
             previous_test_numbers = self.stored_test_numbers[-1]
 
-            # calculate number of tests now performed - cumulative, include those who have died
-            number_tests_new = df.hv_number_tests.sum()
+        # Calculate number of tests now performed - cumulative, include those who have died
+        number_tests_new = df.hv_number_tests.sum()
 
+        # Store the number of tests performed in this year for future reference
         self.stored_test_numbers.append(number_tests_new)
 
-        # number of tests performed in last time period
+        # Number of tests performed in the last time period
         number_tests_in_last_period = number_tests_new - previous_test_numbers
 
         # per-capita testing rate

--- a/src/tlo/methods/hiv.py
+++ b/src/tlo/methods/hiv.py
@@ -1504,7 +1504,7 @@ class Hiv(Module, GenericFirstAppointmentsMixin):
         df = self.sim.population.props
 
         # get number of tests performed in last time period
-        if self.sim.date.year == 2011:
+        if self.sim.date.year == (self.sim.start_date.year + 1):
             number_tests_new = df.hv_number_tests.sum()
             previous_test_numbers = 0
 

--- a/src/tlo/methods/schisto.py
+++ b/src/tlo/methods/schisto.py
@@ -303,6 +303,11 @@ class Schisto(Module, GenericFirstAppointmentsMixin):
     def _schedule_mda_events(self) -> None:
         """Schedule MDA events, historical and prognosed."""
 
+        # todo: tara to confirm if happy with this or if there is an alternative (cant set self.mda_execute == False
+        #  when running full model?)
+        if self.sim.date.year != 2010:
+            return
+
         # Schedule the  MDA that have occurred, in each district and in each year:
         for (district, year), cov in self.parameters['MDA_coverage_historical'].iterrows():
             assert district in self.sim.modules['Demography'].districts, f'District {district} is not recognised.'

--- a/src/tlo/methods/schisto.py
+++ b/src/tlo/methods/schisto.py
@@ -303,11 +303,6 @@ class Schisto(Module, GenericFirstAppointmentsMixin):
     def _schedule_mda_events(self) -> None:
         """Schedule MDA events, historical and prognosed."""
 
-        # todo: tara to confirm if happy with this or if there is an alternative (cant set self.mda_execute == False
-        #  when running full model?)
-        if self.sim.date.year != 2010:
-            return
-
         # Schedule the  MDA that have occurred, in each district and in each year:
         for (district, year), cov in self.parameters['MDA_coverage_historical'].iterrows():
             assert district in self.sim.modules['Demography'].districts, f'District {district} is not recognised.'


### PR DESCRIPTION
This PR edits two modules which have hard coded reference to years in the simulation prevent running of a simulation with a start date after a given year. Therefore running the simulation with a start date later that these years causes the model to crash. This is mainly relevant to attempts to use the model in a cohort mode. 

@tdm32 have requested your review as its two of your modules. please let me know if you'd like me to change what i've got here. 