### PR TITLE
Make the scale_to_effective_capabilities facility ID dependent 

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -1868,9 +1868,9 @@ class HealthSystem(Module):
             summary_by_fac_id['Minutes_Used'] / summary_by_fac_id['Total_Minutes_Per_Day']
         ).replace([np.inf, -np.inf, np.nan], 0.0)
 
-        summary_by_facID_and_officer = comparison.copy()
-        summary_by_facID_and_officer['Fraction_Time_Used'] = (
-            summary_by_facID_and_officer['Minutes_Used'] / summary_by_facID_and_officer['Total_Minutes_Per_Day']
+        #summary_by_facID_and_officer = comparison.copy()
+        fraction_time_used_by_facID_and_officer = (
+            comparison['Minutes_Used'] / comparison['Total_Minutes_Per_Day']
         ).replace([np.inf, -np.inf, np.nan], 0.0)
 
         # Compute Fraction of Time For Each Officer and level
@@ -1895,7 +1895,7 @@ class HealthSystem(Module):
 
         self._summary_counter.record_hs_status(
             fraction_time_used_across_all_facilities=fraction_time_used_overall,
-            fraction_time_used_by_facID_and_officer=summary_by_facID_and_officer["Fraction_Time_Used"].to_dict()
+            fraction_time_used_by_facID_and_officer=fraction_time_used_by_facID_and_officer.to_dict()
         )
 
     def remove_beddays_footprint(self, person_id):
@@ -2788,7 +2788,7 @@ class HealthSystemSummaryCounter:
         logger_summary.info(
             key="Capacity_By_FacID_and_Officer",
             description="The fraction of healthcare worker time that is used each day, averaged over this "
-                        "calendar year, for each officer type at each facility level.",
+                        "calendar year, for each officer type at each facility.",
             data=flatten_multi_index_series_into_dict_for_logging(
                 self.frac_time_used_by_facID_and_officer()),
         )


### PR DESCRIPTION
The scale_to_effective_capabilities option in the healthsystem module allows us to rescale, when switching from mode 1 to mode 2, assumed HRH capabilities based on the average daily "load" (=total_minutes_worked/total_minutes_available) on healthcare workers observed in the year before the switch. This allows us to effectively rescale assumed HRH resources based on observed productivity. 

Previously, this "load" was computed per officer type and facility level (basically averaging productivity at the facility level for a particular officer type). Instead, in this PR we enforce a facility-specific rescaling, which accounts for district-level variations in the productivity of officers at the same facility level.
