### PR TITLE
gitattributes: excl resources/**/*.md from LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@
 *.xlsx filter=lfs diff=lfs merge=lfs -text
 *.pickle filter=lfs diff=lfs merge=lfs -text
 resources/** filter=lfs diff=lfs merge=lfs -text
+resources/**/*.md !filter !diff !merge !text


### PR DESCRIPTION
This update excludes all `resources/**/*.md` files from being tracked by Git LFS, ensuring that Markdown files under the `resources/` directory are treated as regular text files.

Fixes: #1646.