### PR TITLE
Don't cache in checks & docs workflows to prevent out-of-space errors

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
-        
+
   check:
     name: Run checks
     runs-on: ubuntu-latest
@@ -26,11 +26,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: false
-      - name: Cache tox
-        uses: actions/cache@v5
-        with:
-          path: .tox
-          key: tox-${{hashFiles('requirements/*.txt', 'tox.ini')}}
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ concurrency:
   # master branch will be allowed to have pending jobs
   # https://stackoverflow.com/a/70972844
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
-  
+
 jobs:
 
   build-docs:
@@ -34,11 +34,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: true
-      - name: Cache tox
-        uses: actions/cache@v5
-        with:
-          path: .tox
-          key: tox-${{hashFiles('requirements/*.txt', 'tox.ini')}}
       - name: Set up Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
For #1762. Checks and docs workflows are failing due to out-of-space errors related to cache. After manually deleting the cache, the workflows run successfully. These changes turn off caching.
 