### PR TITLE
Add ECSA-HC link to list of collaborators

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ TLOmodel is developed in a collaboration between:
 - [Institute for Global Health][igh-link], [University College London][ucl-link]
 - [Centre for Advanced Research Computing][arc-link], [University College London][ucl-link]
 - [Centre for Health Economics][che-link], [University of York][york-link]
+- [East, Central, and Southern African Health Community][ecsa-hc-link]
 
 It benefits from a close partnership between this team and the Ministry of Health, Malawi.
 
@@ -57,4 +58,5 @@ This work has been funded by grants from [Wellcome](https://wellcome.org/),
 [arc-link]: https://www.ucl.ac.uk/arc
 [york-link]: https://www.york.ac.uk/
 [che-link]: https://www.york.ac.uk/che/
+[ecsea-hc-link]: https://ecsahc.org/
 [contributors-link]: https://www.tlomodel.org/contributors.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,8 @@ It is developed in a collaboration between:
 
 * `University of York <https://www.york.ac.uk/che/>`_
 
+* `East, Central and Southern Africa Health Community (ECSA-HC) <https://ecsahc.org/>`_
+
 It benefits from a close partnership between this team and the Ministry of Health, Malawi.
 
 


### PR DESCRIPTION
Adds link to ECSA-HC website to list of collaborators involve in TLOmodel project in both top-level README and welcome page of website.