### PR TITLE
Tell isort to skip setuptools-scm's generated `_version.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ include_trailing_comma = true
 line_length = 100
 known_first_party = "tlo"
 default_section = "THIRDPARTY"
+skip = ["src/tlo/_version.py"]
 
 [tool.pylint.main]
 extension-pkg-whitelist = ["numpy"]


### PR DESCRIPTION
isort does not like change in v8.2.0 of setuptools https://github.com/pypa/setuptools-scm/commit/24d7797e1872aca7936dcd71a1aac81a08ee5326

Quick way to fix failing CI. 