### PR TITLE
Malaria: use more efficient calls for some Pandas operations

### DIFF
--- a/src/tlo/methods/malaria.py
+++ b/src/tlo/methods/malaria.py
@@ -1576,9 +1576,7 @@ class MalariaLoggingEvent(RegularEvent, PopulationScopeEventMixin):
         # infected in the last time-step, clinical and severe cases only
         # incidence rate per 1000 person-years
         # include those cases that have died in the case load
-        tmp = len(
-            df.loc[(df.ma_date_symptoms > (now - DateOffset(months=self.repeat)))]
-        )
+        tmp = sum(df.ma_date_symptoms > (now - DateOffset(months=self.repeat)))
         pop = sum(df.is_alive)
 
         inc_1000py = ((tmp / pop) * 1000) if pop else 0


### PR DESCRIPTION
Profiling revealed that some Pandas operations in the malaria module were copying and moving lots of memory. I've replaced these with more efficient calls. Results of some micro benchmarking below.

<img width="1379" alt="Screenshot 2025-02-10 at 21 42 46" src="https://github.com/user-attachments/assets/c1f0035b-eb6b-424b-b4ca-0aff57cdd6c8" />

```
def current():
    pop = df[df.is_alive].groupby('district_num_of_residence').size()
    return pop


def suggestion():
    pop = df.district_num_of_residence[df.is_alive].value_counts()
    return pop

%timeit current()
%timeit suggestion()

17.6 ms ± 178 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
174 μs ± 1.56 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

```
alive = df.is_alive & (df.age_years < 80)
alive_uninfected = alive & df.ma_inf_type.isin(['none', 'asym'])

def current():
	pop = df[alive_uninfected].set_index(['district_num_of_residence', 'ma_age_edited']).index
	return pop

def suggestions():
	pop = pd.MultiIndex.from_frame(df.loc[alive_uninfected, ['district_num_of_residence', 'ma_age_edited']])
    return pop

In [19]: %memit current()
peak memory: 1207.64 MiB, increment: 76.84 MiB

In [20]: %memit suggestions()
peak memory: 1130.73 MiB, increment: 0.00 MiB
```
