### PR TITLE
fix_to_district_scaling_factor

### DIFF
--- a/src/tlo/methods/demography.py
+++ b/src/tlo/methods/demography.py
@@ -311,8 +311,7 @@ class Demography(Module):
         model_pop = df.district_of_residence[df.is_alive].value_counts()
 
         self.initial_model_to_data_popsize_ratio_district = \
-            self.compute_initial_model_to_data_popsize_ratio_by_district(district_pop=district_pop,
-                                                                         model_pop=model_pop)
+            self.compute_initial_model_to_data_popsize_ratio_by_district(district_pop, model_pop)
 
     def initialise_simulation(self, sim):
         """


### PR DESCRIPTION
This contains a fix to the error when calculating district level scaling factors - applicable when calling equal_allocation_by_district=True