### PR TITLE
Option to force SymptomManager to always use properties (instead of the built-in tracker)

### DIFF
--- a/src/tlo/methods/symptommanager.py
+++ b/src/tlo/methods/symptommanager.py
@@ -193,14 +193,14 @@ class SymptomManager(Module):
                         'NB. This is over-ridden if a module key-word argument is provided.'),
     }
 
-    def __init__(self, name=None, spurious_symptoms=None, always_refer_to_properties: Optional[bool] = None):
+    def __init__(self, name=None, spurious_symptoms=None, always_refer_to_properties: bool = False):
         super().__init__(name)
         self.spurious_symptoms = None
         self.arg_spurious_symptoms = spurious_symptoms
         self._persons_with_newly_onset_symptoms = set()
 
         assert isinstance(always_refer_to_properties, bool), "Argument `always_refer_to_properties` must be a bool."
-        self.always_refer_to_properties = always_refer_to_properties
+        self.always_refer_to_properties = always_refer_to_properties  # <-- avoids use of in-build tracker
 
         self.generic_symptoms = {
             'fever',


### PR DESCRIPTION
The need for this option has arisen as the functionality of cohort model relies on being able to run a simulation from a (reconstructed) initial dataframe, and this would not work if the `SymptomManager` uses its own inbuilt tracker rather than the properties. This comes at the expenses of the speed-up that the tracker allows. The option is `False` (i.e., preserved current behaviour) by default.