### PR TITLE
Removal of old versions of the maternal and newborn health write ups

### DIFF
--- a/docs/write-ups/CareOfWomenDuringPregnancy.docx
+++ b/docs/write-ups/CareOfWomenDuringPregnancy.docx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ea2293d04b42ed60c719ff4864670138c886d499fb0ae730f12575cf2abbdc2
-size 760210

--- a/docs/write-ups/Labour.docx
+++ b/docs/write-ups/Labour.docx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0fdbc5a8a118384a63b3f622c909684af63e8011714f640015d4b63623f351b6
-size 931746

--- a/docs/write-ups/NewbornOutcomes.docx
+++ b/docs/write-ups/NewbornOutcomes.docx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b86e91a8bd336a09e9aa55e4f03ce6a41bc062e6b5d5ee51ef044ed3bec77264
-size 395887

--- a/docs/write-ups/PostnatalSupervisor.docx
+++ b/docs/write-ups/PostnatalSupervisor.docx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f1956bd6ae8a66ed8f7a9dce8a3a675166c906ec4f1959f3ef336d7d660f9ef
-size 285655

--- a/docs/write-ups/PregnancySupervisor.docx
+++ b/docs/write-ups/PregnancySupervisor.docx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82be768077e4933feac49ea9be676adc5df548639ddc3225929a9ffa650e76a2
-size 476845


### PR DESCRIPTION
This PR removes old versions of the documentation for the maternal health modules. The correct version remains in the docs folder.