### PR TITLE
Speed up documentation build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,6 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
-    'sphinx.ext.viewcode',
     'rawfiles'
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,6 @@ if not on_rtd:  # only set the theme if we're building docs locally
     html_theme = 'sphinx_rtd_theme'
 
 html_use_smartypants = True
-html_last_updated_fmt = '%b %d, %Y'
 html_split_index = False
 html_show_copyright = False
 html_sidebars = {

--- a/docs/tlo_resources.py
+++ b/docs/tlo_resources.py
@@ -99,7 +99,7 @@ def excel_to_rst_table(input_path: Path, output_path: Path) -> None:
 def generate_docs_pages_from_resource_files(
     resources_directory: Path,
     docs_directory: Path,
-    max_file_size_bytes: int = 2**20,
+    max_file_size_bytes: int = 2**15,
 ) -> None:
     root_output_directory = docs_directory / "resources"
     root_output_directory.mkdir(exist_ok=True)

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,6 @@ commands =
     ; Generate parameters listing
     python docs/tlo_parameters.py {toxinidir}{/}resources {toxinidir}{/}docs{/}parameters.rst
     sphinx-build {posargs:-E} -b html docs dist/docs
-    -sphinx-build -b linkcheck docs dist/docs
 
 [testenv:check]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ deps =
     ; require setuptools_scm for getting version info
     setuptools_scm
 commands =
-    sphinx-apidoc -e -f -o {toxinidir}/docs/reference {toxinidir}/src/tlo
+    sphinx-apidoc -e -o {toxinidir}/docs/reference {toxinidir}/src/tlo
     ; Generate API documentation for TLO methods
     python docs/tlo_methods_rst.py
     ; Generate data sources page

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ commands =
     python src/tlo/analysis/hsi_events.py --output-file docs/hsi_events.csv --output-format csv
     ; Generate parameters listing
     python docs/tlo_parameters.py {toxinidir}{/}resources {toxinidir}{/}docs{/}parameters.rst
-    sphinx-build {posargs:-E} -b html docs dist/docs
+    sphinx-build -b html docs dist/docs
 
 [testenv:check]
 deps =


### PR DESCRIPTION
Resolves (some of) #1513 

- Remove `linkcheck` step
- Removes `-f` force option to `sphinx-apidoc` and `-E` fresh env default argument to `sphinx-build`
- Removes `sphinx.ext.viewcode` extension
- Stops last updated date text being added to footers to minimize diff noise
- Changes maximum resource file size before switching to just including a placeholder page linking to file to download rather than rendering table to 32KiB rather than 1MiB - this was a quicker alternative to suggestion in #1513 to use an online viewer. This would still be nice to have but as a lot of resource files are still XLSX can be delayed till we have finished with converting them to CSV.

Times for `tox -e docs` steps before and after changes (in both cases from a clean state):

| Step | Time (`master`) / s | Time (this PR) / s |
|------|-------------------|-------------------|
| Setup | 8.89 | 8.06 |
|  `sphinx-apidoc` | 0.31 | 0.29 |
| `tlo_methods_rst.py` | 7.51 | 7.51 |
|  `tlo_data_sources.py` | 0.34 | 0.37 |
| `tlo_contributors.py` | 0.06 |  0.06 |
| `tlo_publications.py` | 0.38 | 0.42 |
| `tlo_resources.py` | 8.17 | 1.18 |
| `hsi_events.py` (RST) | 6.95 | 7.01 |
| `hsi_events.py` (CSV) | 7.75 | 7.00 |
| `tlo_parameters.py` | 4.95 | 5.10 |
| `sphinx-build` | 216.90 | 39.63 |
| `linkcheck` | 720.06 | (removed) |
| Total | 982.26 | 76.63 | 

Biggest gain is removing `linkcheck` step but `sphinx-build` step is also significantly reduced, mainly because of previously some of the large resource files taking a while to render.