### PR TITLE
Fix branching issues in PR #1662, #1689, and #1773

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -2812,10 +2812,6 @@ class HealthSystemSummaryCounter:
 
     def write_to_log_and_reset_counters(self):
         """Log summary statistics reset the data structures. This usually occurs at the end of the year."""
-        print("what is looks like", {t_id: 0.0 for t_id, v in self._treatment_ids.items()})
-        print(self._treatment_ids)
-
-
         logger_summary.info(
             key="HSI_Event",
             description="Counts of the HSI_Events that have occurred in this calendar year by TREATMENT_ID, "

--- a/tests/test_healthsystem.py
+++ b/tests/test_healthsystem.py
@@ -315,7 +315,6 @@ def test_rescaling_capabilities_based_on_load_factors(tmpdir, seed):
     n_pop_2010 = 14.6e6
     # Ensure capabilities are much smaller (1/1000) than expected given initial pop size
     small_capabilities = (n_sim_initial_population / n_pop_2010) / 10000
-    print(small_capabilities)
 
     # Register the core modules
     # Set the year in which mode is changed to start_date + 1 year, and mode after that still 1.


### PR DESCRIPTION
This PR manually manually reproduces changes that had originally been implemented in PR #1662, #1689, and #1773 from the current version of master, to ensure that all updates to the HealthSystem that have occurred since are accounted for. 

PRs #1662 and #1689: removed the concept of squeeze factor from the HealthSystem entirely.
The only difference in this implementation compared to that of PR #1662 is that although "squeeze_factor" is still logged (always as zero), to ensure consistency in logging, this is no longer passed to the logging fnc as an argument. Reasoning for this is to emphasise that currently the logged value is not dynamically estimated, but @tamuri let me know if you disagree.

PR #1773: had introduced fixes to the estimation of the load factor to ensure that this is clinic-compatible, these have now been copied over. Changes introduced here are that the clinic should should not be an optional input to `frac_time_used_by_facID_and_officer`: ensuring this appears to have interfered with the logging of key `key="Capacity_By_FacID_and_Officer"`, so it would be great @sangeetabhatia03 if you could address this.

As discussed over slack, reviews provided to PR #1773 should be addressed in this PR instead.

@sangeetabhatia03: an additional test that would be great to have is one where the rescaling across clinics happens 'organically' when undergoing a mode transition; this would ensure not only that the rescaling based on footprints works as expected, but that this is also consistent with mode change _and_ with a previous period in mode 1. This is ultimately the functionality that we will need for all TLO runs, so having a test that clears that this is all working as it should would be very useful. For the purposes of the test, the sim can be very small (everyone in one district, running only for one year i.e. mode switch in 2011).
