### PR TITLE
Print container image name to stdout

### DIFF
--- a/src/tlo/cli.py
+++ b/src/tlo/cli.py
@@ -266,6 +266,7 @@ def batch_submit(ctx, scenario_file, asserts_on, more_memory, keep_pool_alive, i
     git checkout {commit.hexsha}
     pip install -r requirements/base.txt
     env | grep "^AZ_" | while read line; do echo "$line"; done
+    echo "Container image name: {image_name}"
     {py_opt} tlo --config-file tlo.example.conf batch-run {azure_run_json} {working_dir} {{draw_number}} {{run_number}}
     tlo --config-file tlo.example.conf parse-log {working_dir}/{{draw_number}}/{{run_number}}
     cp {task_dir}/std*.txt {working_dir}/{{draw_number}}/{{run_number}}/.


### PR DESCRIPTION
Prints the container image name (including tag) used in an Azure Batch submission. Useful for debugging.