### PR TITLE
fix a health system parameter capitalisation

### DIFF
--- a/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
+++ b/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1cb38ba76c5673855e2e17e28ad1d36b5cec07d5d7872a7d6bc8aafde0f7009
-size 828
+oid sha256:b663b87018dfe7a10d74afb537082c6f52e71254b3aa36e096b48e2cc4e48070
+size 806

--- a/src/scripts/healthsystem/effects_of_each_treatment_multi_scenario/scenario_effect_of_each_treatment_max.py
+++ b/src/scripts/healthsystem/effects_of_each_treatment_multi_scenario/scenario_effect_of_each_treatment_max.py
@@ -63,7 +63,7 @@ class EffectOfEachTreatmentMax(BaseScenario):
             get_parameters_for_status_quo(),
             {
                 'HealthSystem': {
-                    'Service_Availability': list(self._scenarios.values())[draw_number],
+                    'service_availability': list(self._scenarios.values())[draw_number],
                     'cons_availability': 'all',
                     "mode_appt_constraints": 0,
                     "use_funded_or_actual_staffing": "funded_plus",
@@ -75,14 +75,14 @@ class EffectOfEachTreatmentMax(BaseScenario):
         )
 
     def _get_scenarios(self) -> Dict[str, List[str]]:
-        """Return the Dict with values for the parameter `Service_Availability` keyed by a name for the scenario.
+        """Return the Dict with values for the parameter `service_availability` keyed by a name for the scenario.
         The sequences of scenarios systematically omits one of the TREATMENT_ID's that is defined in the model. The
         complete list of TREATMENT_ID's is found by running `tlo_hsi_events.py`."""
 
         # Generate list of TREATMENT_IDs and filter to the resolution needed
         treatments = get_filtered_treatment_ids(depth=1)
 
-        # Return 'Service_Availability' values, with scenarios for everything, nothing, and ones for which each
+        # Return 'service_availability' values, with scenarios for everything, nothing, and ones for which each
         # treatment is omitted
         service_availability = dict({"Everything": ["*"], "Nothing": []})
         service_availability.update(

--- a/src/scripts/healthsystem/effects_of_each_treatment_multi_scenario/scenario_effect_of_each_treatment_status_quo.py
+++ b/src/scripts/healthsystem/effects_of_each_treatment_multi_scenario/scenario_effect_of_each_treatment_status_quo.py
@@ -68,19 +68,19 @@ class EffectOfEachTreatmentStatusQuo(BaseScenario):
             get_parameters_for_status_quo(),
             {
                 'HealthSystem': {
-                    'Service_Availability': list(self._scenarios.values())[draw_number],
+                    'service_availability': list(self._scenarios.values())[draw_number],
                 },
             }
         )
 
     def _get_scenarios(self) -> Dict[str, List[str]]:
-        """Return the Dict with values for the parameter `Service_Availability` keyed by a name for the scenario.
+        """Return the Dict with values for the parameter `service_availability` keyed by a name for the scenario.
         The sequences of scenarios systematically omits one of the TREATMENT_ID's that is defined in the model."""
 
         # Generate list of TREATMENT_IDs and filter to the resolution needed
         treatments = get_filtered_treatment_ids(depth=1)
 
-        # Return 'Service_Availability' values, with scenarios for everything, nothing, and ones for which each
+        # Return 'service_availability' values, with scenarios for everything, nothing, and ones for which each
         # treatment is omitted
         service_availability = dict({"Everything": ["*"], "Nothing": []})
         service_availability.update(

--- a/src/scripts/healthsystem/impact_of_mode/scenario_impact_of_mode.py
+++ b/src/scripts/healthsystem/impact_of_mode/scenario_impact_of_mode.py
@@ -72,7 +72,7 @@ class ImpactOfHealthSystemMode(BaseScenario):
         return {
             "No Healthcare System": {
                 'HealthSystem': {
-                    'Service_Availability': []
+                    'service_availability': []
                 },
             },
 

--- a/src/scripts/overview_paper/B_finding_effects_of_each_treatment/scenario_effect_of_each_treatment.py
+++ b/src/scripts/overview_paper/B_finding_effects_of_each_treatment/scenario_effect_of_each_treatment.py
@@ -62,19 +62,19 @@ class EffectOfEachTreatment(BaseScenario):
             get_parameters_for_status_quo(),
             {
                 'HealthSystem': {
-                    'Service_Availability': list(self._scenarios.values())[draw_number],
+                    'service_availability': list(self._scenarios.values())[draw_number],
                 },
             }
         )
 
     def _get_scenarios(self) -> Dict[str, List[str]]:
-        """Return the Dict with values for the parameter `Service_Availability` keyed by a name for the scenario.
+        """Return the Dict with values for the parameter `service_availability` keyed by a name for the scenario.
         The sequences of scenarios systematically omits one of the TREATMENT_ID's that is defined in the model."""
 
         # Generate list of TREATMENT_IDs and filter to the resolution needed
         treatments = get_filtered_treatment_ids(depth=1)
 
-        # Return 'Service_Availability' values, with scenarios for everything, nothing, and ones for which each
+        # Return 'service_availability' values, with scenarios for everything, nothing, and ones for which each
         # treatment is omitted
         service_availability = dict({"Everything": ["*"], "Nothing": []})
         service_availability.update(

--- a/src/scripts/overview_paper/C_impact_of_healthsystem_assumptions/scenario_impact_of_healthsystem.py
+++ b/src/scripts/overview_paper/C_impact_of_healthsystem_assumptions/scenario_impact_of_healthsystem.py
@@ -64,7 +64,7 @@ class ImpactOfHealthSystemAssumptions(BaseScenario):
                     get_parameters_for_status_quo(),
                     {
                         'HealthSystem': {
-                            'Service_Availability': []
+                            'service_availability': []
                         }
                     },
                 ),

--- a/src/scripts/undernutrition_analyses/stunting/stunting_analysis_scenario.py
+++ b/src/scripts/undernutrition_analyses/stunting/stunting_analysis_scenario.py
@@ -79,7 +79,7 @@ class Scenario(BaseScenario):
         # ]
         # return {
         #     'HealthSystem': {
-        #         'Service_Availability': service_availability[draw_number],
+        #         'service_availability': service_availability[draw_number],
         #     },
         # }
         # Awaiting fix to https://github.com/UCL/TLOmodel/issues/392

--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -1260,7 +1260,7 @@ def get_parameters_for_status_quo() -> Dict:
             "spurious_symptoms": True,
         },
         "HealthSystem": {
-            'Service_Availability': ['*'],
+            "service_availability": ['*'],
             "use_funded_or_actual_staffing": "actual",
             "mode_appt_constraints": 1,
             "cons_availability": "default",

--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -1291,7 +1291,7 @@ def get_parameters_for_standard_mode2_runs() -> Dict:
             "spurious_symptoms": True,
         },
         "HealthSystem": {
-            'Service_Availability': ['*'],
+            'service_availability': ['*'],
             "use_funded_or_actual_staffing": "actual",
             "mode_appt_constraints": 1,
             "mode_appt_constraints_postSwitch": 2, # <-- Include a transition to mode 2, to pick up any issues with this
@@ -1330,7 +1330,7 @@ def get_parameters_for_hrh_historical_scaling_and_rescaling_for_mode2() -> Dict:
             "spurious_symptoms": True,
         },
         "HealthSystem": {
-            'Service_Availability': ['*'],
+            'service_availability': ['*'],
             "use_funded_or_actual_staffing": "actual",
             "mode_appt_constraints": 1,
             "mode_appt_constraints_postSwitch": 2,

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -223,7 +223,7 @@ class HealthSystem(Module):
         ),
 
         # Service Availability
-        'Service_Availability': Parameter(
+        'service_availability': Parameter(
             Types.LIST, 'List of services to be available. NB. This parameter is over-ridden if an argument is provided'
                         ' to the module initialiser.'),
 
@@ -1134,7 +1134,7 @@ class HealthSystem(Module):
         was provided in argument if an argument was specified -- provided for backward compatibility/debugging.)"""
 
         if self.arg_service_availability is None:
-            service_availability = self.parameters['Service_Availability']
+            service_availability = self.parameters['service_availability']
         else:
             service_availability = self.arg_service_availability
 

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -74,7 +74,7 @@ def test_using_parameter_or_argument_to_set_service_availability(seed):
         demography.Demography(),
         healthsystem.HealthSystem()
     )
-    sim.modules['HealthSystem'].parameters['Service_Availability'] = service_availability_params
+    sim.modules['HealthSystem'].parameters['service_availability'] = service_availability_params
     sim.make_initial_population(n=100)
     sim.simulate(end_date=start_date + pd.DateOffset(days=0))
     assert sim.modules['HealthSystem'].service_availability == service_availability_params
@@ -87,7 +87,7 @@ def test_using_parameter_or_argument_to_set_service_availability(seed):
         demography.Demography(),
         healthsystem.HealthSystem(service_availability=service_availability_arg)
     )
-    sim.modules['HealthSystem'].parameters['Service_Availability'] = service_availability_params
+    sim.modules['HealthSystem'].parameters['service_availability'] = service_availability_params
     sim.make_initial_population(n=100)
     sim.simulate(end_date=start_date + pd.DateOffset(days=0))
     assert sim.modules['HealthSystem'].service_availability == service_availability_arg
@@ -1491,7 +1491,7 @@ def test_manipulation_of_service_availability(seed, tmpdir):
         }, resourcefilepath=resourcefilepath)
 
         sim.register(*fullmodel())
-        sim.modules['HealthSystem'].parameters['Service_Availability'] = service_availability  # Change parameter
+        sim.modules['HealthSystem'].parameters['service_availability'] = service_availability  # Change parameter
         sim.modules['HealthSystem'].parameters['cons_availability'] = 'default'
         sim.make_initial_population(n=500)
         sim.simulate(end_date=start_date + pd.DateOffset(days=7))
@@ -2231,7 +2231,7 @@ def test_determinism_of_hsi_that_run_and_consumables_availabilities(seed, tmpdir
             }
         }, resourcefilepath=resourcefilepath)
         sim.register(*fullmodel())
-        sim.modules['HealthSystem'].parameters['Service_Availability'] = ["*"]
+        sim.modules['HealthSystem'].parameters['service_availability'] = ["*"]
         sim.modules['HealthSystem'].parameters['cons_availability'] = 'default'
         sim.make_initial_population(n=1_000)
 
@@ -2278,7 +2278,7 @@ def test_service_availability_can_be_set_using_list_of_treatment_ids_and_asteris
             }
         }, resourcefilepath=resourcefilepath)
         sim.register(*fullmodel(module_kwargs={'HealthSystem': {'randomise_queue': randomise_hsi_queue}}))
-        sim.modules['HealthSystem'].parameters['Service_Availability'] = service_availability
+        sim.modules['HealthSystem'].parameters['service_availability'] = service_availability
         sim.modules['HealthSystem'].parameters['cons_availability'] = 'default'
         sim.make_initial_population(n=500)
 


### PR DESCRIPTION
The HealthSystem module's `service_availability` parameter was not capitalised correctly, which caused errors when running on Linux.