### PR TITLE
Rename series to preserve legacy behaviour of "summarize"

### DIFF
--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -471,6 +471,9 @@ def summarize(
     if isinstance(output, pd.DataFrame):
         output = output.rename(columns={'central': 'mean'},
                                level=0 if output.columns.nlevels == 1 else 1)
+    else:
+        output.name = 'mean'  # rename the series to mean
+
     return output
 
 


### PR DESCRIPTION
Fixes #1567


(Have confirmed it runs the whole calibration procedure cleanly now).