### PR TITLE
Adding HEPU videos page to docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,8 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
-    'rawfiles'
+    'rawfiles',
+    'sphinxcontrib.youtube',
 ]
 
 if os.getenv('SPELLCHECK'):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,7 @@ Contents
    resources/index
    parameters
    learning
+   videos
    publications
    contributors
    contributing

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx>=1.3
 sphinx-rtd-theme
+sphinxcontrib-youtube
 pybtex
 pyyaml
 requests

--- a/docs/videos.rst
+++ b/docs/videos.rst
@@ -1,0 +1,85 @@
+===========
+HEPU Videos
+===========
+
+The *Health Economics and Policy Unit* (HEPU) is a unit within the Department of Health Systems 
+under the School of Global and Public Health at the Kamuzu University of Health Sciences. 
+It was established in 2018 with support from the Thanzi La Onse Program with the aim of promoting demand, 
+generation and use of health economics evidence in health policy and decision making.
+
+Background: Thanzi La Mawa Project
+==================================
+
+A video exploring the Thanzi La Mawa project, led by Prof Tim Hallett at Imperial. 
+In response to the need for more evidence to support resource allocation decision making processes in Malawi, 
+researchers and modellers have partnered with Kamuzu University of Health Sciences, led by Prof Joseph Mfutso-Bengo, 
+to develop a 'whole system and all-disease model' for the Malawi health system. 
+Discover how their findings could potentially revolutionize healthcare practices and policies, 
+ultimately benefiting millions of Malawians.
+
+..  youtube:: dazYfnhaNOw
+   :align: center
+
+Training and Capacity Building
+==============================
+
+A modelling short course was held in Blantyre, Malawi, from 23-26 September 2024, 
+hosted by the Health Economics and Policy Unit of Kamuzu University of Health Sciences 
+in collaboration with Imperial and University College London. 
+This course marks a significant milestone for health education in Malawi, 
+empowering local professionals with advanced modelling skills 
+to strengthen the capacity of Malawi's health systems in responding to future challenges.
+
+..  youtube:: T5WvzDFpuF4
+   :align: center
+
+Policy Think Tanks
+==================
+
+**HEPU 9th Extraordinary Think Tank Conference, Launch of Thanzi La Mawa Program.**
+
+..  youtube:: 6HCJVFV-gGI
+   :align: center
+
+**HEPU 12th Extraordinary Think Tank Conference, Christian Health Association of Malawi Service Level Agreement Value for Money Evaluation.**
+
+..  youtube:: Ce_iLowNwIQ
+   :align: center
+
+**HEPU 13th Extraordinary Think Tank Conference, Progress of the Direct Facility Financing and Financial Risk Management.**
+
+..  youtube:: tTp6FprPRGs
+   :align: center
+
+Research Seminars 
+=================
+
+**86th Research Seminar, Institutionalization of Health Technology Assessment in Malawi: A Progress Update with Dr. Lucky Ngwira.**
+
+..  youtube:: hcRNwU-SA98
+   :align: center
+
+3rd KUHeS Research Dissemination Conference
+-------------------------------------------
+
+**Performance of Pooled Donor Funding to Support the Malawi Health Service Strategic Plans in the Context of Suspended Direct Budgetary Support.**
+
+..  youtube:: RFTmfkvUbNg
+   :align: center
+
+**Advancing Universal Health Coverage: Assessing the Efficiency of Contracting Not-for-Profit Faith-Based Healthcare Providers in Malawi.**
+
+..  youtube:: RMUItOZTtWg
+   :align: center
+
+**Improved Community Governance and Public Financial Management Outcomes: Direct Facility Financing Evaluation.**
+
+..  youtube:: YqbRT3CNVQY
+   :align: center
+
+**Demonstrating the Use of VEDMAP Framework as a Research Tool for Value-Mapping and Value-Implementation Fidelity-Assessment: 
+A Case of Feasibility Study of Health Technology Assessment in Malawi.**
+
+..  youtube:: u4CZcBqRRoA
+   :align: center
+   


### PR DESCRIPTION
Adds a top-level page to documentation embedding HEPU YouTube videos plus some associated description, with content by @imperialkate . Uses [`sphinxcontrib-youtube` plugin](https://sphinxcontrib-youtube.readthedocs.io) to add reStructuredText directive for embedding YouTube videos.