### PR TITLE
Improve dataframe access in some hotspots

### DIFF
--- a/src/tlo/methods/contraception.py
+++ b/src/tlo/methods/contraception.py
@@ -1175,14 +1175,14 @@ class HSI_Contraception_FamilyPlanningAppt(HSI_Event, IndividualScopeEventMixin)
     def apply(self, person_id, squeeze_factor):
         """If the relevant consumable is available, do change in contraception and log it"""
 
-        person = self.sim.population.props.loc[person_id]
-        current_method = person.co_contraception
-
-        if not (person.is_alive and not person.is_pregnant):
+        df = self.sim.population.props
+        if not df.at[person_id, 'is_alive'] or df.at[person_id, 'is_pregnant']:
             return
 
+        current_method = df.at[person_id, 'co_contraception']
+
         # Record the date that Family Planning Appointment happened for this person
-        self.sim.population.props.at[person_id, "co_date_of_last_fp_appt"] = self.sim.date
+        df.at[person_id, "co_date_of_last_fp_appt"] = self.sim.date
 
         # Measure weight, height and BP even if contraception not administrated
         self.add_equipment({

--- a/src/tlo/methods/symptommanager.py
+++ b/src/tlo/methods/symptommanager.py
@@ -757,8 +757,7 @@ class SymptomManager_SpuriousSymptomResolve(RegularEvent, PopulationScopeEventMi
         for symp in self.to_resolve.keys():
             if date_today in self.to_resolve[symp]:
                 person_ids = self.to_resolve[symp].pop(date_today)
-                persons = df.loc[sorted(person_ids)]
-                person_ids_alive = persons[persons.is_alive].index
+                person_ids_alive = df.index[df.index.isin(person_ids) & df.is_alive]
                 self.module.change_symptom(
                     person_id=person_ids_alive,
                     add_or_remove='-',


### PR DESCRIPTION
Some population dataframe access patterns showed up during profiling. These changes reduced runtime in these methods in contraception and symptommanager, 6x and 3x respectively.
