### PR TITLE
Fix to HSI Event Queue following introduction of clinic eligibility attribute

### DIFF
--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -1582,7 +1582,7 @@ class HealthSystem(Module):
             rand_queue = self.hsi_event_queue_counter
 
         _new_item: HSIEventQueueItem = HSIEventQueueItem(
-            clinic_eligibility, priority, topen, rand_queue, self.hsi_event_queue_counter, tclose, hsi_event
+            priority, topen, rand_queue, self.hsi_event_queue_counter, clinic_eligibility, tclose, hsi_event
         )
 
         # Add to queue:
@@ -2189,6 +2189,7 @@ class HealthSystem(Module):
                         actual_appt_footprint=actual_appt_footprint,
                         did_run=True,
                         priority=_priority,
+                        clinic=clinic
                     )
 
                 # if not ok_to_run
@@ -2211,6 +2212,7 @@ class HealthSystem(Module):
                         actual_appt_footprint=event.EXPECTED_APPT_FOOTPRINT,
                         did_run=False,
                         priority=_priority,
+                        clinic=clinic
                     )
 
         return _to_be_held_over

--- a/src/tlo/methods/healthsystem.py
+++ b/src/tlo/methods/healthsystem.py
@@ -3047,11 +3047,11 @@ class HealthSystemChangeMode(RegularEvent, PopulationScopeEventMixin):
                 if event.priority != enforced_priority:
                     # Wrap it up with the new priority - everything else is the same
                     event = HSIEventQueueItem(
-                        clinic_eligibility,
                         enforced_priority,
                         event.topen,
                         event.rand_queue_counter,
                         event.queue_counter,
+                        clinic_eligibility,
                         event.tclose,
                         event.hsi_event,
                     )

--- a/src/tlo/methods/hsi_event.py
+++ b/src/tlo/methods/hsi_event.py
@@ -57,7 +57,6 @@ class HSIEventQueueItem(NamedTuple):
 
     """
 
-    clinic_eligibility: str
     priority: int
     topen: Date
     rand_queue_counter: (
@@ -66,6 +65,7 @@ class HSIEventQueueItem(NamedTuple):
     queue_counter: (
         int  # Include safety tie-breaker in unlikely event rand_queue_counter is equal
     )
+    clinic_eligibility: str
     tclose: Date
     # Define HSI_Event type as string to avoid NameError exception as HSI_Event defined
     # later in module (see https://stackoverflow.com/a/36286947/4798943)


### PR DESCRIPTION
Clinics PR introduced error in order of attributes of `HSIEventQueueItem`, ordering events by clinic types first. This meant that `_get_events_due_today` erroneously exited the `HSI_EVENT_QUEUE` at the first not-due event for the first clinic type encountered, missing all events due on the day for other clinic types. This PR fixes this, and additionally ensures clinic type is logged when logging HSI events ran in mode 1.
Notice that this bug should not have impacted master's default configuration, where only one clinic type is considered. 

