### PR TITLE
Make `setuptools-scm` look for versions only in v[digit] prefixed tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,3 +127,4 @@ where = ["src"]
 
 [tool.setuptools_scm]
 version_file  = "src/tlo/_version.py"
+git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", 'v[0-9]*']


### PR DESCRIPTION
Should resolve #1561

Changes `setuptools_scm` configuration option `git_describe_command` from [default value](https://setuptools-scm.readthedocs.io/en/latest/config/#setuptools_scm.git.DEFAULT_DESCRIBE) which uses glob pattern `*[0-9]*` to match possible versions from tags to instead use more specific glob pattern `v[0-9]*` which will only match tags which start with `v` then a digit which should hopefully avoid spurious matches such as to `prof1` which was causing issue in #1561. With this change running `python -m setuptools_scm` locally succeeds (while was previously failing) as does running `tox -e check`.

