### PR TITLE
Fix error using incorrect name of NewbornOutcomes module within HIV

### DIFF
--- a/src/tlo/methods/hiv.py
+++ b/src/tlo/methods/hiv.py
@@ -1716,7 +1716,7 @@ class Hiv(Module, GenericFirstAppointmentsMixin):
                 tclose=None,
             )
 
-            if "newborn_outcomes" not in self.sim.modules and (
+            if "NewbornOutcomes" not in self.sim.modules and (
                     self.rng.random_sample() < p['prob_hiv_test_for_newborn_infant']):
                 self.sim.modules["HealthSystem"].schedule_hsi_event(
                     hsi_event=HSI_Hiv_TestAndRefer(


### PR DESCRIPTION
This PR fixes an existing error in line 1719 of hiv.py where the incorrect name for NewbornOutcomes was used.