### PR TITLE
Use pinned dependencies in `tox check` 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -87,6 +87,7 @@ commands =
 
 [testenv:check]
 deps =
+    -r{toxinidir}/requirements/base.txt
     build
     docutils
     check-manifest


### PR DESCRIPTION
Unpinned dependency API changes make checks fail, so use the pinned dependencies.