### PR TITLE
Ensure `bitset_handler` tests run in GitHub Actions workflow and remove usages of `BytesDType`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,9 +46,10 @@ jobs:
         name: Set matrix
         run: |
           set -e
+          shopt -s globstar
           # Find all test files and generate their list in JSON format
           VAR_FILES="{\"include\":["
-          for file in tests/test_*.py; do
+          for file in tests/**/test_*.py; do
               VAR_FILES="${VAR_FILES}{\"file\":\"${file}\"},"
           done
           VAR_FILES="${VAR_FILES}]}"

--- a/src/tlo/bitset_handler/bitset_extension.py
+++ b/src/tlo/bitset_handler/bitset_extension.py
@@ -19,7 +19,6 @@ from typing import (
 
 import numpy as np
 import pandas as pd
-from numpy.dtypes import BytesDType  # pylint: disable=E0611
 from numpy.typing import NDArray
 from pandas._typing import TakeIndexer, type_t
 from pandas.core.arrays.base import ExtensionArray
@@ -130,8 +129,8 @@ class BitsetDtype(ExtensionDtype):
         return self.__str__()
 
     @property
-    def np_array_dtype(self) -> BytesDType:
-        return BytesDType(self.fixed_width)
+    def np_array_dtype(self) -> np.dtype:
+        return np.dtype((bytes, self.fixed_width))
 
     @property
     def type(self) -> Type[np.bytes_]:
@@ -374,7 +373,7 @@ class BitsetArray(ExtensionArray):
 
     def __init__(
         self,
-        data: Iterable[BytesDType] | np.ndarray[BytesDType],
+        data: Iterable | np.ndarray,
         dtype: BitsetDtype,
         copy: bool = False,
     ) -> None:
@@ -688,7 +687,7 @@ class BitsetArray(ExtensionArray):
         indices: TakeIndexer,
         *,
         allow_fill: bool = False,
-        fill_value: Optional[BytesDType | Set[ElementType]] = None,
+        fill_value: Optional[np.bytes_ | Set[ElementType]] = None,
     ) -> BitsetArray:
         if allow_fill:
             if isinstance(fill_value, set):

--- a/src/tlo/bitset_handler/bitset_extension.py
+++ b/src/tlo/bitset_handler/bitset_extension.py
@@ -85,14 +85,14 @@ class BitsetDtype(ExtensionDtype):
         if not isinstance(string, str):
             raise TypeError(f"'construct_from_string' expects a string, got {type(string)}")
 
-        string_has_bitset_prefix = re.match("bitset\((\d+)\):", string)
+        string_has_bitset_prefix = re.match(r"bitset\((\d+)\):", string)
         n_elements = None
         if string_has_bitset_prefix:
             prefix = string_has_bitset_prefix.group(0)
             # Remove prefix
             string = string.removeprefix(prefix)
             # Extract number of elements if provided though
-            n_elements = int(re.search("(\d+)", prefix).group(0))
+            n_elements = int(re.search(r"(\d+)", prefix).group(0))
         if "," not in string:
             raise TypeError(
                 "Need at least 2 (comma-separated) elements in string to construct bitset."

--- a/tests/bitset_handler/conftest.py
+++ b/tests/bitset_handler/conftest.py
@@ -11,7 +11,6 @@ from typing import List, Set
 
 import numpy as np
 import pytest
-from numpy.dtypes import BytesDType  # pylint: disable=E0611
 from numpy.random import PCG64, Generator
 from numpy.typing import NDArray
 
@@ -89,7 +88,7 @@ def data_for_twos(dtype: BitsetDtype) -> None:
 
 
 @pytest.fixture
-def data_missing(dtype: BitsetDtype) -> np.ndarray[BytesDType]:
+def data_missing(dtype: BitsetDtype) -> np.ndarray:
     data = np.zeros((2,), dtype=dtype.np_array_dtype)
     data[0] = dtype.na_value
     data[1] = dtype.as_bytes({"a"})


### PR DESCRIPTION
Resolves #1501 and resolves #1502.

Avoids import of `BytesDType` from `numpy.dtypes` (which is not available in `numpy==1.24.4` which is what we currently pin at) and also updates construction of matrix of test files in tests workflow to also include test modules under subdirectories in `tests`. Also makes a couple of regex strings raw string literals to avoid warnings about unrecognised character escapes.