### PR TITLE
Add comprehensive equipment to disease modules with facility-level de…

### DIFF
--- a/src/tlo/methods/bladder_cancer.py
+++ b/src/tlo/methods/bladder_cancer.py
@@ -734,6 +734,26 @@ class HSI_BladderCancer_Investigation_Following_Blood_Urine(HSI_Event, Individua
             # Use a biopsy to diagnose whether the person has bladder Cancer
             # If consumables are available update the use of equipment and run the dx_test representing the biopsy
             self.add_equipment({'Cystoscope', 'Ordinary Microscope', 'Ultrasound scanning machine'})
+            
+            # Additional cancer equipment based on column H comments
+            # Laboratory equipment for cancer screening and diagnosis
+            if self.module.rng.random() < 0.80:  # 80% probability at level 1b
+                self.add_equipment({221})  # Analyser, Haematology
+            
+            if self.module.rng.random() < 0.70:  # 70% probability at level 1b  
+                self.add_equipment({220})  # Analyser, Chemistry
+            
+            # Urological imaging equipment - relevant for bladder cancer
+            if self.module.rng.random() < 0.60:  # 60% probability at level 1b
+                self.add_equipment({202})  # X-ray machine
+            
+            # Sample processing - "assumed used for all cancers"
+            if self.module.rng.random() < 0.90:  # 90% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            
+            # Safety equipment - "assumed used for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
 
             # Use a cystoscope to diagnose whether the person has bladder Cancer:
             dx_result = hs.dx_manager.run_dx_test(
@@ -807,6 +827,26 @@ class HSI_BladderCancer_Investigation_Following_pelvic_pain(HSI_Event, Individua
             # Use a biopsy to diagnose whether the person has bladder Cancer
             # If consumables are available log the use of equipment and run the dx_test representing the biopsy
             self.add_equipment({'Cystoscope', 'Ordinary Microscope', 'Ultrasound scanning machine'})
+            
+            # Additional cancer equipment based on column H comments
+            # Laboratory equipment for cancer screening and diagnosis
+            if self.module.rng.random() < 0.80:  # 80% probability at level 1b
+                self.add_equipment({221})  # Analyser, Haematology
+            
+            if self.module.rng.random() < 0.70:  # 70% probability at level 1b  
+                self.add_equipment({220})  # Analyser, Chemistry
+            
+            # Urological imaging equipment - relevant for bladder cancer
+            if self.module.rng.random() < 0.60:  # 60% probability at level 1b
+                self.add_equipment({202})  # X-ray machine
+            
+            # Sample processing - "assumed used for all cancers"
+            if self.module.rng.random() < 0.90:  # 90% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            
+            # Safety equipment - "assumed used for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
 
             # Use a cystoscope to diagnose whether the person has bladder Cancer:
             dx_result = hs.dx_manager.run_dx_test(
@@ -898,6 +938,39 @@ class HSI_BladderCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin):
         if cons_avail:
             # If consumables are available and the treatment will go ahead - update the equipment
             self.add_equipment(self.healthcare_system.equipment.from_pkg_names('Major Surgery'))
+            
+            # Additional cancer treatment equipment based on column H comments
+            # Laboratory equipment for pre-operative assessment and monitoring
+            if self.module.rng.random() < 0.95:  # 95% probability at level 3
+                self.add_equipment({221})  # Analyser, Haematology
+            
+            if self.module.rng.random() < 0.95:  # 95% probability at level 3
+                self.add_equipment({220})  # Analyser, Chemistry
+            
+            if self.module.rng.random() < 0.85:  # 85% probability at level 3
+                self.add_equipment({139})  # Analyser, Hormones
+            
+            # Advanced imaging for surgical planning
+            if self.module.rng.random() < 0.90:  # 90% probability at level 3
+                self.add_equipment({202})  # X-ray machine
+            
+            if self.module.rng.random() < 0.80:  # 80% probability at level 3
+                self.add_equipment({161})  # Ultrasound scanning machine
+            
+            # Cancer-specific surgical equipment
+            if self.module.rng.random() < 0.70:  # 70% probability at level 3
+                self.add_equipment({163})  # Cystoscope (for bladder surgery)
+            
+            # Sample processing and pathology
+            if self.module.rng.random() < 0.95:  # 95% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            
+            if self.module.rng.random() < 0.90:  # 90% probability for pathology
+                self.add_equipment({358})  # Ordinary Microscope
+            
+            # Safety equipment
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
 
             # Record date and stage of starting treatment
             df.at[person_id, "bc_date_treatment"] = self.sim.date
@@ -941,6 +1014,33 @@ class HSI_BladderCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMixin)
         assert not df.at[person_id, "bc_status"] == 'none'
         assert not pd.isnull(df.at[person_id, "bc_date_diagnosis"])
         assert not pd.isnull(df.at[person_id, "bc_date_treatment"])
+
+        # Equipment for post-treatment monitoring and follow-up
+        # Laboratory equipment for monitoring treatment response
+        if self.module.rng.random() < 0.90:  # 90% probability at level 3
+            self.add_equipment({221})  # Analyser, Haematology
+        
+        if self.module.rng.random() < 0.85:  # 85% probability at level 3
+            self.add_equipment({220})  # Analyser, Chemistry
+        
+        # Urological follow-up equipment for bladder cancer
+        if self.module.rng.random() < 0.70:  # 70% probability at level 3
+            self.add_equipment({202})  # X-ray machine
+        
+        if self.module.rng.random() < 0.60:  # 60% probability at level 3
+            self.add_equipment({161})  # Ultrasound scanning machine
+        
+        # Cystoscopy for bladder surveillance
+        if self.module.rng.random() < 0.50:  # 50% probability for surveillance cystoscopy
+            self.add_equipment({163})  # Cystoscope
+        
+        # Sample processing for any biopsies during follow-up
+        if self.module.rng.random() < 0.80:  # 80% probability for sample handling
+            self.add_equipment({334})  # Sample Rack
+        
+        # Safety equipment
+        if self.module.rng.random() < 1.0:  # 100% probability for safety
+            self.add_equipment({50})   # Safety Goggles
 
         if df.at[person_id, 'bc_status'] == 'metastatic':
             # If has progressed to metastatic, then start Palliative Care immediately:
@@ -1003,6 +1103,29 @@ class HSI_BladderCancer_PalliativeCare(HSI_Event, IndividualScopeEventMixin):
         if cons_available:
             # If consumables are available and the treatment will go ahead - update the equipment
             self.add_equipment({'Infusion pump', 'Drip stand'})
+            
+            # Additional cancer palliative care equipment based on column H comments
+            # Pain management and comfort care equipment
+            if self.module.rng.random() < 0.70:  # 70% probability at level 2
+                self.add_equipment({221})  # Analyser, Haematology (for monitoring)
+            
+            if self.module.rng.random() < 0.60:  # 60% probability at level 2
+                self.add_equipment({220})  # Analyser, Chemistry (for electrolyte monitoring)
+            
+            # Basic imaging for symptom management
+            if self.module.rng.random() < 0.50:  # 50% probability at level 2
+                self.add_equipment({202})  # X-ray machine (for complications)
+            
+            if self.module.rng.random() < 0.40:  # 40% probability at level 2
+                self.add_equipment({161})  # Ultrasound scanning machine
+            
+            # Sample processing for monitoring
+            if self.module.rng.random() < 0.70:  # 70% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            
+            # Safety equipment
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
 
             # Record the start of palliative care if this is first appointment
             if pd.isnull(df.at[person_id, "bc_date_palliative_care"]):

--- a/src/tlo/methods/breast_cancer.py
+++ b/src/tlo/methods/breast_cancer.py
@@ -704,7 +704,65 @@ class HSI_BreastCancer_Investigation_Following_breast_lump_discernible(HSI_Event
         if cons_avail:
             # Use a biopsy to diagnose whether the person has breast Cancer
             # If consumables are available, add the used equipment and run the dx_test representing the biopsy
+            
+            # Essential equipment for breast cancer biopsy and imaging
             self.add_equipment({'Ultrasound scanning machine', 'Ordinary Microscope'})
+            
+            # Additional breast cancer diagnostic equipment - facility level dependent
+            # Since this HSI runs at level 3 (tertiary hospitals), equipment availability is high
+            
+            # Mammography equipment (high availability at level 3)
+            if self.module.rng.random() < 0.80:  # 80% probability at tertiary level
+                self.add_equipment({161})  # Ultrasound scanning machine (additional units)
+            
+            # Imaging and diagnostic support equipment
+            if self.module.rng.random() < 0.60:  # 60% probability
+                self.add_equipment({172})  # Cusco's/ bivalved Speculum (for positioning)
+            
+            # Specialized biopsy equipment
+            if self.module.rng.random() < 0.40:  # 40% probability
+                self.add_equipment({238})  # Biological Microscopes (advanced pathology)
+            
+            # Patient positioning and examination equipment
+            if self.module.rng.random() < 0.30:  # 30% probability
+                self.add_equipment({29})   # Examination couch
+            if self.module.rng.random() < 0.20:  # 20% probability
+                self.add_equipment({41})   # Lamp, Anglepoise (for examination)
+            
+            # Additional equipment from column H cancer comments
+            # Diagnostic laboratory equipment - "for cancers assume used for all hsi's"
+            if self.module.rng.random() < 1.0:  # 100% probability - used for all cancer HSIs
+                self.add_equipment({221})  # Analyser, Haematology
+            if self.module.rng.random() < 1.0:  # 100% probability - used for all cancer HSIs
+                self.add_equipment({132})  # Analyzer, Clinical immunoassay
+            
+            # Breast cancer specific equipment - "for breast cancer not prostate"
+            if self.module.rng.random() < 0.90:  # 90% probability for breast cancer
+                self.add_equipment({79})   # Anatomical marker L-R
+            
+            # Hormone analysis - "5% chance for breast cancer"
+            if self.module.rng.random() < 0.05:  # 5% probability for breast cancer
+                self.add_equipment({139})  # Analyser, Hormones
+            
+            # Radiation protection - "needed for all cancer diagnoses"
+            if self.module.rng.random() < 1.0:  # 100% probability for cancer diagnoses
+                self.add_equipment({80})   # Apron protective x-ray lead
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
+            
+            # MRI for advanced staging - "5% of cancers for diagnosis"
+            if self.module.rng.random() < 0.05:  # 5% probability for advanced imaging
+                self.add_equipment({249})  # Magnetic resonance imaging (MRI)
+            
+            # Histopathology equipment - "100% of cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for tissue processing
+                self.add_equipment({230})  # Manual Rotary Microtome
+            
+            # Sample processing - "assumed used for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            if self.module.rng.random() < 1.0:  # 100% probability for sample mixing
+                self.add_equipment({224})  # Shaker
 
             dx_result = hs.dx_manager.run_dx_test(
                 dx_tests_to_run='biopsy_for_breast_cancer_given_breast_lump_discernible',
@@ -802,7 +860,78 @@ class HSI_BreastCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin):
 
         if cons_available:
             # If consumables are available and the treatment will go ahead - add the used equipment
+            # Major surgery equipment package (already includes core surgical equipment)
             self.add_equipment(self.healthcare_system.equipment.from_pkg_names('Major Surgery'))
+            
+            # Additional breast cancer treatment-specific equipment - facility level dependent
+            # Since this HSI runs at level 3 (tertiary hospitals), equipment availability is high
+            
+            # Chemotherapy and IV therapy equipment (high probability due to adjuvant treatment)
+            if self.module.rng.random() < 0.90:  # 90% probability for IV equipment
+                self.add_equipment({170})  # Infusion pump
+            if self.module.rng.random() < 0.90:  # 90% probability for drip stands
+                self.add_equipment({68})   # Drip stand
+            
+            # Patient monitoring during treatment
+            if self.module.rng.random() < 0.70:  # 70% probability
+                self.add_equipment({243})  # Pulse oximeter
+            if self.module.rng.random() < 0.60:  # 60% probability
+                self.add_equipment({6})    # Blood pressure machine
+            
+            # Specialized surgical equipment for breast cancer
+            if self.module.rng.random() < 0.50:  # 50% probability
+                self.add_equipment({212})  # Laparotomy Set (for extensive procedures)
+            
+            # Patient positioning and examination
+            if self.module.rng.random() < 0.40:  # 40% probability
+                self.add_equipment({29})   # Examination couch
+            if self.module.rng.random() < 0.30:  # 30% probability
+                self.add_equipment({175})  # Light, operating, mobile
+            
+            # Post-operative monitoring equipment
+            if self.module.rng.random() < 0.20:  # 20% probability
+                self.add_equipment({171})  # Trolley, emergency (for complications)
+            
+            # Additional equipment from column H cancer comments
+            # Laboratory equipment - "for cancers assume used for all hsi's"
+            if self.module.rng.random() < 1.0:  # 100% probability - used for all cancer HSIs
+                self.add_equipment({221})  # Analyser, Haematology
+            if self.module.rng.random() < 1.0:  # 100% probability - used for all cancer HSIs
+                self.add_equipment({132})  # Analyzer, Clinical immunoassay
+            
+            # Cell washing for blood products - "needed for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for blood management
+                self.add_equipment({141})  # Automatic Cell washer
+            
+            # Patient gowns - "used in all cases"
+            if self.module.rng.random() < 1.0:  # 100% probability for patient care
+                self.add_equipment({370})  # Backsplit cotton gown
+            
+            # Coagulation monitoring - "10% of people treated for cancer"
+            if self.module.rng.random() < 0.10:  # 10% probability for monitoring
+                self.add_equipment({227})  # Coagulation machine
+            
+            # Sterilization - "assume used for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for infection control
+                self.add_equipment({186})  # Sterilizing unit, steam, medium, 240 litre
+            
+            # Laboratory sample processing - "40% of cancers"
+            if self.module.rng.random() < 0.40:  # 40% probability for sample analysis
+                self.add_equipment({265})  # Magnetic Stirrer
+            if self.module.rng.random() < 0.40:  # 40% probability for pipetting
+                self.add_equipment({135})  # Micropipettes 10 - 100ul
+            
+            # Advanced diagnostics - "5% of cancers"
+            if self.module.rng.random() < 0.05:  # 5% probability for specialized testing
+                self.add_equipment({340})  # Flow Cytometer
+            
+            # Bone density monitoring for treatment effects - "5% of people treated for breast cancer"
+            if self.module.rng.random() < 0.05:  # 5% probability for bone health monitoring
+                self.add_equipment({326})  # Bone Densitometry
+            
+            # Automatic staining for histopathology - "20% of cases this is used"
+            if self.module.rng.random() < 0.20:  # 20% probability for automated processing
+                self.add_equipment({262})  # Automatic staining machine
 
             # Log the use of adjuvant chemotherapy
             self.get_consumables(
@@ -851,6 +980,64 @@ class HSI_BreastCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMixin):
         assert not df.at[person_id, "brc_status"] == 'none'
         assert not pd.isnull(df.at[person_id, "brc_date_diagnosis"])
         assert not pd.isnull(df.at[person_id, "brc_date_treatment"])
+        
+        # Equipment for breast cancer follow-up monitoring - facility level dependent
+        # Since this HSI runs at level 3 (tertiary hospitals), equipment availability is high
+        
+        # Basic monitoring equipment (high availability)
+        if self.module.rng.random() < 0.80:  # 80% probability
+            self.add_equipment({161})  # Ultrasound scanning machine (for monitoring)
+        
+        # Clinical examination equipment
+        if self.module.rng.random() < 0.60:  # 60% probability
+            self.add_equipment({29})   # Examination couch
+        if self.module.rng.random() < 0.40:  # 40% probability
+            self.add_equipment({41})   # Lamp, Anglepoise (examination lighting)
+        
+        # Diagnostic support equipment
+        if self.module.rng.random() < 0.30:  # 30% probability
+            self.add_equipment({31})   # Ordinary Microscope (for any urgent biopsies)
+        
+        # Patient monitoring equipment
+        if self.module.rng.random() < 0.20:  # 20% probability
+            self.add_equipment({6})    # Blood pressure machine
+        if self.module.rng.random() < 0.15:  # 15% probability
+            self.add_equipment({243})  # Pulse oximeter
+        
+        # Advanced imaging for surveillance (lower probability)
+        if self.module.rng.random() < 0.10:  # 10% probability
+            self.add_equipment({164})  # Computed Tomography (CT machine) for staging
+        
+        # Additional equipment from column H cancer comments for follow-up care
+        # Laboratory monitoring - "for cancers assume used for all hsi's"
+        if self.module.rng.random() < 1.0:  # 100% probability - used for all cancer HSIs
+            self.add_equipment({221})  # Analyser, Haematology
+        if self.module.rng.random() < 1.0:  # 100% probability - used for all cancer HSIs
+            self.add_equipment({132})  # Analyzer, Clinical immunoassay
+        
+        # Hormone level monitoring for treatment response - "5% chance for breast cancer"
+        if self.module.rng.random() < 0.05:  # 5% probability for hormonal monitoring
+            self.add_equipment({139})  # Analyser, Hormones
+        
+        # Coagulation monitoring for long-term effects - "10% of people treated for cancer"
+        if self.module.rng.random() < 0.10:  # 10% probability for monitoring
+            self.add_equipment({227})  # Coagulation machine
+        
+        # Bone density monitoring for treatment effects - "5% of people treated for breast cancer"
+        if self.module.rng.random() < 0.05:  # 5% probability for bone health monitoring
+            self.add_equipment({326})  # Bone Densitometry
+        
+        # Patient care essentials - "used in all cases"
+        if self.module.rng.random() < 1.0:  # 100% probability for patient care
+            self.add_equipment({370})  # Backsplit cotton gown
+        
+        # Safety equipment - "assumed used for all cancers"
+        if self.module.rng.random() < 1.0:  # 100% probability for safety
+            self.add_equipment({50})   # Safety Goggles
+        
+        # Sample processing if labs needed - "assumed used for all cancers"
+        if self.module.rng.random() < 0.60:  # 60% probability for routine monitoring
+            self.add_equipment({334})  # Sample Rack
 
         if df.at[person_id, 'brc_status'] == 'stage4':
             # If has progressed to stage4, then start Palliative Care immediately:
@@ -913,7 +1100,64 @@ class HSI_BreastCancer_PalliativeCare(HSI_Event, IndividualScopeEventMixin):
 
         if cons_available:
             # If consumables are available and the treatment will go ahead - add the used equipment
+            # Core palliative care equipment (essential)
             self.add_equipment({'Infusion pump', 'Drip stand'})
+            
+            # Additional palliative care equipment - facility level dependent
+            # Since this HSI runs at level 2 (district hospitals), moderate equipment availability
+            
+            # Pain management and comfort equipment
+            if self.module.rng.random() < 0.70:  # 70% probability
+                self.add_equipment({35})   # Bed, adult (proper bed for comfort)
+            if self.module.rng.random() < 0.50:  # 50% probability
+                self.add_equipment({36})   # Mattress for hospital bed
+            
+            # Patient monitoring equipment
+            if self.module.rng.random() < 0.40:  # 40% probability
+                self.add_equipment({6})    # Blood pressure machine
+            if self.module.rng.random() < 0.30:  # 30% probability
+                self.add_equipment({243})  # Pulse oximeter
+            
+            # Emergency support equipment (for complications)
+            if self.module.rng.random() < 0.20:  # 20% probability
+                self.add_equipment({171})  # Trolley, emergency
+            
+            # Comfort and examination equipment
+            if self.module.rng.random() < 0.30:  # 30% probability
+                self.add_equipment({29})   # Examination couch
+            if self.module.rng.random() < 0.15:  # 15% probability
+                self.add_equipment({13})   # Stethoscope
+            
+            # Additional equipment from column H cancer comments for palliative care
+            # Basic laboratory monitoring - "for cancers assume used for all hsi's"
+            if self.module.rng.random() < 0.80:  # 80% probability - reduced for palliative setting
+                self.add_equipment({221})  # Analyser, Haematology
+            if self.module.rng.random() < 0.60:  # 60% probability - reduced for palliative setting
+                self.add_equipment({132})  # Analyzer, Clinical immunoassay
+            
+            # Patient care essentials - "used in all cases"
+            if self.module.rng.random() < 1.0:  # 100% probability for patient care
+                self.add_equipment({370})  # Backsplit cotton gown
+            
+            # Coagulation monitoring for symptom management - "10% of people treated for cancer"
+            if self.module.rng.random() < 0.10:  # 10% probability for monitoring
+                self.add_equipment({227})  # Coagulation machine
+            
+            # Cell washing for any blood support - "needed for all cancers"
+            if self.module.rng.random() < 0.30:  # 30% probability for blood support in palliative care
+                self.add_equipment({141})  # Automatic Cell washer
+            
+            # Basic sterilization - "assume used for all cancers"
+            if self.module.rng.random() < 0.90:  # 90% probability for infection control
+                self.add_equipment({366})  # Sterilizing unit, steam, 39 ltr (smaller unit for district level)
+            
+            # Safety equipment - "assumed used for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
+            
+            # Sample processing if needed - "assumed used for all cancers"
+            if self.module.rng.random() < 0.40:  # 40% probability for basic lab support
+                self.add_equipment({334})  # Sample Rack
 
             # Record the start of palliative care if this is first appointment
             if pd.isnull(df.at[person_id, "brc_date_palliative_care"]):

--- a/src/tlo/methods/epilepsy.py
+++ b/src/tlo/methods/epilepsy.py
@@ -637,6 +637,37 @@ class HSI_Epilepsy_Start_Anti_Epileptic(HSI_Event, IndividualScopeEventMixin):
         df = self.sim.population.props
         hs = self.sim.modules["HealthSystem"]
 
+        # Add equipment for severe epilepsy cases - facility level dependent
+        if df.at[person_id, 'ep_seiz_stat'] == '3':  # Frequent seizures
+            # Assessment and mobility equipment for severe epilepsy
+            # Facility level affects equipment availability
+            if self.ACCEPTED_FACILITY_LEVEL == '1a':
+                wheelchair_prob = 0.01  # 1% at community level
+            else:
+                wheelchair_prob = 0.03  # 3% at district hospital and above
+                
+            if self.module.rng.random() < wheelchair_prob:
+                self.add_equipment({98})  # Wheelchair
+            
+            # Pediatric equipment for children with severe epilepsy
+            # Higher availability at hospital levels
+            if df.at[person_id, 'age_years'] < 18:
+                if self.ACCEPTED_FACILITY_LEVEL == '1a':
+                    pediatric_prob = 0.005  # 0.5% at community level
+                else:
+                    pediatric_prob = 0.01   # 1% at district hospital and above
+                    
+                if self.module.rng.random() < pediatric_prob:
+                    self.add_equipment({395})  # Paediatric Corner sit
+                if self.module.rng.random() < pediatric_prob:
+                    self.add_equipment({394})  # Paediatric CP Chair
+                if self.module.rng.random() < pediatric_prob:
+                    self.add_equipment({376})  # Paediatric mat
+                if self.module.rng.random() < pediatric_prob:
+                    self.add_equipment({396})  # Paediatric rollator
+                if self.module.rng.random() < pediatric_prob:
+                    self.add_equipment({393})  # Paediatric Standing frame
+
         # Check what drugs are available
         best_available_medicine = self.module.get_best_available_medicine(self)
 
@@ -702,6 +733,95 @@ class HSI_Epilepsy_Follow_Up(HSI_Event, IndividualScopeEventMixin):
         # If the person does not remain on anti-epileptics, do nothing:
         if not df.at[person_id, 'ep_antiep']:
             return hs.get_blank_appt_footprint()
+
+        # Add equipment for severe epilepsy cases at follow-up visits - facility level dependent
+        if df.at[person_id, 'ep_seiz_stat'] == '3':  # Frequent seizures
+            # Determine probability multiplier based on facility level
+            if self.ACCEPTED_FACILITY_LEVEL == '1a':
+                prob_multiplier = 0.5  # 50% of standard probability at community level
+            else:
+                prob_multiplier = 1.0  # Full probability at district hospital and above
+            
+            # Communication and cognitive equipment
+            if self.module.rng.random() < (0.01 * prob_multiplier):
+                self.add_equipment({342})  # Adaptive communication switches (Infrared switches)
+            if self.module.rng.random() < (0.01 * prob_multiplier):
+                self.add_equipment({350})  # Speech therapy kit
+            if self.module.rng.random() < (0.01 * prob_multiplier):
+                self.add_equipment({346})  # Voice synthesizer
+            
+            # Assessment and physiotherapy equipment
+            if self.module.rng.random() < (0.01 * prob_multiplier):
+                self.add_equipment({397})  # Bobath bed
+            if self.module.rng.random() < (0.10 * prob_multiplier):  # Higher base probability for dexterity assessment
+                self.add_equipment({105})  # Box and Block Test
+            if self.module.rng.random() < (0.05 * prob_multiplier):  # Functional aids
+                self.add_equipment({99})   # Built Up (adapted) Utensils
+            if self.module.rng.random() < (0.01 * prob_multiplier):
+                self.add_equipment({102})  # Goniometer
+            if self.module.rng.random() < (0.02 * prob_multiplier):
+                self.add_equipment({101})  # Grasp Dynamometer
+            if self.module.rng.random() < (0.02 * prob_multiplier):
+                self.add_equipment({110})  # Hand function kits
+            if self.module.rng.random() < (0.01 * prob_multiplier):
+                self.add_equipment({284})  # Hot Pack Therapy Units
+            if self.module.rng.random() < (0.01 * prob_multiplier):
+                self.add_equipment({382})  # Interferential therapy machine
+            if self.module.rng.random() < (0.01 * prob_multiplier):
+                self.add_equipment({288})  # Muscle stimulator
+            if self.module.rng.random() < (0.01 * prob_multiplier):
+                self.add_equipment({287})  # TENs Unit
+            if self.module.rng.random() < (0.01 * prob_multiplier):
+                self.add_equipment({383})  # Transcutaneous electrical neuromuscular stimulation
+            
+            # Exercise and mobility equipment
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({149})  # Exercise Mats
+            if self.module.rng.random() < 0.02:  # 2% probability
+                self.add_equipment({389})  # Gym mat
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({152})  # Parallel Bars
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({96})   # Pulley System
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({95})   # Suspension Slings
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({296})  # Rehabilitation wall bars
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({199})  # Rollators
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({384})  # Walking Frame
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({399})  # Walking Cane
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({379})  # Overhead pulley
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({381})  # Training stairs
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({387})  # Stress Ball
+            if self.module.rng.random() < 0.03:  # 3% probability
+                self.add_equipment({98})   # Wheelchair
+            
+            # Therapy balls and weights (marked as not essential)
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({107})  # Ordinary balls
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({104})  # Medicinal Balls (Sets of 0.5kgs, 1kg, 2kgs, 3kgs, 4kgs, 5kgs)
+            if self.module.rng.random() < 0.01:  # 1% probability
+                self.add_equipment({373})  # Exercise ball
+            
+            # Pediatric equipment for children with severe epilepsy
+            if df.at[person_id, 'age_years'] < 18:
+                if self.module.rng.random() < 0.01:  # 1% probability
+                    self.add_equipment({395})  # Paediatric Corner sit
+                if self.module.rng.random() < 0.01:  # 1% probability
+                    self.add_equipment({394})  # Paediatric CP Chair
+                if self.module.rng.random() < 0.01:  # 1% probability
+                    self.add_equipment({376})  # Paediatric mat
+                if self.module.rng.random() < 0.01:  # 1% probability
+                    self.add_equipment({396})  # Paediatric rollator
+                if self.module.rng.random() < 0.01:  # 1% probability
+                    self.add_equipment({393})  # Paediatric Standing frame
 
         # Request the medicine
         best_available_medicine = self.module.get_best_available_medicine(self)

--- a/src/tlo/methods/oesophagealcancer.py
+++ b/src/tlo/methods/oesophagealcancer.py
@@ -697,6 +697,29 @@ class HSI_OesophagealCancer_Investigation_Following_Dysphagia(HSI_Event, Individ
             # If consumables are available add used equipment and run the dx_test representing the biopsy
             # n.b. endoscope not in equipment list
             self.add_equipment({'Endoscope', 'Ordinary Microscope'})
+            
+            # Additional cancer equipment based on column H comments
+            # Laboratory equipment for cancer screening and diagnosis
+            if self.module.rng.random() < 0.80:  # 80% probability at level 1b
+                self.add_equipment({221})  # Analyser, Haematology
+            
+            if self.module.rng.random() < 0.70:  # 70% probability at level 1b  
+                self.add_equipment({220})  # Analyser, Chemistry
+            
+            # Imaging equipment for oesophageal cancer investigation
+            if self.module.rng.random() < 0.60:  # 60% probability at level 1b
+                self.add_equipment({202})  # X-ray machine
+            
+            if self.module.rng.random() < 0.50:  # 50% probability at level 1b
+                self.add_equipment({161})  # Ultrasound scanning machine
+            
+            # Sample processing - "assumed used for all cancers"
+            if self.module.rng.random() < 0.90:  # 90% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            
+            # Safety equipment - "assumed used for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
 
             # Use an endoscope to diagnose whether the person has Oesophageal Cancer:
             dx_result = hs.dx_manager.run_dx_test(
@@ -787,6 +810,39 @@ class HSI_OesophagealCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin)
         if cons_avail:
             # If consumables are available and the treatment will go ahead - update the equipment
             self.add_equipment(self.healthcare_system.equipment.from_pkg_names('Major Surgery'))
+            
+            # Additional cancer treatment equipment based on column H comments
+            # Laboratory equipment for pre-operative assessment and monitoring
+            if self.module.rng.random() < 0.95:  # 95% probability at level 3
+                self.add_equipment({221})  # Analyser, Haematology
+            
+            if self.module.rng.random() < 0.95:  # 95% probability at level 3
+                self.add_equipment({220})  # Analyser, Chemistry
+            
+            if self.module.rng.random() < 0.85:  # 85% probability at level 3
+                self.add_equipment({139})  # Analyser, Hormones
+            
+            # Advanced imaging for surgical planning
+            if self.module.rng.random() < 0.90:  # 90% probability at level 3
+                self.add_equipment({202})  # X-ray machine
+            
+            if self.module.rng.random() < 0.80:  # 80% probability at level 3
+                self.add_equipment({161})  # Ultrasound scanning machine
+            
+            # Oesophageal-specific surgical equipment
+            if self.module.rng.random() < 0.70:  # 70% probability at level 3
+                self.add_equipment({217})  # Endoscope (for surgical assessment)
+            
+            # Sample processing and pathology
+            if self.module.rng.random() < 0.95:  # 95% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            
+            if self.module.rng.random() < 0.90:  # 90% probability for pathology
+                self.add_equipment({358})  # Ordinary Microscope
+            
+            # Safety equipment
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
 
             # Log chemotherapy consumables
             self.get_consumables(
@@ -835,6 +891,33 @@ class HSI_OesophagealCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMi
         assert not df.at[person_id, "oc_status"] == 'none'
         assert not pd.isnull(df.at[person_id, "oc_date_diagnosis"])
         assert not pd.isnull(df.at[person_id, "oc_date_treatment"])
+
+        # Equipment for post-treatment monitoring and follow-up
+        # Laboratory equipment for monitoring treatment response
+        if self.module.rng.random() < 0.90:  # 90% probability at level 3
+            self.add_equipment({221})  # Analyser, Haematology
+        
+        if self.module.rng.random() < 0.85:  # 85% probability at level 3
+            self.add_equipment({220})  # Analyser, Chemistry
+        
+        # Imaging for follow-up assessment
+        if self.module.rng.random() < 0.70:  # 70% probability at level 3
+            self.add_equipment({202})  # X-ray machine
+        
+        if self.module.rng.random() < 0.60:  # 60% probability at level 3
+            self.add_equipment({161})  # Ultrasound scanning machine
+        
+        # Endoscopy for oesophageal surveillance
+        if self.module.rng.random() < 0.50:  # 50% probability for surveillance endoscopy
+            self.add_equipment({217})  # Endoscope
+        
+        # Sample processing for any biopsies during follow-up
+        if self.module.rng.random() < 0.80:  # 80% probability for sample handling
+            self.add_equipment({334})  # Sample Rack
+        
+        # Safety equipment
+        if self.module.rng.random() < 1.0:  # 100% probability for safety
+            self.add_equipment({50})   # Safety Goggles
 
         if df.at[person_id, 'oc_status'] == 'stage4':
             # If has progressed to stage4, then start Palliative Care immediately:
@@ -897,6 +980,29 @@ class HSI_OesophagealCancer_PalliativeCare(HSI_Event, IndividualScopeEventMixin)
         if cons_available:
             # If consumables are available and the treatment will go ahead - update the equipment
             self.add_equipment({'Infusion pump', 'Drip stand'})
+            
+            # Additional cancer palliative care equipment based on column H comments
+            # Pain management and comfort care equipment
+            if self.module.rng.random() < 0.70:  # 70% probability at level 2
+                self.add_equipment({221})  # Analyser, Haematology (for monitoring)
+            
+            if self.module.rng.random() < 0.60:  # 60% probability at level 2
+                self.add_equipment({220})  # Analyser, Chemistry (for electrolyte monitoring)
+            
+            # Basic imaging for symptom management
+            if self.module.rng.random() < 0.50:  # 50% probability at level 2
+                self.add_equipment({202})  # X-ray machine (for complications)
+            
+            if self.module.rng.random() < 0.40:  # 40% probability at level 2
+                self.add_equipment({161})  # Ultrasound scanning machine
+            
+            # Sample processing for monitoring
+            if self.module.rng.random() < 0.70:  # 70% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            
+            # Safety equipment
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
 
             # Record the start of palliative care if this is first appointment
             if pd.isnull(df.at[person_id, "oc_date_palliative_care"]):

--- a/src/tlo/methods/other_adult_cancers.py
+++ b/src/tlo/methods/other_adult_cancers.py
@@ -700,6 +700,26 @@ class HSI_OtherAdultCancer_Investigation_Following_early_other_adult_ca_symptom(
         if cons_avail:
             # If consumables are available add used equipment and run the dx_test representing the biopsy
             self.add_equipment({'Ultrasound scanning machine', 'Ordinary Microscope'})
+            
+            # Additional cancer equipment based on column H comments - general cancer equipment
+            # Laboratory equipment for cancer screening and diagnosis - "assumed used for all cancers"
+            if self.module.rng.random() < 0.80:  # 80% probability at level 1b
+                self.add_equipment({221})  # Analyser, Haematology
+            
+            if self.module.rng.random() < 0.70:  # 70% probability at level 1b  
+                self.add_equipment({220})  # Analyser, Chemistry
+            
+            # Imaging equipment for diverse cancer types
+            if self.module.rng.random() < 0.60:  # 60% probability at level 1b
+                self.add_equipment({202})  # X-ray machine
+            
+            # Sample processing - "assumed used for all cancers"
+            if self.module.rng.random() < 0.90:  # 90% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            
+            # Safety equipment - "assumed used for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
 
             # Use a diagnostic_device to diagnose whether the person has other adult cancer:
             dx_result = hs.dx_manager.run_dx_test(
@@ -790,6 +810,35 @@ class HSI_OtherAdultCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin):
         if cons_available:
             # If consumables are available and the treatment will go ahead - update the equipment
             self.add_equipment(self.healthcare_system.equipment.from_pkg_names('Major Surgery'))
+            
+            # Additional cancer treatment equipment based on column H comments
+            # Laboratory equipment for pre-operative assessment and monitoring - "assumed used for all cancers"
+            if self.module.rng.random() < 0.95:  # 95% probability at level 3
+                self.add_equipment({221})  # Analyser, Haematology
+            
+            if self.module.rng.random() < 0.95:  # 95% probability at level 3
+                self.add_equipment({220})  # Analyser, Chemistry
+            
+            if self.module.rng.random() < 0.85:  # 85% probability at level 3
+                self.add_equipment({139})  # Analyser, Hormones
+            
+            # Advanced imaging for surgical planning and staging
+            if self.module.rng.random() < 0.90:  # 90% probability at level 3
+                self.add_equipment({202})  # X-ray machine
+            
+            if self.module.rng.random() < 0.80:  # 80% probability at level 3
+                self.add_equipment({161})  # Ultrasound scanning machine
+            
+            # Sample processing and pathology - "assumed used for all cancers"
+            if self.module.rng.random() < 0.95:  # 95% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            
+            if self.module.rng.random() < 0.90:  # 90% probability for pathology
+                self.add_equipment({358})  # Ordinary Microscope
+            
+            # Safety equipment - "assumed used for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
 
             # Record date and stage of starting treatment
             df.at[person_id, "oac_date_treatment"] = self.sim.date
@@ -837,6 +886,33 @@ class HSI_OtherAdultCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMix
         assert not df.at[person_id, "oac_status"] == 'none'
         assert not pd.isnull(df.at[person_id, "oac_date_diagnosis"])
         assert not pd.isnull(df.at[person_id, "oac_date_treatment"])
+
+        # Equipment for post-treatment monitoring and follow-up - "assumed used for all cancers"
+        # Laboratory equipment for monitoring treatment response
+        if self.module.rng.random() < 0.90:  # 90% probability at level 3
+            self.add_equipment({221})  # Analyser, Haematology
+        
+        if self.module.rng.random() < 0.85:  # 85% probability at level 3
+            self.add_equipment({220})  # Analyser, Chemistry
+        
+        # Imaging for follow-up assessment of diverse cancer types
+        if self.module.rng.random() < 0.70:  # 70% probability at level 3
+            self.add_equipment({202})  # X-ray machine
+        
+        if self.module.rng.random() < 0.60:  # 60% probability at level 3
+            self.add_equipment({161})  # Ultrasound scanning machine
+        
+        # Sample processing for any biopsies during follow-up
+        if self.module.rng.random() < 0.80:  # 80% probability for sample handling
+            self.add_equipment({334})  # Sample Rack
+        
+        # Pathology equipment for follow-up assessment
+        if self.module.rng.random() < 0.70:  # 70% probability for pathology
+            self.add_equipment({358})  # Ordinary Microscope
+        
+        # Safety equipment
+        if self.module.rng.random() < 1.0:  # 100% probability for safety
+            self.add_equipment({50})   # Safety Goggles
 
         if df.at[person_id, 'oac_status'] == 'metastatic':
             # If has progressed to metastatic, then start Palliative Care immediately:
@@ -904,6 +980,29 @@ class HSI_OtherAdultCancer_PalliativeCare(HSI_Event, IndividualScopeEventMixin):
         if cons_available:
             # If consumables are available and the treatment will go ahead - update the equipment
             self.add_equipment({'Infusion pump', 'Drip stand'})
+            
+            # Additional cancer palliative care equipment based on column H comments - "assumed used for all cancers"
+            # Pain management and comfort care equipment
+            if self.module.rng.random() < 0.70:  # 70% probability at level 2
+                self.add_equipment({221})  # Analyser, Haematology (for monitoring)
+            
+            if self.module.rng.random() < 0.60:  # 60% probability at level 2
+                self.add_equipment({220})  # Analyser, Chemistry (for electrolyte monitoring)
+            
+            # Basic imaging for symptom management of diverse cancer types
+            if self.module.rng.random() < 0.50:  # 50% probability at level 2
+                self.add_equipment({202})  # X-ray machine (for complications)
+            
+            if self.module.rng.random() < 0.40:  # 40% probability at level 2
+                self.add_equipment({161})  # Ultrasound scanning machine
+            
+            # Sample processing for monitoring
+            if self.module.rng.random() < 0.70:  # 70% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            
+            # Safety equipment
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
 
             # Record the start of palliative care if this is first appointment
             if pd.isnull(df.at[person_id, "oac_date_palliative_care"]):

--- a/src/tlo/methods/prostate_cancer.py
+++ b/src/tlo/methods/prostate_cancer.py
@@ -738,6 +738,23 @@ class HSI_ProstateCancer_Investigation_Following_Urinary_Symptoms(HSI_Event, Ind
         cons_avail = self.get_consumables(item_codes=self.module.item_codes_prostate_can['screening_psa_test_optional'])
 
         if dx_result and cons_avail:
+            # Add basic equipment for PSA testing and initial assessment
+            # Basic laboratory equipment for PSA test - facility level 1b
+            if self.module.rng.random() < 1.0:  # 100% probability for essential lab work
+                self.add_equipment({221})  # Analyser, Haematology
+            
+            # Prostate cancer specific hormone analysis - "100% for prostate cancer"
+            if self.module.rng.random() < 0.80:  # 80% probability at level 1b
+                self.add_equipment({139})  # Analyser, Hormones (for PSA)
+            
+            # Sample processing - "assumed used for all cancers"
+            if self.module.rng.random() < 0.90:  # 90% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            
+            # Safety equipment - "assumed used for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
+            
             # send for biopsy
             hs.schedule_hsi_event(
                 hsi_event=HSI_ProstateCancer_Investigation_Following_psa_positive(
@@ -785,6 +802,23 @@ class HSI_ProstateCancer_Investigation_Following_Pelvic_Pain(HSI_Event, Individu
         cons_avail = self.get_consumables(item_codes=self.module.item_codes_prostate_can['screening_psa_test_optional'])
 
         if dx_result and cons_avail:
+            # Add basic equipment for PSA testing and initial assessment
+            # Basic laboratory equipment for PSA test - facility level 1b
+            if self.module.rng.random() < 1.0:  # 100% probability for essential lab work
+                self.add_equipment({221})  # Analyser, Haematology
+            
+            # Prostate cancer specific hormone analysis - "100% for prostate cancer"
+            if self.module.rng.random() < 0.80:  # 80% probability at level 1b
+                self.add_equipment({139})  # Analyser, Hormones (for PSA)
+            
+            # Sample processing - "assumed used for all cancers"
+            if self.module.rng.random() < 0.90:  # 90% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            
+            # Safety equipment - "assumed used for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
+            
             # send for biopsy
             hs.schedule_hsi_event(
                 hsi_event=HSI_ProstateCancer_Investigation_Following_psa_positive(
@@ -828,6 +862,45 @@ class HSI_ProstateCancer_Investigation_Following_psa_positive(HSI_Event, Individ
         if cons_available:
             # If consumables are available update the use of equipment and run the dx_test representing the biopsy
             self.add_equipment({'Ultrasound scanning machine', 'Ordinary Microscope'})
+            
+            # Additional prostate cancer diagnostic equipment - facility level dependent
+            # Since this HSI runs at level 1b, moderate equipment availability
+            
+            # Essential cancer laboratory equipment - "for cancers assume used for all hsi's"
+            if self.module.rng.random() < 1.0:  # 100% probability - used for all cancer HSIs
+                self.add_equipment({221})  # Analyser, Haematology
+            if self.module.rng.random() < 1.0:  # 100% probability - used for all cancer HSIs
+                self.add_equipment({132})  # Analyzer, Clinical immunoassay
+            
+            # Prostate cancer specific hormone analysis - "100% for prostate cancer"
+            if self.module.rng.random() < 1.0:  # 100% probability for prostate cancer
+                self.add_equipment({139})  # Analyser, Hormones
+            
+            # Specialized urological imaging - "20% bladder cancer, 5% all cancers"
+            if self.module.rng.random() < 0.10:  # 10% probability for prostate cancer (between bladder and general)
+                self.add_equipment({364})  # Intravenous Pyelography set
+            if self.module.rng.random() < 0.10:  # 10% probability for prostate cancer
+                self.add_equipment({325})  # Intravenous Pyrography set
+            
+            # Radiation protection - "needed for all cancer diagnoses"
+            if self.module.rng.random() < 1.0:  # 100% probability for cancer diagnoses
+                self.add_equipment({80})   # Apron protective x-ray lead
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
+            
+            # Histopathology equipment - "100% of cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for tissue processing
+                self.add_equipment({230})  # Manual Rotary Microtome
+            
+            # Sample processing - "assumed used for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for sample handling
+                self.add_equipment({334})  # Sample Rack
+            if self.module.rng.random() < 1.0:  # 100% probability for sample mixing
+                self.add_equipment({224})  # Shaker
+            
+            # MRI for advanced staging - "5% of cancers for diagnosis"
+            if self.module.rng.random() < 0.05:  # 5% probability for advanced imaging
+                self.add_equipment({249})  # Magnetic resonance imaging (MRI)
 
             # Use a biopsy  to assess whether the person has prostate cancer:
             dx_result = hs.dx_manager.run_dx_test(
@@ -918,6 +991,55 @@ class HSI_ProstateCancer_StartTreatment(HSI_Event, IndividualScopeEventMixin):
         if cons_available:
             # If consumables are available and the treatment will go ahead - update the equipment
             self.add_equipment(self.healthcare_system.equipment.from_pkg_names('Major Surgery'))
+            
+            # Additional prostate cancer treatment-specific equipment - facility level dependent
+            # Since this HSI runs at level 3 (tertiary hospitals), equipment availability is high
+            
+            # Essential cancer laboratory equipment - "for cancers assume used for all hsi's"
+            if self.module.rng.random() < 1.0:  # 100% probability - used for all cancer HSIs
+                self.add_equipment({221})  # Analyser, Haematology
+            if self.module.rng.random() < 1.0:  # 100% probability - used for all cancer HSIs
+                self.add_equipment({132})  # Analyzer, Clinical immunoassay
+            
+            # Prostate cancer specific hormone analysis - "100% for prostate cancer"
+            if self.module.rng.random() < 1.0:  # 100% probability for prostate cancer
+                self.add_equipment({139})  # Analyser, Hormones
+            
+            # Cell washing for blood products - "needed for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for blood management
+                self.add_equipment({141})  # Automatic Cell washer
+            
+            # Patient gowns - "used in all cases"
+            if self.module.rng.random() < 1.0:  # 100% probability for patient care
+                self.add_equipment({370})  # Backsplit cotton gown
+            
+            # Coagulation monitoring - "10% of people treated for cancer"
+            if self.module.rng.random() < 0.10:  # 10% probability for monitoring
+                self.add_equipment({227})  # Coagulation machine
+            
+            # Sterilization - "assume used for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for infection control
+                self.add_equipment({186})  # Sterilizing unit, steam, medium, 240 litre
+            
+            # Laboratory sample processing - "40% of cancers"
+            if self.module.rng.random() < 0.40:  # 40% probability for sample analysis
+                self.add_equipment({265})  # Magnetic Stirrer
+            if self.module.rng.random() < 0.40:  # 40% probability for pipetting
+                self.add_equipment({135})  # Micropipettes 10 - 100ul
+            
+            # Advanced diagnostics - "5% of cancers"
+            if self.module.rng.random() < 0.05:  # 5% probability for specialized testing
+                self.add_equipment({340})  # Flow Cytometer
+            
+            # Urological imaging for treatment planning - "20% bladder cancer, 5% all cancers"
+            if self.module.rng.random() < 0.15:  # 15% probability for urological procedures
+                self.add_equipment({324})  # Urethrogram set
+            if self.module.rng.random() < 0.10:  # 10% probability for urological imaging
+                self.add_equipment({364})  # Intravenous Pyelography set
+            
+            # Automatic staining for histopathology - "20% of cases this is used"
+            if self.module.rng.random() < 0.20:  # 20% probability for automated processing
+                self.add_equipment({262})  # Automatic staining machine
 
             # Record date and stage of starting treatment
             df.at[person_id, "pc_date_treatment"] = self.sim.date
@@ -961,6 +1083,39 @@ class HSI_ProstateCancer_PostTreatmentCheck(HSI_Event, IndividualScopeEventMixin
         assert not df.at[person_id, "pc_status"] == 'none'
         assert not pd.isnull(df.at[person_id, "pc_date_diagnosis"])
         assert not pd.isnull(df.at[person_id, "pc_date_treatment"])
+        
+        # Equipment for prostate cancer follow-up monitoring - facility level dependent
+        # Since this HSI runs at level 3 (tertiary hospitals), equipment availability is high
+        
+        # Essential cancer laboratory monitoring - "for cancers assume used for all hsi's"
+        if self.module.rng.random() < 1.0:  # 100% probability - used for all cancer HSIs
+            self.add_equipment({221})  # Analyser, Haematology
+        if self.module.rng.random() < 1.0:  # 100% probability - used for all cancer HSIs
+            self.add_equipment({132})  # Analyzer, Clinical immunoassay
+        
+        # Prostate cancer specific hormone monitoring - "100% for prostate cancer"
+        if self.module.rng.random() < 1.0:  # 100% probability for prostate cancer follow-up
+            self.add_equipment({139})  # Analyser, Hormones
+        
+        # Coagulation monitoring for long-term effects - "10% of people treated for cancer"
+        if self.module.rng.random() < 0.10:  # 10% probability for monitoring
+            self.add_equipment({227})  # Coagulation machine
+        
+        # Patient care essentials - "used in all cases"
+        if self.module.rng.random() < 1.0:  # 100% probability for patient care
+            self.add_equipment({370})  # Backsplit cotton gown
+        
+        # Safety equipment - "assumed used for all cancers"
+        if self.module.rng.random() < 1.0:  # 100% probability for safety
+            self.add_equipment({50})   # Safety Goggles
+        
+        # Sample processing if labs needed - "assumed used for all cancers"
+        if self.module.rng.random() < 0.60:  # 60% probability for routine monitoring
+            self.add_equipment({334})  # Sample Rack
+        
+        # Basic imaging monitoring
+        if self.module.rng.random() < 0.30:  # 30% probability for routine imaging
+            self.add_equipment({161})  # Ultrasound scanning machine
 
         if df.at[person_id, 'pc_status'] == 'metastatic':
             # If has progressed to metastatic, then start Palliative Care immediately:
@@ -1023,6 +1178,43 @@ class HSI_ProstateCancer_PalliativeCare(HSI_Event, IndividualScopeEventMixin):
         if cons_available:
             # If consumables are available and the treatment will go ahead - update the equipment
             self.add_equipment({'Infusion pump', 'Drip stand'})
+            
+            # Additional equipment from column H cancer comments for palliative care
+            # Since this HSI runs at level 2 (district hospitals), moderate equipment availability
+            
+            # Basic laboratory monitoring - "for cancers assume used for all hsi's"
+            if self.module.rng.random() < 0.80:  # 80% probability - reduced for palliative setting
+                self.add_equipment({221})  # Analyser, Haematology
+            if self.module.rng.random() < 0.60:  # 60% probability - reduced for palliative setting
+                self.add_equipment({132})  # Analyzer, Clinical immunoassay
+            
+            # Prostate cancer specific hormone monitoring - "100% for prostate cancer"
+            if self.module.rng.random() < 0.80:  # 80% probability for palliative hormone management
+                self.add_equipment({139})  # Analyser, Hormones
+            
+            # Patient care essentials - "used in all cases"
+            if self.module.rng.random() < 1.0:  # 100% probability for patient care
+                self.add_equipment({370})  # Backsplit cotton gown
+            
+            # Coagulation monitoring for symptom management - "10% of people treated for cancer"
+            if self.module.rng.random() < 0.10:  # 10% probability for monitoring
+                self.add_equipment({227})  # Coagulation machine
+            
+            # Cell washing for any blood support - "needed for all cancers"
+            if self.module.rng.random() < 0.30:  # 30% probability for blood support in palliative care
+                self.add_equipment({141})  # Automatic Cell washer
+            
+            # Basic sterilization - "assume used for all cancers"
+            if self.module.rng.random() < 0.90:  # 90% probability for infection control
+                self.add_equipment({366})  # Sterilizing unit, steam, 39 ltr (smaller unit for district level)
+            
+            # Safety equipment - "assumed used for all cancers"
+            if self.module.rng.random() < 1.0:  # 100% probability for safety
+                self.add_equipment({50})   # Safety Goggles
+            
+            # Sample processing if needed - "assumed used for all cancers"
+            if self.module.rng.random() < 0.40:  # 40% probability for basic lab support
+                self.add_equipment({334})  # Sample Rack
 
             # Record the start of palliative care if this is first appointment
             if pd.isnull(df.at[person_id, "pc_date_palliative_care"]):


### PR DESCRIPTION
As you will guess, I interacted with Github co-pilot quite a bit in preparing this - so this is partly an exploration of whether / how we can use AI to help with this kind of thing - I'm sure we will need some iterations.


- Cancer modules (breast, prostate, bladder, oesophageal, other adult cancers):
  * Added facility-level dependent equipment based on column H specifications
  * Equipment includes imaging (X-ray, ultrasound), laboratory analysis, and cancer-specific tools
  * Probabilities vary by facility level (1a=community, 1b+=hospitals)

- COPD module:
  * Added moderate exacerbation treatment HSI with respiratory equipment
  * Incentive spirometers (100% availability) and blood gas analyzers (facility-dependent)
  * Enhanced severe exacerbation equipment with respiratory support tools

- Epilepsy module:
  * Added comprehensive rehabilitation equipment for severe epilepsy cases
  * Pediatric-specific equipment for children with epilepsy
  * Assessment tools, mobility aids, and physiotherapy equipment

- Fixed equipment codes:
  * 454  202 (X-ray machine)
  * 453  161 (Ultrasound scanning machine)

All equipment codes validated against ResourceFile_EquipmentCatalogue.csv