### PR TITLE
Improve performance of initialisation of wasting HSI

### DIFF
--- a/src/tlo/methods/wasting.py
+++ b/src/tlo/methods/wasting.py
@@ -1384,7 +1384,7 @@ class HSI_Wasting_GrowthMonitoring(HSI_Event, IndividualScopeEventMixin):
         p = self.module.parameters
         if person_age < 1:
             prob = p["growth_monitoring_attendance_prob_agecat"][0]
-        if person_age < 2:
+        elif person_age < 2:
             prob = p["growth_monitoring_attendance_prob_agecat"][1]
         else:
             prob = p["growth_monitoring_attendance_prob_agecat"][2]


### PR DESCRIPTION
Profiling found initialisation of `HSI_Wasting_GrowthMonitoring` to be a hotspot. Key changes:

1. Use `.at` instead of `.loc` to get single cell value from population dataframe
2. Inline if-condition to get probability of attendance to avoid function call
3. Join if-conditions into single block
