### PR TITLE
Another fix for Schisto Module's 'single_district' parameter being misread

### DIFF
--- a/resources/ResourceFile_Schisto/parameter_values.csv
+++ b/resources/ResourceFile_Schisto/parameter_values.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc49b667b56b4157056ff0a5df292630a10f4dc0541b768776f77bb4ab7ba742
-size 5356
+oid sha256:a0ffeaa745c471beb5246a94567d04ad46abe2d2d10a7c9f3d429cfdc01ebd26
+size 5351


### PR DESCRIPTION
The changes in PR #1720 introduced an issue whereby FALSE and TRUE symbols were used in `parameters_values.csv`, which was read-by by `Module.load_parameters_from_dataframe`.

But both symbols, being 'truthy' to pandas' passing, result in the parameter being evaluated with `bool: True`.

The fix for this, is to use integers: 0 is 'falsey' and 1 is 'truthy'.

So, this PR, updates the values in the `parameters_values.csv` accordingly:

TRUE -> 1
FALSE -> 0