### PR TITLE
Some updates to publication list script to allow for conference papers

### DIFF
--- a/docs/publications.bib
+++ b/docs/publications.bib
@@ -50,6 +50,7 @@ Pages: 2024.11.14.24317330},
 	month = nov,
 	year = {2024},
 	keywords = {Analyses using the model},
+	doi = {10.15124/yao-7b1g-n044},
 }
 
 @article{hallett_estimates_2024,

--- a/docs/tlo_publications.py
+++ b/docs/tlo_publications.py
@@ -109,7 +109,8 @@ class SummarizedStyle(UnsrtStyle):
         ]
 
     def _get_summary_template(self, e, type_):
-        venue_field = "journal" if type_ == "article" else "publisher"
+        bibtex_type_to_venue_field = {"article": "journal", "misc": "publisher", "inproceedings": "booktitle"}
+        venue_field = bibtex_type_to_venue_field[type_]
         url = first_of[
             optional[join["https://doi.org/", field("doi", raw=True)]],
             optional[field("url", raw=True)],
@@ -128,7 +129,7 @@ class SummarizedStyle(UnsrtStyle):
         ]
 
     def _get_details_template(self, type_):
-        bibtex_type_to_label = {"article": "Journal article", "misc": "Pre-print"}
+        bibtex_type_to_label = {"article": "Journal article", "misc": "Pre-print", "inproceedings": "Conference paper"}
         return self._format_details_as_table(
             {
                 "Type": bibtex_type_to_label[type_],
@@ -149,6 +150,9 @@ class SummarizedStyle(UnsrtStyle):
 
     def get_misc_template(self, e):
         return self._get_summarized_template(e, "misc")
+
+    def get_inproceedings_template(self, e):
+        return self._get_summarized_template(e, "inproceedings")
 
 
 def write_publications_list(stream, bibliography_data, section_names, backend, style):

--- a/docs/tlo_publications.py
+++ b/docs/tlo_publications.py
@@ -158,8 +158,10 @@ class SummarizedStyle(UnsrtStyle):
 def write_publications_list(stream, bibliography_data, section_names, backend, style):
     """Write bibliography data with given backend and style to a stream splitting in to sections."""
     keys_by_section = defaultdict(list)
+    section_names = [name.lower() for name in section_names]
     for key, entry in bibliography_data.entries.items():
-        keywords = set(k.strip() for k in entry.fields.get("keywords", "").split(","))
+        # Section names and keywords normalized to lower case to make matching case-insensitive
+        keywords = set(k.strip().lower() for k in entry.fields.get("keywords", "").split(","))
         section_names_in_keywords = keywords & set(section_names)
         if len(section_names_in_keywords) == 1:
             keys_by_section[section_names_in_keywords.pop()].append(key)
@@ -176,7 +178,7 @@ def write_publications_list(stream, bibliography_data, section_names, backend, s
             )
             warn(msg, stacklevel=2)
     for section_name in section_names:
-        stream.write(f"<h2>{section_name}</h2>\n")
+        stream.write(f"<h2>{section_name.capitalize()}</h2>\n")
         formatted_bibliography = style.format_bibliography(
             bibliography_data, keys_by_section[section_name]
         )


### PR DESCRIPTION
@tbhallett 

Proposing some minor updates to #1518 to make BibTeX entries of `inproceedings` type (conference papers) display correctly (previously only had template set up for journal article and pre-prints / misc) and also to make section name / keyword matching case insensitive.