### PR TITLE
Allow suspend/resume of simulations on Batch runs

### DIFF
--- a/src/scripts/dev/scenarios/suspend-resume-test.py
+++ b/src/scripts/dev/scenarios/suspend-resume-test.py
@@ -1,0 +1,54 @@
+"""
+This file defines a batch run of a large population for a long time with all disease modules and full use of HSIs
+It's used for calibrations (demographic patterns, health burdens and healthsystem usage)
+
+Run on the batch system using:
+```tlo batch-submit src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py```
+
+or locally using:
+    ```tlo scenario-run src/scripts/calibration_analyses/scenarios/long_run_all_diseases.py```
+
+"""
+
+from tlo import Date, logging
+from tlo.analysis.utils import get_parameters_for_status_quo
+from tlo.methods.fullmodel import fullmodel
+from tlo.scenario import BaseScenario
+
+
+class SuspendResumeTest(BaseScenario):
+    def __init__(self):
+        super().__init__()
+        self.seed = 0
+        self.start_date = Date(2010, 1, 1)
+        self.end_date = Date(2012, 1, 1)  # The simulation will stop before reaching this date.
+        self.pop_size = 1_000
+        self.number_of_draws = 2
+        self.runs_per_draw = 2
+
+    def log_configuration(self):
+        return {
+            'filename': 'suspend_resume_test',  # <- (specified only for local running)
+            'directory': './outputs',  # <- (specified only for local running)
+            'custom_levels': {
+                '*': logging.WARNING,
+                'tlo.methods.demography': logging.INFO,
+                'tlo.methods.demography.detail': logging.WARNING,
+                'tlo.methods.healthburden': logging.INFO,
+                'tlo.methods.healthsystem': logging.INFO,
+                'tlo.methods.healthsystem.summary': logging.INFO,
+                "tlo.methods.contraception": logging.INFO,
+            }
+        }
+
+    def modules(self):
+        return fullmodel()
+
+    def draw_parameters(self, draw_number, rng):
+        return get_parameters_for_status_quo()
+
+
+if __name__ == '__main__':
+    from tlo.cli import scenario_run
+
+    scenario_run([__file__])

--- a/src/tlo/cli.py
+++ b/src/tlo/cli.py
@@ -107,15 +107,16 @@ def parse_log(log_directory):
             with open(path / f"{key}.pickle", "wb") as f:
                 pickle.dump(output, f)
 
-@cli.command()
+@cli.command(context_settings=dict(ignore_unknown_options=True))
 @click.argument("scenario_file", type=click.Path(exists=True))
 @click.option("--asserts-on", type=bool, default=False, is_flag=True, help="Enable assertions in simulation run.")
 @click.option("--more-memory", type=bool, default=False, is_flag=True,
               help="Request machine wth more memory (for larger population sizes).")
 @click.option("--image-tag", type=str, help="Tag of the Docker image to use.")
 @click.option("--keep-pool-alive", type=bool, default=False, is_flag=True, hidden=True)
+@click.argument('scenario_args', nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
-def batch_submit(ctx, scenario_file, asserts_on, more_memory, keep_pool_alive, image_tag=None):
+def batch_submit(ctx, scenario_file, asserts_on, more_memory, keep_pool_alive, image_tag=None, scenario_args=None):
     """Submit a scenario to the batch system.
 
     SCENARIO_FILE is path to file containing scenario class.
@@ -131,6 +132,10 @@ def batch_submit(ctx, scenario_file, asserts_on, more_memory, keep_pool_alive, i
         return
 
     scenario = load_scenario(scenario_file)
+
+    # if we have other scenario arguments, parse them
+    if scenario_args is not None:
+        scenario.parse_arguments(scenario_args)
 
     # get the commit we're going to submit to run on batch, and save the run config for that commit
     # it's the most recent commit on current branch

--- a/src/tlo/scenario.py
+++ b/src/tlo/scenario.py
@@ -63,6 +63,7 @@ import abc
 import argparse
 import datetime
 import json
+import os
 from collections.abc import Iterable
 from itertools import product
 from pathlib import Path, PurePosixPath
@@ -445,12 +446,13 @@ class SampleRunner:
         ):
             sim.run_simulation_to(to_date=self.scenario.suspend_date)
             suspended_simulation_path = Path(log_config["directory"]) / "suspended_simulation.pickle"
-            sim.save_to_pickle(pickle_path=suspended_simulation_path)
-            sim.close_output_file()
             logger.info(
                 key="message",
-                data=f"Simulation suspended at {self.scenario.suspend_date} and saved to {suspended_simulation_path}",
+                data=f"Suspending simulation at {self.scenario.suspend_date} and saving to {suspended_simulation_path}."
+                     f"Note, output file handle will be closed first & no more output logged",
             )
+            sim.close_output_file()
+            sim.save_to_pickle(pickle_path=suspended_simulation_path)
         else:
             sim.run_simulation_to(to_date=self.scenario.end_date)
             sim.finalise()

--- a/src/tlo/scenario.py
+++ b/src/tlo/scenario.py
@@ -407,6 +407,9 @@ class SampleRunner:
             hasattr(self.scenario, "resume_simulation")
             and self.scenario.resume_simulation is not None
         ):
+            if "$" in self.scenario.resume_simulation:
+                self.scenario.resume_simulation = os.path.expandvars(self.scenario.resume_simulation)
+
             suspended_simulation_path = (
                 Path(self.scenario.resume_simulation)
                 / str(draw_number)


### PR DESCRIPTION
Implements suspend/resume when using `tlo batch-submit` with following caveats:

1) Currently only suspends/resumes exactly the draw+run that was suspended (i.e. cannot use other draw's runs to resume different draws - which is what we want)
2) Have to know some internal Azure Batch environment variables to get the path to pickled simulation - want to get rid of that, somehow.