### PR TITLE
Fix typo in cancer PostTreatmentCheck scheduling

### DIFF
--- a/src/tlo/methods/bladder_cancer.py
+++ b/src/tlo/methods/bladder_cancer.py
@@ -909,7 +909,7 @@ class HSI_BladderCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin):
                     module=self.module,
                     person_id=person_id,
                 ),
-                topen=self.sim.date + DateOffset(years=12),
+                topen=self.sim.date + DateOffset(months=12),
                 tclose=None,
                 priority=0
             )
@@ -961,7 +961,7 @@ class HSI_BladderCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMixin)
                     module=self.module,
                     person_id=person_id
                 ),
-                topen=self.sim.date + DateOffset(years=1),
+                topen=self.sim.date + DateOffset(months=1),
                 tclose=None,
                 priority=0
             )

--- a/src/tlo/methods/oesophagealcancer.py
+++ b/src/tlo/methods/oesophagealcancer.py
@@ -803,7 +803,7 @@ class HSI_OesophagealCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin)
                     module=self.module,
                     person_id=person_id,
                 ),
-                topen=self.sim.date + DateOffset(years=12),
+                topen=self.sim.date + DateOffset(months=12),
                 tclose=None,
                 priority=0
             )
@@ -855,7 +855,7 @@ class HSI_OesophagealCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMi
                     module=self.module,
                     person_id=person_id
                 ),
-                topen=self.sim.date + DateOffset(years=1),
+                topen=self.sim.date + DateOffset(months=1),
                 tclose=None,
                 priority=0
             )

--- a/src/tlo/methods/prostate_cancer.py
+++ b/src/tlo/methods/prostate_cancer.py
@@ -981,7 +981,7 @@ class HSI_ProstateCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMixin
                     module=self.module,
                     person_id=person_id
                 ),
-                topen=self.sim.date + DateOffset(years=1),
+                topen=self.sim.date + DateOffset(months=1),
                 tclose=None,
                 priority=0
             )


### PR DESCRIPTION
This PR solves issue #1681 

Hi @andrew-phillips-1, I have corrected the delay to PostTreatmentCheck from units of "year" to "month" in the cases where there was a discrepancy between comment and code. 

There are just a few additional cases where things are unclear, e.g. a few cases where the comment suggests there should be an interval of 1 month until the PostTreatmentCheck, but it is coded as 3 months, e.g.:
https://github.com/UCL/TLOmodel/blob/42a56c40c9650e112ef11413cc6bfdd3dbddeb17/src/tlo/methods/breast_cancer.py#L868-L877
and cases where the comment says the interval should be 12 or 1 month, but it is coded as 3 months, e.g.:
https://github.com/UCL/TLOmodel/blob/42a56c40c9650e112ef11413cc6bfdd3dbddeb17/src/tlo/methods/other_adult_cancers.py#L798-L807

Could you please advise on these cases? Many thanks in advance!