### PR TITLE
Turn off ruff warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,8 +125,8 @@ line-length = 120
 exclude = ['src/tlo/_version.py']
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W"]
-per-file-ignores = {"src/scripts/**" = ["E501", "W"]}
+select = ["E", "F", "I"]
+per-file-ignores = {"src/scripts/**" = ["E501"]}
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
Ruff warnings are updated far too frequently. Turning them off, and they can be dealt with as and when.