### PR TITLE
Compute district scaling factors

### DIFF
--- a/src/scripts/hiv/projections_jan2023/analysis_logged_deviance.py
+++ b/src/scripts/hiv/projections_jan2023/analysis_logged_deviance.py
@@ -34,8 +34,8 @@ resourcefilepath = Path("./resources")
 
 # %% Run the simulation
 start_date = Date(2010, 1, 1)
-end_date = Date(2014, 1, 1)
-popsize = 25000
+end_date = Date(2013, 1, 1)
+popsize = 2000
 
 # scenario = 1
 
@@ -63,7 +63,7 @@ seed = random.randint(0, 50000)
 # seed = 41728  # set seed for reproducibility
 sim = Simulation(start_date=start_date, seed=seed, log_config=log_config, show_progress_bar=True)
 sim.register(
-    demography.Demography(resourcefilepath=resourcefilepath),
+    demography.Demography(resourcefilepath=resourcefilepath, equal_allocation_by_district=True),
     simplified_births.SimplifiedBirths(resourcefilepath=resourcefilepath),
     enhanced_lifestyle.Lifestyle(resourcefilepath=resourcefilepath),
     healthsystem.HealthSystem(

--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -342,7 +342,7 @@ class Demography(Module):
                             'multiply-up results so that they correspond to the real population size.'
             )
             if self.equal_allocation_by_district:
-                scaling_factor_district = 1.0 / self.initial_model_to_data_popsize_ratio
+                scaling_factor_district = 1.0 / self.initial_model_to_data_popsize_ratio_district
                 _logger.warning(
                     key='scaling_factor_district',
                     data={'scaling_factor_district': scaling_factor_district.to_dict()},


### PR DESCRIPTION
With demography module argument "equal_allocation_by_district" we need to also compute the scaling factors by district. This PR calculates those district-level scaling factors and writes them to the demography logger and to tlo.methods.population logger.

Notes: 
- if equal_allocation_by_district=False, the district-level scaling factors are not logged
- the bed days scaled capacity and capabilities_coefficient uses the original scaling factor and doesn't scale by district

Next steps:

- [ ] need to update extract_results function to use the district_level scaling factors where appropriate 
- [ ] also calculations of deaths and DALYs need to be scaled by district