### PR TITLE
Sort population by age-group before plotting

### DIFF
--- a/src/scripts/calibration_analyses/analysis_scripts/analysis_demography_calibrations.py
+++ b/src/scripts/calibration_analyses/analysis_scripts/analysis_demography_calibrations.py
@@ -260,6 +260,7 @@ def apply(results_folder: Path, output_folder: Path, resourcefilepath: Path = No
             collapse_columns=True,
             only_mean=True
         )
+        num_by_age = num_by_age.reindex(make_age_grp_types().categories)
         return num_by_age
 
     for year in [2010, 2015, 2018, 2029, 2049]:
@@ -718,6 +719,7 @@ def apply(results_folder: Path, output_folder: Path, resourcefilepath: Path = No
                 deaths_by_agesexperiod.loc[
                     (deaths_by_agesexperiod['Period'] == period) & (deaths_by_agesexperiod['Sex'] == sex)].groupby(
                     by=['Variant', 'Age_Grp'])['Count'].sum()).unstack()
+
             tot_deaths_byage.columns = pd.Index([label[1] for label in tot_deaths_byage.columns.tolist()])
             tot_deaths_byage = tot_deaths_byage.transpose()
 


### PR DESCRIPTION
This PR aims to fix #1506 
I have sorted the dataframe by pre-defined age categories available via `make_age_grp_types.categories` and checked that population pyramid is now being plotted correctly. 
Incidentally, I wonder if this line contains a typo? Since we are looping over sex,I expected data[_sex][_source].
https://github.com/UCL/TLOmodel/blob/58256ce671ba316ba55534357af5c516ac5faaa5/src/scripts/calibration_analyses/analysis_scripts/analysis_demography_calibrations.py#L201
