### PR TITLE
Update `ruff` version

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -206,7 +206,7 @@ requests==2.31.0
     #   requests-oauthlib
 requests-oauthlib==1.3.1
     # via msrest
-ruff==0.0.292
+ruff==0.12.11
     # via tlo (pyproject.toml)
 scipy==1.10.1
     # via tlo (pyproject.toml)


### PR DESCRIPTION
Update `ruff` version in requirements to match `tox` configuration
-----
The `tox` environment currently uses the latest version of `ruff` because no specific version is set. But `requirements` list an older version. This mismatch causes issues with code formatting in PyCharm, formatting may look correct in the editor but still fail `tox` checks due to different rules.
This PR updates the `ruff` version in `requirements` to match what `tox` is currently using (the latest version), so formatting is consistent and checks pass reliably.

TODO
It would be good to set a fixed `ruff` version in the `tox` setup too, so we don’t run into the same issue when a new version of `ruff` is released.