### PR TITLE
Optimise getting an individual's symptoms

### DIFF
--- a/src/tlo/methods/symptommanager.py
+++ b/src/tlo/methods/symptommanager.py
@@ -530,16 +530,9 @@ class SymptomManager(Module):
                 person_has = self.bsh.has(
                     [person_id], disease_module.name, first=True, columns=sy_columns
                 )
-                return [s for s in self.symptom_names if person_has[f"sy_{s}"]]
+                return [s for s in self.symptom_names if person_has[self.get_column_name_for_symptom(s)]]
             else:
-                symptom_cols = df.loc[
-                    person_id, [f"sy_{s}" for s in self.symptom_names]
-                ]
-                return (
-                    symptom_cols.index[symptom_cols > 0]
-                    .str.removeprefix("sy_")
-                    .to_list()
-                )
+                return [s for s in self.symptom_names if df.at[person_id, self.get_column_name_for_symptom(s)] > 0]
 
     def have_what(self, person_ids: Sequence[int]):
         """Find the set of symptoms for a list of person_ids.


### PR DESCRIPTION
`has_what` has been identified as a hot spot when processing HSI events. Line profiler showed following block taking 50% of time in calls, and many memory allocations:

```
   537     54.0                  symptom_cols = df.loc[
   538      0.2                      person_id, [f"sy_{s}" for s in self.symptom_names]
   539                           ]
   540      0.0                  return (
   541      4.1                      symptom_cols.index[symptom_cols > 0]
   542      1.9                      .str.removeprefix("sy_")
   543      0.0                      .to_list()
   544                           )
```

Replaced with a version that's 7x faster, and fewer allocations.

```
In [14]: %timeit old()
684 μs ± 1.9 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [13]: %timeit new()
97.7 μs ± 1 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```