### PR TITLE
Tara malaria cons fix dec2024

### DIFF
--- a/resources/costing/~$ResourceFile_Costing.xlsx
+++ b/resources/costing/~$ResourceFile_Costing.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:019349b15c524cfef4b39db4dd792de3376f4bc3da9b6b298a1fee07c4eb219e
+size 165

--- a/resources/costing/~$ResourceFile_Costing.xlsx
+++ b/resources/costing/~$ResourceFile_Costing.xlsx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:019349b15c524cfef4b39db4dd792de3376f4bc3da9b6b298a1fee07c4eb219e
-size 165

--- a/resources/healthsystem/consumables/ResourceFile_Consumables_availability_small.csv
+++ b/resources/healthsystem/consumables/ResourceFile_Consumables_availability_small.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c358a643e4def0e574b75f89f83d77f9c3366f668422e005150f4d69ebe8d7a7
-size 6169152
+oid sha256:8bf105eb266c173feaef4068d100af4ea51f2542c3cac9505a704abade360820
+size 6202574

--- a/resources/healthsystem/consumables/ResourceFile_consumables_matched.csv
+++ b/resources/healthsystem/consumables/ResourceFile_consumables_matched.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5b0f417681cbdd2489e2f9c6634b2825c32beb9637dc045b56e308c910a102c
-size 90569
+oid sha256:793e3b2a94949fdf025bb5297de40a0092c41ad61f6fa0a4de4898de5cfdf2f3
+size 90677

--- a/src/scripts/malaria/analysis_malaria.py
+++ b/src/scripts/malaria/analysis_malaria.py
@@ -35,7 +35,7 @@ resourcefilepath = Path("./resources")
 
 start_date = Date(2010, 1, 1)
 end_date = Date(2014, 1, 1)
-popsize = 100
+popsize = 1000
 
 
 # set up the log config

--- a/src/tlo/methods/malaria.py
+++ b/src/tlo/methods/malaria.py
@@ -1245,26 +1245,32 @@ class HSI_Malaria_Treatment(HSI_Event, IndividualScopeEventMixin):
         # non-complicated malaria
         if age_of_person < 5:
             # Formulation for young children
+            # 5–14kg: 1 tablet(120mg Lumefantrine / 20mg Artemether) every 12 hours for 3 days
+            # paracetamol syrup in 1ml doses, 10ml 4x per day, 3 days
             drugs_available = self.get_consumables(
-                item_codes=self.module.item_codes_for_consumables_required['malaria_uncomplicated_young_children'],
-                optional_item_codes=[self.module.item_codes_for_consumables_required['paracetamol_syrup'],
-                                     self.module.item_codes_for_consumables_required['malaria_rdt']]
+                item_codes={self.module.item_codes_for_consumables_required['malaria_uncomplicated_young_children']: 6},
+                optional_item_codes=[{self.module.item_codes_for_consumables_required['paracetamol_syrup']: 120},
+                                     {self.module.item_codes_for_consumables_required['malaria_rdt']: 1}]
             )
 
         elif 5 <= age_of_person <= 15:
             # Formulation for older children
+            # 35–44 kg: 4 tablets every 12 hours for 3 days
+            # paracetamol syrup in 1ml doses, 15ml 4x per day, 3 days
             drugs_available = self.get_consumables(
-                item_codes=self.module.item_codes_for_consumables_required['malaria_uncomplicated_older_children'],
-                optional_item_codes=[self.module.item_codes_for_consumables_required['paracetamol_syrup'],
-                                     self.module.item_codes_for_consumables_required['malaria_rdt']]
+                item_codes={self.module.item_codes_for_consumables_required['malaria_uncomplicated_older_children']: 24},
+                optional_item_codes=[{self.module.item_codes_for_consumables_required['paracetamol_syrup']: 180},
+                                     {self.module.item_codes_for_consumables_required['malaria_rdt']: 1}]
             )
 
         else:
             # Formulation for adults
+            # 4 tablets every 12 hours for 3 day
+            # paracetamol in 1 mg doses, 4g per day for 3 days
             drugs_available = self.get_consumables(
-                item_codes=self.module.item_codes_for_consumables_required['malaria_uncomplicated_adult'],
-                optional_item_codes=[self.module.item_codes_for_consumables_required['paracetamol'],
-                                     self.module.item_codes_for_consumables_required['malaria_rdt']]
+                item_codes={self.module.item_codes_for_consumables_required['malaria_uncomplicated_adult']: 24},
+                optional_item_codes=[{self.module.item_codes_for_consumables_required['paracetamol']: 12_000},
+                                     {self.module.item_codes_for_consumables_required['malaria_rdt']: 1}]
             )
 
         return drugs_available

--- a/src/tlo/methods/malaria.py
+++ b/src/tlo/methods/malaria.py
@@ -654,7 +654,7 @@ class Malaria(Module, GenericFirstAppointmentsMixin):
 
         # malaria IPTp for pregnant women
         self.item_codes_for_consumables_required['malaria_iptp'] = get_item_code(
-            'Sulfamethoxazole + trimethropin, tablet 400 mg + 80 mg'
+            'Fansidar (sulphadoxine / pyrimethamine tab)'
         )
 
     def update_parameters_for_program_scaleup(self):
@@ -1365,6 +1365,7 @@ class HSI_MalariaIPTp(HSI_Event, IndividualScopeEventMixin):
                      data=f'HSI_MalariaIPTp: requesting IPTp for person {person_id}')
 
         # request the treatment
+        # dosage is one tablet
         if self.get_consumables(self.module.item_codes_for_consumables_required['malaria_iptp']):
             logger.debug(key='message',
                          data=f'HSI_MalariaIPTp: giving IPTp for person {person_id}')


### PR DESCRIPTION
PR addresses Issue #1539 for malaria consumables:

- changed IPTp consumables to Fansidar (was incorrectly listed in ResourceFile_Consumables_Items_and_Packages.csv as "Sulfamethoxazole + trimethropin, tablet 400 mg + 80 mg" under entry IPTP for pregnant women. This is also known as cotrimoxazole).
- add in corrected doses for all antimalarials and paracetamol by age-groups
- following injectable artesunate use for treating severe malaria, follow-up with outpatient appointment to deliver ACT as per guidelines

This will collectively increase the amount of anti-malarial (and paracetamol) prescribed quite significantly. 

Notes:
@sakshimohan: 
- please check Fansidar is also listed in the availability database and costing sheets
- when looking at expenditure on cotrimoxazole, we probably need to combine both cotrimoxazole and Sulfamethoxazole + trimethropin before comparing to TLO model outputs