### PR TITLE
Param Revamp - Care of Women During Pregnancy

### DIFF
--- a/resources/ResourceFile_AntenatalCare/parameter_values.csv
+++ b/resources/ResourceFile_AntenatalCare/parameter_values.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25055ee5db14fb4741e88595a48dbfadeac0c847a549201cf078599894be2ad4
-size 4131
+oid sha256:1cec7cf8d47aab3018512b670fb5c51a19b730c97defeba8e17bb9da000a7616
+size 4105

--- a/src/tlo/methods/care_of_women_during_pregnancy.py
+++ b/src/tlo/methods/care_of_women_during_pregnancy.py
@@ -1450,8 +1450,8 @@ class CareOfWomenDuringPregnancy(Module):
         # Women with abruption, praevia or chorioamnionitis prior to 28 weeks will not be delivered until they have
         # reached that gestation
         if ((mother.ps_placental_abruption or
-            ((mother.ps_placenta_praevia and (mother.ps_antepartum_haemorrhage == 'severe')) or
-             mother.ps_chorioamnionitis)) and
+             (mother.ps_placenta_praevia and (mother.ps_antepartum_haemorrhage == 'severe')) or
+             mother.ps_chorioamnionitis) and
             (mother.ps_gestational_age_in_weeks < 28)):
             beddays = int((28 * 7) - (mother.ps_gestational_age_in_weeks * 7))
 


### PR DESCRIPTION
**To Note**

- Within the ANC visits, there are many checks based on gestational age. These checks seemed to be based on the age cut-offs of the ANC visits (e.g. if someone wen to ANC 4 with the gestational age of ANC 7, then ANC 7 interventions applied). Thus, I used the parameter that I created (e.g. `anc_gestational_age_weeks_anc7` in this case) within the conditions of the other ANC appointments.  
- Calibration information described in detail in the write-up. My review of write-up was not exhaustive, recommend reviewing to ensure proper documentation of calibrated parameters. 

**Parameters to review**

- `prob_seek_anc3`: Had [0.77, 0.77] in an undefined column. I've moved it to be the prior_max value
- `prob_delivery_modes_ec`, `prob_delivery_modes_spe`: Assume to be 'local' 
- `gestational_age_weeks_upper_bound`: I created this parameter. Set this as 'undetermined' with the description 'structural'. It is used as an upper bound of max weeks of pregnancy (not defined by local or universal literature) 
- `treatment_effect_blood_transfusion_anaemia`: marked as 'universal'

**Params that I have left hard-coded** (list not exhaustive, aimed to document the main ones)   
- All med consumable dosages 
- Date 
- The DateOffsets windows for _tlclose_ (e.g. 1, 3, 7 days). I believe it will add confusion to add too many of these variables. See example: 
```
          self.sim.modules['HealthSystem'].schedule_hsi_event(visit,
                                                                priority=0,
                                                                topen=visit_date,
                                                                tclose=visit_date + DateOffset(days=7))
```

- 7 weeks: Seemed to be different conditions with 7 week pregnancies, and did not believe they could be collapsed into single parameter 
```
        # Here we block the event from running for previously scheduled ANC1 HSIs for women who have lost a pregnancy
        # and become pregnant again
        if (
            (date_difference > pd.to_timedelta(7, unit='D')) or
            (df.at[individual_id, 'ac_total_anc_visits_current_pregnancy'] > 0) or
            (df.at[individual_id, 'ps_gestational_age_in_weeks'] < 7)
             ):
            return False
```
- Delivery weeks for grouped parameters, I have left hard-coded, see below: 

```
	# Women with abruption, praevia or chorioamnionitis prior to 28 weeks will not be delivered until they have
	# reached that gestation
	if ((mother.ps_placental_abruption or
	    ((mother.ps_placenta_praevia and (mother.ps_antepartum_haemorrhage == 'severe')) or
	     mother.ps_chorioamnionitis)) and
	    (mother.ps_gestational_age_in_weeks < 28)):
	    beddays = int((28 * 7) - (mother.ps_gestational_age_in_weeks * 7))
	
	# Similarly more mild bleeding or PROM without infection occuring prior to 37 weeks will not be delivered until
	# they have reached that gestation
	elif ((mother.ps_placenta_praevia and (mother.ps_antepartum_haemorrhage == 'mild_moderate')) or
	      (mother.ps_premature_rupture_of_membranes and not mother.ps_chorioamnionitis)) and \
	     (mother.ps_gestational_age_in_weeks < 37):
	    beddays = int((37 * 7) - (mother.ps_gestational_age_in_weeks * 7))
```

Initially I considered creating unique parameters for them, but they are really groupings of other parameters. Namely, 
- 37 weeks is for the parameters: 
	`delivery_weeks_placenta_praevia_mild`, 
	`delivery_weeks_prom_no_infection`

- And the 28 weeks is for the parameters: 
	`delivery_weeks_placental_abruption`
	`delivery_weeks_placenta_praevia_severe`
	`delivery_weeks_chorioamnionitis`


Options moving forward are to: 
a) Separate out each condition and apply individual statement 
b) Believe that universally these will always be the same, so do a "min" or "max" of these in the statement 
c) Create a new parameter (e.g. delivery_weeks_placenta_praevia_mild_no_infection) that encompasses all of them 