### PR TITLE
Tara hiv cons fix dec2024

### DIFF
--- a/src/scripts/hiv/projections_jan2023/analysis_logged_deviance.py
+++ b/src/scripts/hiv/projections_jan2023/analysis_logged_deviance.py
@@ -70,7 +70,7 @@ sim.register(
         resourcefilepath=resourcefilepath,
         service_availability=["*"],  # all treatment allowed
         mode_appt_constraints=1,  # mode of constraints to do with officer numbers and time
-        cons_availability="all",  # mode for consumable constraints (if ignored, all consumables available)
+        cons_availability="default",  # mode for consumable constraints (if ignored, all consumables available)
         ignore_priority=False,  # do not use the priority information in HSI event to schedule
         capabilities_coefficient=1.0,  # multiplier for the capabilities of health officers
         use_funded_or_actual_staffing="actual",  # actual: use numbers/distribution of staff available currently

--- a/src/tlo/methods/enhanced_lifestyle.py
+++ b/src/tlo/methods/enhanced_lifestyle.py
@@ -661,7 +661,7 @@ class LifestyleModels:
         :param df: The population dataframe """
         # get months since last poll
         now = self.module.sim.date
-        months_since_last_poll = round((now - self.date_last_run) / np.timedelta64(1, "W"))
+        months_since_last_poll = round((now - self.date_last_run) / np.timedelta64(1, "M"))
         # loop through linear models dictionary and initialise each property in the population dataframe
         for _property_name, _model in self._models.items():
             if _model['update'] is not None:

--- a/src/tlo/methods/enhanced_lifestyle.py
+++ b/src/tlo/methods/enhanced_lifestyle.py
@@ -661,7 +661,7 @@ class LifestyleModels:
         :param df: The population dataframe """
         # get months since last poll
         now = self.module.sim.date
-        months_since_last_poll = round((now - self.date_last_run) / np.timedelta64(1, "M"))
+        months_since_last_poll = round((now - self.date_last_run) / np.timedelta64(1, "W"))
         # loop through linear models dictionary and initialise each property in the population dataframe
         for _property_name, _model in self._models.items():
             if _model['update'] is not None:

--- a/src/tlo/methods/hiv.py
+++ b/src/tlo/methods/hiv.py
@@ -2497,8 +2497,9 @@ class HSI_Hiv_Circ(HSI_Event, IndividualScopeEventMixin):
         test_result = self.sim.modules["HealthSystem"].dx_manager.run_dx_test(
             dx_tests_to_run="hiv_rapid_test", hsi_event=self
         )
-        df.at[person_id, "hv_number_tests"] += 1
-        df.at[person_id, "hv_last_test_date"] = self.sim.date
+        if test_result is not None:
+            df.at[person_id, "hv_number_tests"] += 1
+            df.at[person_id, "hv_last_test_date"] = self.sim.date
 
         # if person not circumcised, perform the procedure
         if not person["li_is_circ"]:
@@ -2842,8 +2843,9 @@ class HSI_Hiv_StartOrContinueTreatment(HSI_Event, IndividualScopeEventMixin):
             test_result = self.sim.modules["HealthSystem"].dx_manager.run_dx_test(
                 dx_tests_to_run="hiv_rapid_test", hsi_event=self
             )
-            df.at[person_id, "hv_number_tests"] += 1
-            df.at[person_id, "hv_last_test_date"] = self.sim.date
+            if test_result is not None:
+                df.at[person_id, "hv_number_tests"] += 1
+                df.at[person_id, "hv_last_test_date"] = self.sim.date
 
             # Assign person to be suppressed or un-suppressed viral load
             # (If person is VL suppressed This will prevent the Onset of AIDS, or an AIDS death if AIDS has already

--- a/src/tlo/methods/hiv.py
+++ b/src/tlo/methods/hiv.py
@@ -2830,6 +2830,14 @@ class HSI_Hiv_StartOrContinueTreatment(HSI_Event, IndividualScopeEventMixin):
 
         # ART is first item in drugs_available dict
         if drugs_available.get('art', False):
+
+            # get confirmatory test
+            test_result = self.sim.modules["HealthSystem"].dx_manager.run_dx_test(
+                dx_tests_to_run="hiv_rapid_test", hsi_event=self
+            )
+            df.at[person_id, "hv_number_tests"] += 1
+            df.at[person_id, "hv_last_test_date"] = self.sim.date
+
             # Assign person to be suppressed or un-suppressed viral load
             # (If person is VL suppressed This will prevent the Onset of AIDS, or an AIDS death if AIDS has already
             # onset)

--- a/src/tlo/methods/hiv.py
+++ b/src/tlo/methods/hiv.py
@@ -2493,6 +2493,13 @@ class HSI_Hiv_Circ(HSI_Event, IndividualScopeEventMixin):
         if not person["is_alive"]:
             return
 
+        # get confirmatory test
+        test_result = self.sim.modules["HealthSystem"].dx_manager.run_dx_test(
+            dx_tests_to_run="hiv_rapid_test", hsi_event=self
+        )
+        df.at[person_id, "hv_number_tests"] += 1
+        df.at[person_id, "hv_last_test_date"] = self.sim.date
+
         # if person not circumcised, perform the procedure
         if not person["li_is_circ"]:
             # Check/log use of consumables, if materials available, do circumcision and schedule follow-up appts

--- a/src/tlo/methods/tb.py
+++ b/src/tlo/methods/tb.py
@@ -2483,6 +2483,7 @@ class HSI_Tb_Start_or_Continue_Ipt(HSI_Event, IndividualScopeEventMixin):
         self.number_of_occurrences += 1
 
         df = self.sim.population.props  # shortcut to the dataframe
+        now = self.sim.date
 
         person = df.loc[person_id]
 
@@ -2494,6 +2495,19 @@ class HSI_Tb_Start_or_Continue_Ipt(HSI_Event, IndividualScopeEventMixin):
         ):
             return
 
+        # refer for HIV testing: all ages
+        # do not run if already HIV diagnosed or had test in last week
+        if not person["hv_diagnosed"] or (person["hv_last_test_date"] >= (now - DateOffset(days=7))):
+            self.sim.modules["HealthSystem"].schedule_hsi_event(
+                hsi_event=hiv.HSI_Hiv_TestAndRefer(
+                    person_id=person_id,
+                    module=self.sim.modules["Hiv"],
+                    referred_from="Tb",
+                ),
+                priority=1,
+                topen=now,
+                tclose=None,
+            )
         # if currently have symptoms of TB, refer for screening/testing
         persons_symptoms = self.sim.modules["SymptomManager"].has_what(person_id=person_id)
         if any(x in self.module.symptom_list for x in persons_symptoms):


### PR DESCRIPTION
To address issue #1539 - expenditure on HIV tests 1.6x higher than model estimates:
1. include an additional HIV test at ART initiation (1.6% increase in number of HIV tests)
2. prior to performing VMMC (4.6% increase in tests, including increase from step 1)
3. prior to starting IPT for TB prevention (7.3% increase, including increases from steps 1 and 2)

