### PR TITLE
Change `M` timedelta to 4 weeks in Lifestyle

### DIFF
--- a/src/tlo/methods/enhanced_lifestyle.py
+++ b/src/tlo/methods/enhanced_lifestyle.py
@@ -659,7 +659,7 @@ class LifestyleModels:
         :param df: The population dataframe """
         # get months since last poll
         now = self.module.sim.date
-        months_since_last_poll = round((now - self.date_last_run) / np.timedelta64(1, "M"))
+        months_since_last_poll = round((now - self.date_last_run) / np.timedelta64(4, "W"))
         # loop through linear models dictionary and initialise each property in the population dataframe
         for _property_name, _model in self._models.items():
             if _model['update'] is not None:


### PR DESCRIPTION
Unit M is unsupported in more recent versions of Pandas. Fixes #1808 