### PR TITLE
Fix use of np.random in hiv.py and schisto.py

### DIFF
--- a/src/tlo/methods/hiv.py
+++ b/src/tlo/methods/hiv.py
@@ -2030,7 +2030,7 @@ class Hiv(Module, GenericFirstAppointmentsMixin):
         key = (sub_group, year)
         try:
             lengths, probs = self._art_dispensation_lookup[key]
-            return np.random.choice(lengths, p=probs)
+            return self.rng.choice(lengths, p=probs)
         except KeyError:
             raise ValueError(f"No ART dispensation data for sub_group={sub_group} and year={year}")
 

--- a/src/tlo/methods/schisto.py
+++ b/src/tlo/methods/schisto.py
@@ -967,7 +967,7 @@ class Schisto(Module, GenericFirstAppointmentsMixin):
         n_to_reduce = int(p['rr_WASH'] * len(susceptible_no_sanitation))
 
         if n_to_reduce > 0:
-            selected_change_susceptibility = np.random.choice(susceptible_no_sanitation, size=n_to_reduce,
+            selected_change_susceptibility = self.rng.choice(susceptible_no_sanitation, size=n_to_reduce,
                                                               replace=False)
             df.loc[selected_change_susceptibility, species_column] = 0
 


### PR DESCRIPTION
Use of np.random in hiv.py and schisto.py leading to discrepancy in outputs between the same runs in identical draws, as identified in Issue https://github.com/UCL/TLOmodel/issues/1877. This PR fixes this (see below yearly DALYs broken by year).

<img width="1400" height="312" alt="Screenshot 2026-08-04 at 09 55 08" src="https://github.com/user-attachments/assets/352e0c50-5030-430b-b6f8-ef247adbcaac" />
