### PR TITLE
Rollback pyinstrument to v4.5.3 to resolve memory issues in profiling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = [
     # Profiling
     "ansi2html",
     "psutil",
-    "pyinstrument>=4.7",
+    "pyinstrument>=4.3",
     # Building requirements files
     "pip-tools",
 ]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -164,7 +164,7 @@ psutil==5.9.5
     # via tlo (pyproject.toml)
 pycparser==2.21
     # via cffi
-pyinstrument==4.7.3
+pyinstrument==4.5.3
     # via tlo (pyproject.toml)
 pyjwt[crypto]==2.8.0
     # via

--- a/src/scripts/profiling/run_profiling.py
+++ b/src/scripts/profiling/run_profiling.py
@@ -306,7 +306,6 @@ def run_profiling(
             timeline=False,
             color=True,
             flat=True,
-            flat_time="total",
             processor_options={"show_regex": ".*/tlo/.*", "hide_regex": ".*/pandas/.*", "filter_threshold": 1e-3}
         )
         converter = Ansi2HTMLConverter(title=output_name)


### PR DESCRIPTION
Reverts most of changes in #1466 (other than changing some processing options for flat HTML output).

It appears that in `pyinstrument` v4.7 and above we get continual fast growing memory usage during profiling runs, which is causing out of memory issues on GitHub Actions runs. This seems to not have been resolved in the latest `pyinstrument` v5.0 as also seeing same pattern of increasing memory there too.

Memory usage plots when running
```
python src/scripts/profiling/run_profiling.py -y 2 -m 0 -p 10000 --show-progress-bar --flat-html --html
```

with `pyinstrument==4.3`
![mem-graph-after-pyinstrument-4 3](https://github.com/user-attachments/assets/57e6afcd-6179-44b6-a48b-2aaa86d13aee)

with `pyinstrument==4.7`
![mem-graph-after-pyinstrument-4 7](https://github.com/user-attachments/assets/d1b83c83-993f-448b-8d41-6c68ca093ca6)

with `pyinstrument==5.0`
![mem-graph-after-pyinstrument-5 0](https://github.com/user-attachments/assets/9e2cdca7-43a7-4341-a98e-a709b83b4be4)
