### PR TITLE
Allow consumable availability to be overridden for a given Treatment ID

### DIFF
--- a/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
+++ b/resources/healthsystem/ResourceFile_HealthSystem_parameters.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1cb38ba76c5673855e2e17e28ad1d36b5cec07d5d7872a7d6bc8aafde0f7009
-size 828
+oid sha256:3ab2548279c7677d2336c8a17a5a1e6bd0391787a2d60bee2b66e254e4a5f175
+size 862

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -191,6 +191,11 @@ class HealthSystem(Module):
             " When using 'all' or 'none', requests for consumables are not logged. NB. This parameter is over-ridden"
             "if an argument is provided to the module initialiser."
             "Note that other options are also available: see the `Consumables` class."),
+        'cons_override_treatment_ids': Parameter(
+            Types.LIST,
+            "Consumable availability within any treatment ids listed in this parameter will be set at 100%. "
+            "By default this list is empty"),
+
 
         # Infrastructure and Equipment
         'BedCapacity': Parameter(

--- a/src/tlo/methods/hsi_event.py
+++ b/src/tlo/methods/hsi_event.py
@@ -229,6 +229,7 @@ class HSI_Event:
             to_log=_to_log,
             facility_info=self.facility_info,
             treatment_id=self.TREATMENT_ID,
+            override_hsi=self.healthcare_system.parameters['cons_override_treatment_ids'],
         )
 
         # Return result in expected format:

--- a/tests/test_consumables.py
+++ b/tests/test_consumables.py
@@ -315,7 +315,6 @@ def test_items_used_includes_only_available_items(seed, p_known_items, expected_
     items_used = getattr(cons._summary_counter, '_items', {}).get('Used')
     assert items_used == expected_items_used, f"Expected items_used to be {expected_items_used}, but got {items_used}"
 
-
 def get_sim_with_dummy_module_registered(tmpdir=None, run=True, data=None):
     """Return an initialised simulation object with a Dummy Module registered. If the `data` argument is provided,
     the parameter in HealthSystem that holds the data on consumables availability is over-written."""
@@ -465,6 +464,15 @@ def test_use_get_consumables_by_hsi_method_get_consumables():
         optional_item_codes=item_code_not_available[0],
         return_individual_results=True
     )
+
+    # Check that providing a treatment id within the following health system parameter sets treatment availability to
+    # 100%
+    sim.modules['HealthSystem'].parameters['cons_override_treatment_ids'] = [hsi_event.TREATMENT_ID]
+    assert True is hsi_event.get_consumables(item_codes=item_code_not_available[0])
+
+    # check that when the parameter is blank that availability is not overridden
+    sim.modules['HealthSystem'].parameters['cons_override_treatment_ids'] = []
+    assert False is hsi_event.get_consumables(item_codes=item_code_not_available[0])
 
 
 def test_outputs_to_log(tmpdir):


### PR DESCRIPTION
This PR adds functionality allowing modellers to define a single/set of Treatment IDs for which consumable availability is set at 100%. I've taken the following approach:

1. Added a new parameter to the health system - `cons_override_treatment_ids` - which can contain treatment ids for which cons. availability should be set at 100%
2. Added an optional parameter to the function `_request_consumables` within `hsi_event.py` to which the `cons_override_treatment_ids` list can be passed
3. Added a boolean parameter to `_lookup_availability_of_consumables` in `consumables.py` if the relevant treatment id is listed (True)
4. Set all cons. to True within `_lookup_availability_of_consumables` is new function parameter set to True - this preserves logging etc and will correctly capture the use of the consumables but ignores probability of availability.
5. Added a couple of lines of testing to `test_use_get_consumables_by_hsi_method_get_consumables` in `test_consumables.py`

Happy for any comments/changes people want to make (e.g. do we also want to be able to set cons availability to 0 for a certain treatment id).