### PR TITLE
Add monthly daly reporting to individual history tracker

### DIFF
--- a/src/tlo/analysis/utils.py
+++ b/src/tlo/analysis/utils.py
@@ -413,14 +413,14 @@ def reconstruct_individual_histories(df):
     # Collapse into 'entity', 'date', 'event_name', 'Info' format where 'Info' is dict listing attributes
     # (e.g. {a1:v1, a2:v2, a3:v3, ...} )
     df_collapsed = (
-            df.groupby(['entity', 'date', 'event_name'], sort=False)
+            df.groupby(['entity', 'date', 'event_name', 'event_tag'], sort=False)
               .apply(lambda g: dict(zip(g['attribute'], g['value'])))
               .reset_index(name='Info')
         )
 
     df_final = (
         df_collapsed
-            .sort_values(by=['entity', 'date'])
+            .sort_values(by=['entity', 'date', 'event_tag'])
             .reset_index(drop=True)
     )
 
@@ -430,8 +430,6 @@ def reconstruct_individual_histories(df):
     if len(problems)>0:
         print("Values didn't change but were still detected")
         print(problems)
-        
-    
 
     return df_final
 
@@ -484,8 +482,6 @@ def extract_individual_histories(results_folder: Path,
 
         # Combine all dfs into a single DataFrame
         res[draw] = pd.concat(dfs_from_runs, ignore_index=True)
-
-        res[0].to_csv('individual_histories.csv')
 
     return res
 

--- a/src/tlo/methods/healthburden.py
+++ b/src/tlo/methods/healthburden.py
@@ -19,6 +19,7 @@ from tlo.methods.causes import (
     get_gbd_causes_not_represented_in_disease_modules,
 )
 from tlo.methods.demography import age_at_date
+from tlo.notify import notifier
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -613,6 +614,21 @@ class Get_Current_DALYS(RegularEvent, PopulationScopeEventMixin):
 
         # Multiply 1/12 as these weights are for one month only
         disease_specific_daly_values_this_month = disease_specific_daly_values_this_month * (1 / 12)
+
+        if notifier.has_listeners("healthburden.monthly_dalys_report"):
+            # Do not dispatch individuals or causes that have zero dalys reported this month
+            monthly_dalys = disease_specific_daly_values_this_month.copy()
+            monthly_dalys_nonzero = (
+                monthly_dalys.loc[(monthly_dalys != 0).any(axis=1), (monthly_dalys != 0).any(axis=0)]
+                  .to_dict(orient="index"))
+
+            # Store data as dictionary
+            data = {
+                person: {col: val for col, val in cols.items() if val != 0}
+                for person, cols in monthly_dalys_nonzero.items()
+            }
+            
+            notifier.dispatch("healthburden.monthly_dalys_report", data=data)
 
         # 4) Summarise the results for this month wrt sex/age/wealth
         # - merge in age/wealth/sex information

--- a/src/tlo/methods/healthburden.py
+++ b/src/tlo/methods/healthburden.py
@@ -615,7 +615,8 @@ class Get_Current_DALYS(RegularEvent, PopulationScopeEventMixin):
         # Multiply 1/12 as these weights are for one month only
         disease_specific_daly_values_this_month = disease_specific_daly_values_this_month * (1 / 12)
 
-        if notifier.has_listeners("healthburden.monthly_dalys_report"):
+        if notifier.has_listeners("healthburden.monthly_daly_report"):
+            print("Listener is present")
             # Do not dispatch individuals or causes that have zero dalys reported this month
             monthly_dalys = disease_specific_daly_values_this_month.copy()
             monthly_dalys_nonzero = (
@@ -627,8 +628,8 @@ class Get_Current_DALYS(RegularEvent, PopulationScopeEventMixin):
                 person: {col: val for col, val in cols.items() if val != 0}
                 for person, cols in monthly_dalys_nonzero.items()
             }
-            
-            notifier.dispatch("healthburden.monthly_dalys_report", data=data)
+            print("I will dispatch ", data)
+            notifier.dispatch("healthburden.monthly_daly_report", data=data)
 
         # 4) Summarise the results for this month wrt sex/age/wealth
         # - merge in age/wealth/sex information

--- a/src/tlo/methods/healthburden.py
+++ b/src/tlo/methods/healthburden.py
@@ -616,7 +616,6 @@ class Get_Current_DALYS(RegularEvent, PopulationScopeEventMixin):
         disease_specific_daly_values_this_month = disease_specific_daly_values_this_month * (1 / 12)
 
         if notifier.has_listeners("healthburden.monthly_daly_report"):
-            print("Listener is present")
             # Do not dispatch individuals or causes that have zero dalys reported this month
             monthly_dalys = disease_specific_daly_values_this_month.copy()
             monthly_dalys_nonzero = (
@@ -628,7 +627,6 @@ class Get_Current_DALYS(RegularEvent, PopulationScopeEventMixin):
                 person: {col: val for col, val in cols.items() if val != 0}
                 for person, cols in monthly_dalys_nonzero.items()
             }
-            print("I will dispatch ", data)
             notifier.dispatch("healthburden.monthly_daly_report", data=data)
 
         # 4) Summarise the results for this month wrt sex/age/wealth

--- a/src/tlo/methods/healthburden.py
+++ b/src/tlo/methods/healthburden.py
@@ -617,16 +617,16 @@ class Get_Current_DALYS(RegularEvent, PopulationScopeEventMixin):
 
         if notifier.has_listeners("healthburden.monthly_daly_report"):
             # Do not dispatch individuals or causes that have zero dalys reported this month
-            monthly_dalys = disease_specific_daly_values_this_month.copy()
+            monthly_dalys = disease_specific_daly_values_this_month
             monthly_dalys_nonzero = (
-                monthly_dalys.loc[(monthly_dalys != 0).any(axis=1), (monthly_dalys != 0).any(axis=0)]
-                  .to_dict(orient="index"))
+                monthly_dalys.loc[(monthly_dalys != 0).any(axis=1), (monthly_dalys != 0).any(axis=0)])
 
-            # Store data as dictionary
+            # Only retain non-zero info
             data = {
-                person: {col: val for col, val in cols.items() if val != 0}
-                for person, cols in monthly_dalys_nonzero.items()
+                idx: {col: val for col, val in row.items() if val > 0}
+                for idx, row in monthly_dalys_nonzero.iterrows()
             }
+
             notifier.dispatch("healthburden.monthly_daly_report", data=data)
 
         # 4) Summarise the results for this month wrt sex/age/wealth

--- a/src/tlo/methods/individual_history_tracker.py
+++ b/src/tlo/methods/individual_history_tracker.py
@@ -374,7 +374,6 @@ class IndividualHistoryTracker(Module):
 
     def on_monthly_daly_report(self,data):
         """Upon receiving monthly daly report, convert it to custom EAV format and log"""
-        print("I received the dispatch with ", data)
         rows = []
 
         # This is not a real event, so create custom name and create custom tag associated with it

--- a/src/tlo/methods/individual_history_tracker.py
+++ b/src/tlo/methods/individual_history_tracker.py
@@ -374,9 +374,10 @@ class IndividualHistoryTracker(Module):
 
     def on_monthly_daly_report(self,data):
         """Upon receiving monthly daly report, convert it to custom EAV format and log"""
+        print("I received the dispatch with ", data)
         rows = []
 
-        # This is not a real event, so create custom name and invalid tag associated with it
+        # This is not a real event, so create custom name and create custom tag associated with it
         event_name = "monthly_daly_report"
         event_tag = -1
 

--- a/src/tlo/methods/individual_history_tracker.py
+++ b/src/tlo/methods/individual_history_tracker.py
@@ -61,6 +61,7 @@ class IndividualHistoryTracker(Module):
         notifier.add_listener("hsi_event.pre-run", self.on_event_pre_run)
         notifier.add_listener("hsi_event.post-run", self.on_event_post_run)
         notifier.add_listener("consumables.post-request_consumables", self.on_consumable_request)
+        notifier.add_listener("healthburden.monthly_daly_report", self.on_monthly_daly_report)
 
     def read_parameters(self, resourcefilepath: Optional[Path] = None):
         self.load_parameters_from_dataframe(
@@ -370,6 +371,28 @@ class IndividualHistoryTracker(Module):
         self.entire_mni_before = {}
         self.consumable_access = {}
         self.cons_call_number_within_event = 0
+
+    def on_monthly_daly_report(self,data):
+        """Upon receiving monthly daly report, convert it to custom EAV format and log"""
+        rows = []
+
+        # This is not a real event, so create custom name and invalid tag associated with it
+        event_name = "monthly_daly_report"
+        event_tag = -1
+
+        for person, dalys in data.items():
+            for cause, value in dalys.items():
+                rows.append({
+                    "entity": person,
+                    "event_name": event_name,
+                    "event_tag": event_tag,
+                    "attribute": cause,
+                    "value": value
+                })
+
+        eav = pd.DataFrame(rows)
+        self.log_eav_dataframe_to_individual_histories(eav)
+        return
 
     def mni_values_differ(self, v1, v2):
 

--- a/tests/test_individual_history_tracker.py
+++ b/tests/test_individual_history_tracker.py
@@ -66,9 +66,9 @@ def test_individual_history_tracker(tmpdir, seed):
                  symptommanager.SymptomManager(),
                  healthseekingbehaviour.HealthSeekingBehaviour(),
                  chronicsyndrome.ChronicSyndrome(),
-                 #malaria.Malaria(),
-                 rti.RTI(),
-                 schisto.Schisto(),
+                 malaria.Malaria(),
+                 #rti.RTI(),
+                 #schisto.Schisto(),
                  contraception.Contraception(),
                  newborn_outcomes.NewbornOutcomes(),
                  pregnancy_supervisor.PregnancySupervisor(),
@@ -111,31 +111,10 @@ def test_individual_history_tracker(tmpdir, seed):
     # Assert that all HSI events that occurred were also collected in the event chains.
     # Do not include Inpatient_Care HSIs, as these
     # are not currently treated as being individual-specific
+    
     Num_of_HSIs_in_individual_histories = individual_histories["event_name"].str.contains('HSI', na=False).sum()
     Num_of_HSIs_in_hs_log = len(output['tlo.methods.healthsystem']['HSI_Event'].loc[
-    output['tlo.methods.healthsystem']['HSI_Event']['Event_Name'] != 'Inpatient_Care'])
-    
-    
-    print("HSIs in log")
-    HSIs_in_log = output['tlo.methods.healthsystem']['HSI_Event'].loc[output['tlo.methods.healthsystem']['HSI_Event']['Event_Name'] != 'Inpatient_Care', 'Event_Name'].to_list()
-    HSIs_in_IHT = individual_histories.loc[individual_histories["event_name"].str.contains('HSI', na=False),"event_name"].tolist()
-
-    only_in_log = list((Counter(HSIs_in_log) - Counter(HSIs_in_IHT)).elements())
-    only_in_IHT = list((Counter(HSIs_in_IHT) - Counter(HSIs_in_log)).elements())
-    print("Only in log")
-    print(only_in_log)
-    print("Only in IHT")
-    print(only_in_IHT)
-    
-    output['tlo.methods.healthsystem']['HSI_Event'].loc[output['tlo.methods.healthsystem']['HSI_Event']['Event_Name']=='HSI_Malaria_Treatment'].to_csv('HSI_event_log.csv')
-    individual_histories.loc[individual_histories["event_name"].str.contains('HSI_Malaria_Treatment', na=False)].to_csv('HSI_event_IHT.csv')
-    individual_histories.to_csv('full_IHT.csv')
-    
-    malaria_events_in_log =output['tlo.methods.healthsystem']['HSI_Event'].loc[output['tlo.methods.healthsystem']['HSI_Event']['Event_Name']=='HSI_Malaria_Treatment']
-    malaria_events_in_IHT = individual_histories.loc[individual_histories["event_name"].str.contains('HSI_Malaria_Treatment', na=False)]
-    
-    
-    print(output['tlo.methods.healthsystem']['HSI_Event'].loc[output['tlo.methods.healthsystem']['HSI_Event']['Event_Name']=='HSI_Malaria_Treatment'])
+        output['tlo.methods.healthsystem']['HSI_Event']['Event_Name'] != 'Inpatient_Care'])
     assert Num_of_HSIs_in_individual_histories == Num_of_HSIs_in_hs_log
 
     # Check that aside from HSIs, StartOfSimulation, and Birth, other events were collected too

--- a/tests/test_individual_history_tracker.py
+++ b/tests/test_individual_history_tracker.py
@@ -11,6 +11,7 @@ from tlo.methods import (
     contraception,
     demography,
     enhanced_lifestyle,
+    healthburden,
     healthseekingbehaviour,
     healthsystem,
     hiv,
@@ -20,7 +21,6 @@ from tlo.methods import (
     postnatal_supervisor,
     pregnancy_supervisor,
     symptommanager,
-    healthburden,
 )
 
 resourcefilepath = Path(os.path.dirname(__file__)) / '../resources'

--- a/tests/test_individual_history_tracker.py
+++ b/tests/test_individual_history_tracker.py
@@ -81,9 +81,15 @@ def test_individual_history_tracker(tmpdir, seed):
     output_chains = parse_log_file(sim.log_filepath, level=logging.INFO)
     individual_histories = reconstruct_individual_histories(
                             output_chains['tlo.methods.individual_history_tracker']['individual_histories'])
-    print(individual_histories.columns)
-    print(individual_histories.loc[individual_histories['event_name']=='monthly_daly_report'])
-    exit(-1)
+    
+    # Check that monthly daly reporting is included
+    assert (individual_histories['event_name'] == 'monthly_daly_report').sum() > 0
+    
+    # Cannot estimate how many monthly reports should be expected, since monthly report is only logged if individual
+    # experienced dalys that month, so check that at or below this max
+    max_monthly_reports = ((end_date.year - start_date.year) * 12 + (end_date.month - start_date.month))*popsize
+    assert (individual_histories['event_name'] == 'monthly_daly_report').sum() <= max_monthly_reports
+
     # Check that we have a "StartOfSimulation" event for every individual in the initial population,
     #   and that this was logged at the start date
     assert (individual_histories['event_name'] == 'StartOfSimulation').sum() == popsize

--- a/tests/test_individual_history_tracker.py
+++ b/tests/test_individual_history_tracker.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import pytest
+from collections import Counter
 
 from tlo import Date, Simulation, logging
 from tlo.analysis.utils import parse_log_file, reconstruct_individual_histories
@@ -17,9 +18,12 @@ from tlo.methods import (
     hiv,
     individual_history_tracker,
     labour,
+    malaria,
     newborn_outcomes,
     postnatal_supervisor,
     pregnancy_supervisor,
+    rti,
+    schisto,
     symptommanager,
 )
 
@@ -62,6 +66,9 @@ def test_individual_history_tracker(tmpdir, seed):
                  symptommanager.SymptomManager(),
                  healthseekingbehaviour.HealthSeekingBehaviour(),
                  chronicsyndrome.ChronicSyndrome(),
+                 #malaria.Malaria(),
+                 rti.RTI(),
+                 schisto.Schisto(),
                  contraception.Contraception(),
                  newborn_outcomes.NewbornOutcomes(),
                  pregnancy_supervisor.PregnancySupervisor(),
@@ -107,6 +114,28 @@ def test_individual_history_tracker(tmpdir, seed):
     Num_of_HSIs_in_individual_histories = individual_histories["event_name"].str.contains('HSI', na=False).sum()
     Num_of_HSIs_in_hs_log = len(output['tlo.methods.healthsystem']['HSI_Event'].loc[
     output['tlo.methods.healthsystem']['HSI_Event']['Event_Name'] != 'Inpatient_Care'])
+    
+    
+    print("HSIs in log")
+    HSIs_in_log = output['tlo.methods.healthsystem']['HSI_Event'].loc[output['tlo.methods.healthsystem']['HSI_Event']['Event_Name'] != 'Inpatient_Care', 'Event_Name'].to_list()
+    HSIs_in_IHT = individual_histories.loc[individual_histories["event_name"].str.contains('HSI', na=False),"event_name"].tolist()
+
+    only_in_log = list((Counter(HSIs_in_log) - Counter(HSIs_in_IHT)).elements())
+    only_in_IHT = list((Counter(HSIs_in_IHT) - Counter(HSIs_in_log)).elements())
+    print("Only in log")
+    print(only_in_log)
+    print("Only in IHT")
+    print(only_in_IHT)
+    
+    output['tlo.methods.healthsystem']['HSI_Event'].loc[output['tlo.methods.healthsystem']['HSI_Event']['Event_Name']=='HSI_Malaria_Treatment'].to_csv('HSI_event_log.csv')
+    individual_histories.loc[individual_histories["event_name"].str.contains('HSI_Malaria_Treatment', na=False)].to_csv('HSI_event_IHT.csv')
+    individual_histories.to_csv('full_IHT.csv')
+    
+    malaria_events_in_log =output['tlo.methods.healthsystem']['HSI_Event'].loc[output['tlo.methods.healthsystem']['HSI_Event']['Event_Name']=='HSI_Malaria_Treatment']
+    malaria_events_in_IHT = individual_histories.loc[individual_histories["event_name"].str.contains('HSI_Malaria_Treatment', na=False)]
+    
+    
+    print(output['tlo.methods.healthsystem']['HSI_Event'].loc[output['tlo.methods.healthsystem']['HSI_Event']['Event_Name']=='HSI_Malaria_Treatment'])
     assert Num_of_HSIs_in_individual_histories == Num_of_HSIs_in_hs_log
 
     # Check that aside from HSIs, StartOfSimulation, and Birth, other events were collected too

--- a/tests/test_individual_history_tracker.py
+++ b/tests/test_individual_history_tracker.py
@@ -20,6 +20,7 @@ from tlo.methods import (
     postnatal_supervisor,
     pregnancy_supervisor,
     symptommanager,
+    healthburden,
 )
 
 resourcefilepath = Path(os.path.dirname(__file__)) / '../resources'
@@ -56,6 +57,7 @@ def test_individual_history_tracker(tmpdir, seed):
     sim.register(demography.Demography(),
                  enhanced_lifestyle.Lifestyle(),
                  healthsystem.HealthSystem(),
+                 healthburden.HealthBurden(),
                  individual_history_tracker.IndividualHistoryTracker(),
                  symptommanager.SymptomManager(),
                  healthseekingbehaviour.HealthSeekingBehaviour(),
@@ -79,7 +81,9 @@ def test_individual_history_tracker(tmpdir, seed):
     output_chains = parse_log_file(sim.log_filepath, level=logging.INFO)
     individual_histories = reconstruct_individual_histories(
                             output_chains['tlo.methods.individual_history_tracker']['individual_histories'])
-
+    print(individual_histories.columns)
+    print(individual_histories.loc[individual_histories['event_name']=='monthly_daly_report'])
+    exit(-1)
     # Check that we have a "StartOfSimulation" event for every individual in the initial population,
     #   and that this was logged at the start date
     assert (individual_histories['event_name'] == 'StartOfSimulation').sum() == popsize

--- a/tests/test_individual_history_tracker.py
+++ b/tests/test_individual_history_tracker.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 
 import pytest
-from collections import Counter
 
 from tlo import Date, Simulation, logging
 from tlo.analysis.utils import parse_log_file, reconstruct_individual_histories
@@ -22,8 +21,6 @@ from tlo.methods import (
     newborn_outcomes,
     postnatal_supervisor,
     pregnancy_supervisor,
-    rti,
-    schisto,
     symptommanager,
 )
 
@@ -67,8 +64,6 @@ def test_individual_history_tracker(tmpdir, seed):
                  healthseekingbehaviour.HealthSeekingBehaviour(),
                  chronicsyndrome.ChronicSyndrome(),
                  malaria.Malaria(),
-                 #rti.RTI(),
-                 #schisto.Schisto(),
                  contraception.Contraception(),
                  newborn_outcomes.NewbornOutcomes(),
                  pregnancy_supervisor.PregnancySupervisor(),


### PR DESCRIPTION
PR to ensure that the monthly dalys reported are included in the individual history tracker, broken down by cuase.

Note: In the healthburden module, we do not automatically dispatch the raw reported dalys dataframe in all instances, but first:
- Check if relevant listener is included;
- Pre-process dispatched data to only include non-zero entries;
This should avoid unnecessarily dispatching large dataframes during runtime. 
