### PR TITLE
Remove storage of incidence data as parameters in malaria.py to reduce memory usage

### DIFF
--- a/src/tlo/methods/malaria.py
+++ b/src/tlo/methods/malaria.py
@@ -70,7 +70,6 @@ class Malaria(Module, GenericFirstAppointmentsMixin):
     }
 
     PARAMETERS = {
-        'interv': Parameter(Types.REAL, 'data frame of intervention coverage by year'),
         'itn_district': Parameter(
             Types.REAL, 'data frame of ITN usage rates by district'
         ),
@@ -235,7 +234,6 @@ class Malaria(Module, GenericFirstAppointmentsMixin):
         p = self.parameters
 
         # baseline characteristics
-        p['interv'] = workbook['interventions']
         p['itn_district'] = workbook['MAP_ITNrates']
         p['irs_district'] = workbook['MAP_IRSrates']
 

--- a/src/tlo/methods/malaria.py
+++ b/src/tlo/methods/malaria.py
@@ -71,18 +71,6 @@ class Malaria(Module, GenericFirstAppointmentsMixin):
 
     PARAMETERS = {
         'interv': Parameter(Types.REAL, 'data frame of intervention coverage by year'),
-        'clin_inc': Parameter(
-            Types.REAL,
-            'data frame of clinical incidence by age, district, intervention coverage',
-        ),
-        'inf_inc': Parameter(
-            Types.REAL,
-            'data frame of infection incidence by age, district, intervention coverage',
-        ),
-        'sev_inc': Parameter(
-            Types.REAL,
-            'data frame of severe case incidence by age, district, intervention coverage',
-        ),
         'itn_district': Parameter(
             Types.REAL, 'data frame of ITN usage rates by district'
         ),
@@ -255,9 +243,9 @@ class Malaria(Module, GenericFirstAppointmentsMixin):
         p['rdt_testing_rates'] = workbook['WHO_TestData2023']
         p['highrisk_districts'] = workbook['highrisk_districts']
 
-        p['inf_inc'] = pd.read_csv(self.resourcefilepath / 'malaria' / 'ResourceFile_malaria_InfInc_expanded.csv')
-        p['clin_inc'] = pd.read_csv(self.resourcefilepath / 'malaria' / 'ResourceFile_malaria_ClinInc_expanded.csv')
-        p['sev_inc'] = pd.read_csv(self.resourcefilepath / 'malaria' / 'ResourceFile_malaria_SevInc_expanded.csv')
+        inf_inc_sheet = pd.read_csv(self.resourcefilepath / 'malaria' / 'ResourceFile_malaria_InfInc_expanded.csv')
+        clin_inc_sheet = pd.read_csv(self.resourcefilepath / 'malaria' / 'ResourceFile_malaria_ClinInc_expanded.csv')
+        sev_inc_sheet = pd.read_csv(self.resourcefilepath / 'malaria' / 'ResourceFile_malaria_SevInc_expanded.csv')
 
         # load parameters for scale-up projections
         p['scaleup_parameters'] = workbook["scaleup_parameters"]
@@ -296,13 +284,13 @@ class Malaria(Module, GenericFirstAppointmentsMixin):
         # ===============================================================================
         # put the all incidence data into single table with month/admin/llin/irs index
         # ===============================================================================
-        inf_inc = p['inf_inc'].set_index(['month', 'admin', 'llin', 'irs', 'age'])
+        inf_inc = inf_inc_sheet.set_index(['month', 'admin', 'llin', 'irs', 'age'])
         inf_inc = inf_inc.loc[:, ['monthly_prob_inf']]
 
-        clin_inc = p['clin_inc'].set_index(['month', 'admin', 'llin', 'irs', 'age'])
+        clin_inc = clin_inc_sheet.set_index(['month', 'admin', 'llin', 'irs', 'age'])
         clin_inc = clin_inc.loc[:, ['monthly_prob_clin']]
 
-        sev_inc = p['sev_inc'].set_index(['month', 'admin', 'llin', 'irs', 'age'])
+        sev_inc = sev_inc_sheet.set_index(['month', 'admin', 'llin', 'irs', 'age'])
         sev_inc = sev_inc.loc[:, ['monthly_prob_sev']]
 
         all_inc = pd.concat([inf_inc, clin_inc, sev_inc], axis=1)

--- a/tests/test_malaria.py
+++ b/tests/test_malaria.py
@@ -711,11 +711,8 @@ def test_linear_model_for_clinical_malaria(sim):
     # set perfect protection for IPTp against clinical malaria - no cases should occur
     sim.modules['Malaria'].parameters['rr_clinical_malaria_iptp'] = 0
 
-    # set clinical incidence probability to very high value
-    sim.modules['Malaria'].parameters['clin_inc']['monthly_prob_clin'] = 0.99
-
     # Run the simulation and flush the logger
-    sim.make_initial_population(n=10)
+    sim.make_initial_population(n=25)
     # simulate for 0 days, just get everything set up (dxtests etc)
     sim.simulate(end_date=sim.date + pd.DateOffset(days=0))
 
@@ -723,6 +720,8 @@ def test_linear_model_for_clinical_malaria(sim):
 
     # make the whole population infected with parasitaemia
     # and therefore eligible for clinical/severe malaria poll
+    df.loc[df.is_alive, "district_of_residence"] = "Balaka"  # put everyone in high-risk district
+    df.loc[df.is_alive, "district_num_of_residence"] = 28
     df.loc[df.is_alive, "ma_is_infected"] = True
     df.loc[df.is_alive, "ma_date_infected"] = sim.date
     df.loc[df.is_alive, "ma_inf_type"] = "asym"


### PR DESCRIPTION
@tdm32 @tamuri - had some time to look at this and simply swapped out the use of self.parameters for a local variable in the function where this data is used as per Asif's suggestion. Malaria tests running fine for me locally. Let me know if theres other tweaks I can make to save Tara a job. 

This addresses #1538 