### PR TITLE
fix a health system parameter capitalisation

### DIFF
--- a/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
+++ b/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1cb38ba76c5673855e2e17e28ad1d36b5cec07d5d7872a7d6bc8aafde0f7009
-size 828
+oid sha256:b663b87018dfe7a10d74afb537082c6f52e71254b3aa36e096b48e2cc4e48070
+size 806

--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -1291,7 +1291,7 @@ def get_parameters_for_standard_mode2_runs() -> Dict:
             "spurious_symptoms": True,
         },
         "HealthSystem": {
-            'Service_Availability': ['*'],
+            'service_availability': ['*'],
             "use_funded_or_actual_staffing": "actual",
             "mode_appt_constraints": 1,
             "mode_appt_constraints_postSwitch": 2, # <-- Include a transition to mode 2, to pick up any issues with this
@@ -1330,7 +1330,7 @@ def get_parameters_for_hrh_historical_scaling_and_rescaling_for_mode2() -> Dict:
             "spurious_symptoms": True,
         },
         "HealthSystem": {
-            'Service_Availability': ['*'],
+            'service_availability': ['*'],
             "use_funded_or_actual_staffing": "actual",
             "mode_appt_constraints": 1,
             "mode_appt_constraints_postSwitch": 2,

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -223,7 +223,7 @@ class HealthSystem(Module):
         ),
 
         # Service Availability
-        'Service_Availability': Parameter(
+        'service_availability': Parameter(
             Types.LIST, 'List of services to be available. NB. This parameter is over-ridden if an argument is provided'
                         ' to the module initialiser.'),
 


### PR DESCRIPTION
The HealthSystem module's `service_availability` parameter was not capitalised correctly, which caused errors when running on Linux.