### PR TITLE
Add CLI command for combining batch runs

### DIFF
--- a/src/tlo/cli.py
+++ b/src/tlo/cli.py
@@ -838,16 +838,14 @@ def add_tasks(batch_service_client, user_identity, job_id,
     nargs=-1,
     type=click.Path(exists=True, file_okay=False, path_type=Path),
 )
-def combine_runs(
-    output_results_directory: Path, additional_result_directories: tuple[Path]
-) -> None:
+def combine_runs(output_results_directory: Path, additional_result_directories: tuple[Path]) -> None:
     """Combine runs from multiple batch jobs locally.
-    
+
     Merges runs from each draw in one or more additional results directories in
     to corresponding draws in output results directory.
-    
+
     All results directories must contain same draw numbers and the draw numbers
-    must be consecutive integers starting from 0. All run numbers in the output 
+    must be consecutive integers starting from 0. All run numbers in the output
     result directory draw directories must be consecutive integers starting
     from 0.
     """
@@ -878,7 +876,7 @@ def combine_runs(
     ]
     for runs in runs_per_draw:
         if not runs == list(range(len(runs))):
-            msg = "All runs in output directory be consecutively numbered from 0."
+            msg = "All runs in output directory must be consecutively numbered from 0."
             raise click.UsageError(msg)
     for results_directory in additional_result_directories:
         for draw in draws:

--- a/src/tlo/cli.py
+++ b/src/tlo/cli.py
@@ -855,7 +855,9 @@ def combine_runs(output_results_directory: Path, additional_result_directories: 
     results_directories = (output_results_directory,) + additional_result_directories
     draws_per_directory = [
         sorted(
-            int(draw_directory.name) for draw_directory in results_directory.iterdir()
+            int(draw_directory.name)
+            for draw_directory in results_directory.iterdir()
+            if draw_directory.is_dir()
         )
         for results_directory in results_directories
     ]
@@ -871,6 +873,7 @@ def combine_runs(output_results_directory: Path, additional_result_directories: 
         sorted(
             int(run_directory.name)
             for run_directory in (output_results_directory / str(draw)).iterdir()
+            if run_directory.is_dir()
         )
         for draw in draws
     ]
@@ -882,12 +885,12 @@ def combine_runs(output_results_directory: Path, additional_result_directories: 
         for draw in draws:
             run_counter = len(runs_per_draw[draw])
             for source_path in sorted((results_directory / str(draw)).iterdir()):
-                destination_path = (
-                    output_results_directory / str(draw) / str(run_counter)
-                )
+                if not source_path.is_dir():
+                    continue
+                destination_path = output_results_directory / str(draw) / str(run_counter)
                 run_counter = run_counter + 1
                 copytree(source_path, destination_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli(obj={})


### PR DESCRIPTION
Following question from @BinglingICL on Slack, this PR adds a command to CLI interface for combining the runs from multiple batch jobs, with the assumption that the draws are aligned across the jobs (and different seeds used for runs). It does some basic checks to ensure same draw numbers across different results directories, and that run numbers in base results directory that additional runs are being merged into are consecutively numbered from 0, with the additional runs then being added with further consecutive run numbers.

