### PR TITLE
Delete the availability estimates dataframe once Consumables initialised

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -670,6 +670,8 @@ class HealthSystem(Module):
             rng=rng_for_consumables,
             availability=self.get_cons_availability()
         )
+        # We don't need to hold onto this large dataframe
+        del self.parameters['availability_estimates']
 
         # Determine equip_availability
         self.equipment = Equipment(


### PR DESCRIPTION
Resolves #1584. The availability estimates dataframe uses quite a lot of memory but we don't need it once Consumables has been initialised. This is a quick fix that simply deletes the key from the parameters dictionary.