### PR TITLE
Generate `HSI_Contraception_FamilyPlanningAppt.EXPECTED_APPT_FOOTPRINT` at class initialisation

### DIFF
--- a/src/tlo/methods/contraception.py
+++ b/src/tlo/methods/contraception.py
@@ -1146,12 +1146,12 @@ class HSI_Contraception_FamilyPlanningAppt(HSI_Event, IndividualScopeEventMixin)
 
         self.TREATMENT_ID = "Contraception_Routine"
         self.ACCEPTED_FACILITY_LEVEL = _facility_level
-
-    @property
-    def EXPECTED_APPT_FOOTPRINT(self):
-        """Return the expected appt footprint based on contraception method and whether the HSI has been rescheduled."""
-        person_id = self.target
         current_method = self.sim.population.props.loc[person_id].co_contraception
+        self.EXPECTED_APPT_FOOTPRINT = self._get_expected_appt_footprint(current_method)
+
+
+    def _get_expected_appt_footprint(self, current_method: str):
+        """Return the expected appt footprint based on contraception method and whether the HSI has been rescheduled."""
         if self._number_of_times_run > 0:  # if it is to re-schedule due to unavailable consumables
             return self.make_appt_footprint({})
         # if to switch to a method
@@ -1165,9 +1165,11 @@ class HSI_Contraception_FamilyPlanningAppt(HSI_Event, IndividualScopeEventMixin)
         elif self.new_contraceptive in ['male_condom', 'other_modern', 'pill']:
             return self.make_appt_footprint({'PharmDispensing': 1})
         else:
+            warnings.warn(
+                "Assumed empty footprint for Contraception Routine appt because couldn't find actual case.",
+                stacklevel=3,
+            )
             return self.make_appt_footprint({})
-            warnings.warn(UserWarning("Assumed empty footprint for Contraception Routine appt because couldn't find"
-                                      "actual case."))
 
     def apply(self, person_id, squeeze_factor):
         """If the relevant consumable is available, do change in contraception and log it"""

--- a/src/tlo/methods/contraception.py
+++ b/src/tlo/methods/contraception.py
@@ -1147,11 +1147,11 @@ class HSI_Contraception_FamilyPlanningAppt(HSI_Event, IndividualScopeEventMixin)
         self.TREATMENT_ID = "Contraception_Routine"
         self.ACCEPTED_FACILITY_LEVEL = _facility_level
         current_method = self.sim.population.props.loc[person_id].co_contraception
-        self.EXPECTED_APPT_FOOTPRINT = self._get_expected_appt_footprint(current_method)
+        self.EXPECTED_APPT_FOOTPRINT = self._get_appt_footprint(current_method)
 
 
-    def _get_expected_appt_footprint(self, current_method: str):
-        """Return the expected appt footprint based on contraception method and whether the HSI has been rescheduled."""
+    def _get_appt_footprint(self, current_method: str):
+        """Return the appointment footprint based on contraception method and whether the HSI has been rescheduled."""
         if self._number_of_times_run > 0:  # if it is to re-schedule due to unavailable consumables
             return self.make_appt_footprint({})
         # if to switch to a method
@@ -1267,6 +1267,8 @@ class HSI_Contraception_FamilyPlanningAppt(HSI_Event, IndividualScopeEventMixin)
             self._number_of_times_run < self.module.parameters['max_number_of_runs_of_hsi_if_consumable_not_available']
         ):
             self.reschedule()
+
+        return self._get_appt_footprint(current_method)
 
     def post_apply_hook(self):
         self._number_of_times_run += 1


### PR DESCRIPTION
Resolves #1467 

Changes `HSI_Contraception_FamilyPlanningAppt.EXPECTED_APPT_FOOTPRINT` from being a property to a static attribute, with the value evaluated when the class (HSI event) is initialised (scheduled).

This may change the value associated with `EXPECTED_APPT_FOOTPRINT` as it is now depends on the targets properties (specifically the current contraception method indicated by the categorical `co_contraception` property) at the time of scheduling rather than evaluation of `EXPECTED_APPT_FOOTPRINT`. Marking this as draft for now as will need @EvaJanouskova and/or @BinglingICL to verify if this change in behaviour is reasonable.

As discussed in #1467 repeated dataframe accesses when dynamically evaluating `EXPECTED_APPT_FOOTPRINT` for this HSI event where becoming a significant performance bottleneck - from some short profiled runs locally the changes here give around a 20% reduction in run time.

