### PR TITLE
Adding case studies to website

### DIFF
--- a/docs/case-studies/fcdo/header.jpg
+++ b/docs/case-studies/fcdo/header.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebce4f3b76e72195a9568f67251153cbb89329b4f75f31b715764d6b5b9db397
+size 84321

--- a/docs/case-studies/fcdo/htm-programs-roi.png
+++ b/docs/case-studies/fcdo/htm-programs-roi.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4abc393e66e86d268e6166c30eb9cb9fe3fe97838e7a1b3c0cc10daaddfc344
+size 120394

--- a/docs/case-studies/fcdo/htm-programs-roi.png
+++ b/docs/case-studies/fcdo/htm-programs-roi.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4abc393e66e86d268e6166c30eb9cb9fe3fe97838e7a1b3c0cc10daaddfc344
-size 120394
+oid sha256:d8b1a347a734a23528a2d0fc55bf7028c993448dbd32169c7f65b71634b1bd12
+size 589870

--- a/docs/case-studies/fcdo/index.rst
+++ b/docs/case-studies/fcdo/index.rst
@@ -1,0 +1,37 @@
+=================================================================================================================
+The Health Impact of Investments in Vertical Programs and Broader Health System Development: Findings from Malawi 
+=================================================================================================================
+
+*Tara Mangal and Sakshi Mohan et al.*
+
+.. image:: header.jpg
+  :width: 100%
+  :alt: View of exterior of an accident and emergency hospital department in Malawi
+
+Investments in vertical programs for HIV, tuberculosis (TB), and malaria (HTM) have driven substantial public health improvements in low- and middle-income countries. 
+However, their effectiveness can be limited by challenges within broader health systems, such as insufficient human resources, unreliable supply chains, and inadequate infrastructure. 
+This study evaluates the independent and combined health impacts of HTM program scale-up and investments in broader health system development in Malawi, using the *Thanzi La Onse* (TLO) model.  
+   
+One finding is that increasing the number of healthcare workers by 6% each year could prevent up to 14% of *disability-adjusted life years* (DALYs). 
+Focusing on primary healthcare workers alone could prevent about 5% of DALYs. 
+Improving the availability of medical supplies to the standards seen in top-performing programs, like the *Expanded Program on Immunization* (EPI), could also prevent 9% of DALYs.
+
+These impacts are large relative to the additional cost required: 
+the 'return-on-investment' (ROI) from scaling the healthcare workforce across all facility levels could generate an ROI as high as a factor of &times;8. 
+Additionally, improving supply chains to reduce stockouts and ensure reliable service delivery showed a strong ROI, further emphasizing the importance of a well-functioning healthcare system.
+
+While targeted programs to reduce diseases such as HIV, tuberculosis, and malaria showed some effectiveness, this study found that the gains were limited by a shortage of healthcare workers and resources. 
+However, when investments in these disease-specific programs (HTM) were combined with broader system improvements, the reduction in DALYs was 12% greater compared to focusing on HTM alone.
+This joint approach could help avert an estimated 23.4 million DALYs, with 70% of the benefits coming from reductions in diseases beyond those directly targeted by HTM programs.
+The ROI of a joint approach - combined HTM scale-up with health system strengthening - would be much greater than an approach that focussed only on HTM (see Figure).
+
+Thus, this study shows that a combined investment in both targeted disease programs and broader healthcare system improvements can be more efficient and impactful in reducing illness and disability. 
+
+.. figure:: htm-programs-roi.png
+   :class: with-border
+
+   The return on investment for HTM programs, with and without concurrent broader health system investments (HSS),
+   is presented with thresholds of US$0, US$1 billion, and US$3 billion for comparison.
+   Inset: the DALYs averted relative to Baseline for scenarios involving broader health system investments alone, HTM programs alone, and combined investments in vertical and horizontal approaches. 
+   Boxed values indicate life expectancy gains in 2035 compared with the Baseline for males and females. 
+   Percentage DALYs averted over the 11-year period compared to Baseline are annotated above each bar.

--- a/docs/case-studies/hbp-design/header.jpg
+++ b/docs/case-studies/hbp-design/header.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57395fb84b4fc6e10e1ca8e5467eaf1dc0ef90ca003fc323a74defb679c78518
+size 72953

--- a/docs/case-studies/hbp-design/index.rst
+++ b/docs/case-studies/hbp-design/index.rst
@@ -1,0 +1,31 @@
+======================================================================================================
+A new approach to Health Benefits Package design: an application of the Thanzi La Onse model in Malawi
+======================================================================================================
+
+*Margherita Molaro et al.*
+
+.. image:: header.jpg
+  :width: 100%
+  :alt: View of noticeboard with poster headed 'Paediatric ward annual report' with table of major causes of admissions and death
+
+How should limited resources be allocated to achieve the greatest possible return in health?
+All publicly funded healthcare systems face difficult decisions about how limited resources should be allocated to achieve the greatest possible return in health.
+These decisions are particularly pressing in *lower-income countries* (LICs) like Malawi, where resources are extremely limited and their inefficient allocation could result in larger morbidity and mortality. 
+
+An efficient allocation of limited resources in low-income settings offers the opportunity to improve population-health outcomes given the available health system capacity. 
+Efforts to achieve this are often framed through the lens of *health benefits packages* (HBPs), which seek to establish which services the public healthcare system should include in its provision. 
+
+This study explores the effectiveness of different healthcare policies in improving health outcomes when resources are limited and uses a new analytical tool to inform such decisions based on an "all diseases, whole healthcare system" simulation specifically tailored to Malawi: the *Thanzi La Onse* (TLO) model. 
+By modelling the incidence of disease, health-seeking behaviour, and the capacity of the healthcare system to meet the demand for care under realistic constraints on human resources for health available, we were able to simulate the health gains achievable under several plausible HBP strategies for Malawi.   
+
+Three of the proposed policies - LCOA (the current standard approach, *linear constrained optimization analysis*), CV (focussing on those *clinically vulnerable*), and VP (focussing on *vertical programmes* for HIV, tuberculosis and malaria and routine immunization) - showed greater overall health benefit compared to the NP (*no policy*) scenario where no prioritization is applied. 
+Among these, the LCOA policy actually achieved the largest relative health gain - approximately 8% reduction in *disability adjusted life years* (DALYs) between 2023 and 2042 compared to the NP scenario—by concentrating resources on high-impact treatments. 
+
+On the other hand, the study also found that some policies did not perform well. For example, the reproductive, maternal, newborn, and child health policy (focussing on those services) led to an increase in DALYs, meaning it worsened health outcomes. 
+
+These findings demonstrate that the TLO simulation provides a unique tool with which to test HBPs designed specifically for Malawi and highlight the importance of carefully considering how healthcare services are prioritized, as not all approaches will lead to improved health outcomes.
+
+.. figure:: total-dalys-plot.png
+   :class: with-border
+   
+   Total DALYs incurred overall (between 2023 and 2042 inclusive) under each policy considered. 

--- a/docs/case-studies/hbp-design/index.rst
+++ b/docs/case-studies/hbp-design/index.rst
@@ -2,7 +2,7 @@
 A new approach to Health Benefits Package design: an application of the Thanzi La Onse model in Malawi
 ======================================================================================================
 
-*Margherita Molaro et al.*
+*Margherita Molaro et al.* `(PLOS Computational Biology article) <https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1012462>`_
 
 .. image:: header.jpg
   :width: 100%

--- a/docs/case-studies/hbp-design/total-dalys-plot.png
+++ b/docs/case-studies/hbp-design/total-dalys-plot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbb78747a22223e91d77774b9ac96b8ede9c96c9d1b14365106f45a07d10e469
+size 33969

--- a/docs/case-studies/index.rst
+++ b/docs/case-studies/index.rst
@@ -1,0 +1,13 @@
+============
+Case studies
+============
+
+In this section we provide some case studies illustrating how Thanzi La Onse model has been used in practice.
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+   
+   fcdo/index
+   hbp-design/index
+   pop-health/index

--- a/docs/case-studies/pop-health/header.jpg
+++ b/docs/case-studies/pop-health/header.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcc80ab1f91ac47ad6dfffd8d957bc757012362fb5afceb4cf1b167cca70564d
+size 367849

--- a/docs/case-studies/pop-health/index.rst
+++ b/docs/case-studies/pop-health/index.rst
@@ -2,7 +2,7 @@
 The potential impact of declining development assistance for healthcare on population health: projections for Malawi
 ====================================================================================================================
 
-*Margherita Molaro et al.*
+*Margherita Molaro et al.* `(medRxiv pre-print) <https://www.medrxiv.org/content/10.1101/2024.10.11.24315287v1>`_
 
 .. image:: header.jpg
   :width: 100%

--- a/docs/case-studies/pop-health/index.rst
+++ b/docs/case-studies/pop-health/index.rst
@@ -1,0 +1,38 @@
+====================================================================================================================
+The potential impact of declining development assistance for healthcare on population health: projections for Malawi
+====================================================================================================================
+
+*Margherita Molaro et al.*
+
+.. image:: header.jpg
+  :width: 100%
+  :alt: View of exterior of a medical clinic showing a signboard with opening hours
+
+*Development assistance for health* (DAH) to Malawi as a fraction of its *gross domestic product* (GDP) will likely decrease in the next few decades.
+Given the country's significant reliance on DAH for the delivery of its healthcare services, 
+estimating the impact that this could have on health projections for the country is crucial. 
+We use the *Thanzi La Onse* (TLO) model to simulate the health burden that would be incurred under different scenarios of health expenditure in Malawi between 2019 and 2040 (inclusive).
+Because the ability of the healthcare system to meet the demand for care in the model is constrained by the *human resources for health* (HRH) available,
+this allows us to estimate the return in health from each expenditure scenario.
+
+We found that between 2019 and 2040, the total health burden, measured in *disability-adjusted life years* (DALYs),
+is reduced by about 10 million DALYs for each 1% increase in annual healthcare spending. 
+However, the benefits of increasing healthcare spending diminish once spending grows beyond an additional 4% of GDP.
+The reasons for these diminishing returns are due to the healthcare system reaching a point
+where it has already addressed the most urgent needs with the available cost-effective treatments and persistent constraints that not immediately resolved by more funding,
+such as limited access to healthcare for some population groups, imperfect diagnoses, 
+and the natural limitations of each treatment. 
+All these factors are explicitly captured in the TLO model. 
+If the forecasts by the *Institute for Health Metrics and Evaluation* (IHME) about a reduction in the percentage of GDP spent on healthcare are accurate,
+the country could experience an increase in total health burdens of 7% to 16%,
+compared to that predicted for current levels of spending. 
+A lot of this increased in ill health would come from reversals in the gains made previously by Malawi in important areas of health such as 
+reproductive, maternal, newborn, and child health, malaria, and tuberculosis.
+This analysis offers the first-ever quantification of the potential long-term impacts of various health expenditure scenarios in Malawi.
+It demonstrates the potential risk of reversing gains in several key areas of health in Malawi if current projections of declining development assistance for health materialise and 
+highlights the need for both domestic and international stakeholders to take proactive measures in response to this anticipated trend.
+
+.. figure:: life-expectancy-across-scenarios.png
+   :class: with-border
+   
+   Life expectancy (averaged over two-year periods) achieved under different expenditure scenario.

--- a/docs/case-studies/pop-health/life-expectancy-across-scenarios.png
+++ b/docs/case-studies/pop-health/life-expectancy-across-scenarios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2794f188f636f62e58a6ec4fe6a28b7bd0c3f55abb9cce612f76d3445d6ac21
+size 192176

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,7 @@ Contents
    resources/index
    parameters
    learning
+   case-studies/index
    videos
    publications
    contributors


### PR DESCRIPTION
Adds three case studies to new top-level section in website with content from @tdm32, @sakshimohan and @marghe-molaro.

@imperialkate I've added the case studies as HTML pages rather than attaching the Word / PDF files - hope that is okay. I can also add links to download the PDF versions if that would be useful.

@tdm32, @sakshimohan and @marghe-molaro - the photos and figures I extracted from the case study Word files are quite low resolution, particularly the return on investment figure in the _The Health Impact of Investments in Vertical Programs and Broader Health System Development: Findings from Malawi_ case study. Do you have higher resolution source files for these figures available or even better versions in a vector format such as SVG or PDF?