### PR TITLE
Log Consumables That are Assumed to Be Used

### DIFF
--- a/src/scripts/hiv/projections_jan2023/analysis_logged_deviance.py
+++ b/src/scripts/hiv/projections_jan2023/analysis_logged_deviance.py
@@ -34,8 +34,8 @@ resourcefilepath = Path("./resources")
 
 # %% Run the simulation
 start_date = Date(2010, 1, 1)
-end_date = Date(2015, 1, 1)
-popsize = 2000
+end_date = Date(2022, 1, 1)
+popsize = 5000
 
 # scenario = 1
 
@@ -46,12 +46,12 @@ log_config = {
     "custom_levels": {
         "*": logging.WARNING,
         # "tlo.methods.deviance_measure": logging.INFO,
-        "tlo.methods.epi": logging.INFO,
+        # "tlo.methods.epi": logging.INFO,
         "tlo.methods.hiv": logging.INFO,
         "tlo.methods.tb": logging.INFO,
         "tlo.methods.demography": logging.INFO,
         # "tlo.methods.demography.detail": logging.WARNING,
-        "tlo.methods.healthsystem.summary": logging.INFO,
+        # "tlo.methods.healthsystem.summary": logging.INFO,
         # "tlo.methods.healthsystem": logging.INFO,
         # "tlo.methods.healthburden": logging.INFO,
     },

--- a/src/scripts/hiv/projections_jan2023/analysis_logged_deviance.py
+++ b/src/scripts/hiv/projections_jan2023/analysis_logged_deviance.py
@@ -34,8 +34,8 @@ resourcefilepath = Path("./resources")
 
 # %% Run the simulation
 start_date = Date(2010, 1, 1)
-end_date = Date(2022, 1, 1)
-popsize = 5000
+end_date = Date(2015, 1, 1)
+popsize = 2000
 
 # scenario = 1
 
@@ -46,12 +46,12 @@ log_config = {
     "custom_levels": {
         "*": logging.WARNING,
         # "tlo.methods.deviance_measure": logging.INFO,
-        # "tlo.methods.epi": logging.INFO,
+        "tlo.methods.epi": logging.INFO,
         "tlo.methods.hiv": logging.INFO,
         "tlo.methods.tb": logging.INFO,
         "tlo.methods.demography": logging.INFO,
         # "tlo.methods.demography.detail": logging.WARNING,
-        # "tlo.methods.healthsystem.summary": logging.INFO,
+        "tlo.methods.healthsystem.summary": logging.INFO,
         # "tlo.methods.healthsystem": logging.INFO,
         # "tlo.methods.healthburden": logging.INFO,
     },

--- a/src/tlo/methods/consumables.py
+++ b/src/tlo/methods/consumables.py
@@ -240,7 +240,7 @@ class Consumables:
                     'TREATMENT_ID': treatment_id or "",
                     'Item_Available': str(items_available),
                     'Item_NotAvailable': str(items_not_available),
-                    'Items_Used': str(items_used),
+                    'Item_Used': str(items_used),
                 },
                 description="Record of requested and used consumable items."
             )

--- a/src/tlo/methods/consumables.py
+++ b/src/tlo/methods/consumables.py
@@ -200,7 +200,7 @@ class Consumables:
     def _request_consumables(self,
                              facility_info: 'FacilityInfo',  # noqa: F821
                              item_codes: dict,
-                             optional_item_codes: Optional[dict],
+                             optional_item_codes: Optional[dict] = None,
                              to_log: bool = True,
                              treatment_id: Optional[str] = None
                              ) -> dict:

--- a/src/tlo/methods/consumables.py
+++ b/src/tlo/methods/consumables.py
@@ -231,10 +231,7 @@ class Consumables:
             items_not_available = {k: v for k, v in _all_item_codes.items() if not available[k]}
 
             # Log items used if all essential items are available
-            items_used = {
-                **{k: v for k, v in item_codes.items() if available[k]},
-                **{k: v for k, v in optional_item_codes.items() if available[k]}
-            } if all(available.get(k, False) for k in item_codes) else {}
+            items_used = items_available if all(available.get(k, False) for k in item_codes) else {}
 
             logger.info(
                 key='Consumables',

--- a/src/tlo/methods/consumables.py
+++ b/src/tlo/methods/consumables.py
@@ -200,7 +200,7 @@ class Consumables:
     def _request_consumables(self,
                              facility_info: 'FacilityInfo',  # noqa: F821
                              item_codes: dict,
-                             optional_item_codes: dict,
+                             optional_item_codes: Optional[dict],
                              to_log: bool = True,
                              treatment_id: Optional[str] = None
                              ) -> dict:

--- a/src/tlo/methods/consumables.py
+++ b/src/tlo/methods/consumables.py
@@ -200,6 +200,7 @@ class Consumables:
     def _request_consumables(self,
                              facility_info: 'FacilityInfo',  # noqa: F821
                              item_codes: dict,
+                             optional_item_codes: dict,
                              to_log: bool = True,
                              treatment_id: Optional[str] = None
                              ) -> dict:
@@ -208,35 +209,44 @@ class Consumables:
 
         :param facility_info: The facility_info from which the request for consumables originates
         :param item_codes: dict of the form {<item_code>: <quantity>} for the items requested
+        :param optional_item_codes: dict of the form {<item_code>: <quantity>} for the optional items requested
         :param to_log: whether the request is logged.
         :param treatment_id: the TREATMENT_ID of the HSI (which is entered to the log, if provided).
         :return: dict of the form {<item_code>: <bool>} indicating the availability of each item requested.
         """
 
+        _all_item_codes = {**item_codes, **optional_item_codes}
+
         # Issue warning if any item_code is not recognised.
-        not_recognised_item_codes = item_codes.keys() - self.item_codes
+        not_recognised_item_codes = _all_item_codes.keys() - self.item_codes
         if len(not_recognised_item_codes) > 0:
             self._not_recognised_item_codes[treatment_id] |= not_recognised_item_codes
 
         # Look-up whether each of these items is available in this facility currently:
-        available = self._lookup_availability_of_consumables(item_codes=item_codes, facility_info=facility_info)
+        available = self._lookup_availability_of_consumables(item_codes=_all_item_codes, facility_info=facility_info)
 
         # Log the request and the outcome:
         if to_log:
-            items_available = {k: v for k, v in item_codes.items() if available[k]}
-            items_not_available = {k: v for k, v in item_codes.items() if not available[k]}
-            logger.info(key='Consumables',
-                        data={
-                            'TREATMENT_ID': (treatment_id if treatment_id is not None else ""),
-                            'Item_Available': str(items_available),
-                            'Item_NotAvailable': str(items_not_available),
-                        },
-                        # NB. Casting the data to strings because logger complains with dict of varying sizes/keys
-                        description="Record of each consumable item that is requested."
-                        )
+            items_available = {k: v for k, v in _all_item_codes.items() if available[k]}
+            items_not_available = {k: v for k, v in _all_item_codes.items() if not available[k]}
 
-            self._summary_counter.record_availability(items_available=items_available,
-                                                      items_not_available=items_not_available)
+            # Log items used if all essential items are available
+            items_used = {
+                **{k: v for k, v in item_codes.items() if available[k]},
+                **{k: v for k, v in optional_item_codes.items() if available[k]}
+            } if all(available.get(k, False) for k in item_codes) else {}
+
+            logger.info(
+                key='Consumables',
+                data={
+                    'TREATMENT_ID': treatment_id or "",
+                    'Item_Available': str(items_available),
+                    'Item_NotAvailable': str(items_not_available),
+                    'Items_Used': str(items_used),
+                },
+                description="Record of requested and used consumable items."
+            )
+            self._summary_counter.record_availability(items_available, items_not_available, items_used)
 
         # Return the result of the check on availability
         return available
@@ -267,12 +277,12 @@ class Consumables:
 
     def on_simulation_end(self):
         """Do tasks at the end of the simulation.
-         
+
         Raise warnings and enter to log about item_codes not recognised.
         """
         if len(self._not_recognised_item_codes) > 0:
             not_recognised_item_codes = {
-                treatment_id if treatment_id is not None else "": sorted(codes) 
+                treatment_id if treatment_id is not None else "": sorted(codes)
                 for treatment_id, codes in self._not_recognised_item_codes.items()
             }
             warnings.warn(
@@ -363,10 +373,11 @@ class ConsumablesSummaryCounter:
 
         self._items = {
             'Available': defaultdict(int),
-            'NotAvailable': defaultdict(int)
+            'NotAvailable': defaultdict(int),
+            'Used': defaultdict(int),
         }
 
-    def record_availability(self, items_available: dict, items_not_available: dict) -> None:
+    def record_availability(self, items_available: dict, items_not_available: dict, items_used: dict) -> None:
         """Add information about the availability of requested items to the running summaries."""
 
         # Record items that were available
@@ -376,6 +387,10 @@ class ConsumablesSummaryCounter:
         # Record items that were not available
         for _item, _num in items_not_available.items():
             self._items['NotAvailable'][_item] += _num
+
+        # Record items that were used
+        for _item, _num in items_used.items():
+            self._items['Used'][_item] += _num
 
     def write_to_log_and_reset_counters(self):
         """Log summary statistics and reset the data structures."""
@@ -387,6 +402,7 @@ class ConsumablesSummaryCounter:
             data={
                 "Item_Available": self._items['Available'],
                 "Item_NotAvailable": self._items['NotAvailable'],
+                "Item_Used": self._items['Used'],
             },
         )
 

--- a/src/tlo/methods/consumables.py
+++ b/src/tlo/methods/consumables.py
@@ -246,7 +246,11 @@ class Consumables:
                 },
                 description="Record of requested and used consumable items."
             )
-            self._summary_counter.record_availability(items_available, items_not_available, items_used)
+            self._summary_counter.record_availability(
+            items_available=items_available, 
+            items_not_available=items_not_available, 
+            items_used=items_used,
+            )
 
         # Return the result of the check on availability
         return available

--- a/src/tlo/methods/hsi_event.py
+++ b/src/tlo/methods/hsi_event.py
@@ -225,7 +225,7 @@ class HSI_Event:
 
         # Checking the availability and logging:
         rtn = self.healthcare_system.consumables._request_consumables(
-            item_codes=_item_codes,
+            essential_item_codes=_item_codes,
             optional_item_codes=_optional_item_codes,
             to_log=_to_log,
             facility_info=self.facility_info,

--- a/src/tlo/methods/hsi_event.py
+++ b/src/tlo/methods/hsi_event.py
@@ -225,7 +225,8 @@ class HSI_Event:
 
         # Checking the availability and logging:
         rtn = self.healthcare_system.consumables._request_consumables(
-            item_codes={**_item_codes, **_optional_item_codes},
+            item_codes=_item_codes,
+            optional_item_codes=_optional_item_codes,
             to_log=_to_log,
             facility_info=self.facility_info,
             treatment_id=self.TREATMENT_ID,

--- a/tests/test_consumables.py
+++ b/tests/test_consumables.py
@@ -157,7 +157,9 @@ def test_override_cons_availability(seed):
             item_code = [item_code]
 
         return all(cons._request_consumables(
-            item_codes={_i: 1 for _i in item_code}, to_log=False, facility_info=facility_info_0
+            item_codes={_i: 1 for _i in item_code},
+            optional_item_codes={},
+            to_log=False, facility_info=facility_info_0
         ).values())
 
     rng = get_rng(seed)

--- a/tests/test_consumables.py
+++ b/tests/test_consumables.py
@@ -62,6 +62,7 @@ def test_using_recognised_item_codes(seed):
     # Make requests for consumables (which would normally come from an instance of `HSI_Event`).
     rtn = cons._request_consumables(
         item_codes={0: 1, 1: 1},
+        optional_item_codes={},
         facility_info=facility_info_0
     )
 
@@ -89,6 +90,7 @@ def test_unrecognised_item_code_is_recorded(seed):
     # Make requests for consumables (which would normally come from an instance of `HSI_Event`).
     rtn = cons._request_consumables(
         item_codes={99: 1},
+        optional_item_codes={},
         facility_info=facility_info_0
     )
 
@@ -128,7 +130,9 @@ def test_consumables_availability_options(seed):
         cons.on_start_of_day(date=date)
 
         assert _expected_result == cons._request_consumables(
-            item_codes={_item_code: 1 for _item_code in all_items_request}, to_log=False, facility_info=facility_info_0
+            item_codes={_item_code: 1 for _item_code in all_items_request},
+            optional_item_codes={},
+            to_log=False, facility_info=facility_info_0
         )
 
 
@@ -251,6 +255,7 @@ def test_consumables_available_at_right_frequency(seed):
         cons.on_start_of_day(date=date)
         rtn = cons._request_consumables(
             item_codes=requested_items,
+            optional_item_codes={},
             facility_info=facility_info_0,
         )
         for _i in requested_items:

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -952,7 +952,7 @@ def test_two_loggers_in_healthsystem(seed, tmpdir):
             } == set(detailed_hsi_event.columns)
     assert {'date', 'Frac_Time_Used_Overall', 'Frac_Time_Used_By_Facility_ID', 'Frac_Time_Used_By_OfficerType',
             } == set(detailed_capacity.columns)
-    assert {'date', 'TREATMENT_ID', 'Item_Available', 'Item_NotAvailable'
+    assert {'date', 'TREATMENT_ID', 'Item_Available', 'Item_NotAvailable', 'Item_Used'
             } == set(detailed_consumables.columns)
 
     bed_types = sim.modules['HealthSystem'].bed_days.bed_types
@@ -1018,6 +1018,9 @@ def test_two_loggers_in_healthsystem(seed, tmpdir):
                lambda x: {f'{k}': v for k, v in eval(x).items()}).apply(pd.Series).sum().to_dict()
     assert summary_consumables['Item_NotAvailable'].apply(pd.Series).sum().to_dict() == \
            detailed_consumables['Item_NotAvailable'].apply(
+               lambda x: {f'{k}': v for k, v in eval(x).items()}).apply(pd.Series).sum().to_dict()
+    assert summary_consumables['Item_Used'].apply(pd.Series).sum().to_dict() == \
+           detailed_consumables['Item_Used'].apply(
                lambda x: {f'{k}': v for k, v in eval(x).items()}).apply(pd.Series).sum().to_dict()
 
     #  - Bed-Days (bed-type by bed-type and year by year)


### PR DESCRIPTION
Fixes #1505

PR creates a new entry in the consumables logger which records only those consumables used. This uses the logic that if all requested item_codes are available, then the HSI will run and the items will be used. The availability check only requires essential item_codes, any available optional_item_codes are logged only if the essential item_codes are all available. 